### PR TITLE
Improve error handling for access key parsing failures

### DIFF
--- a/www/app/cordova_main.ts
+++ b/www/app/cordova_main.ts
@@ -20,7 +20,7 @@ import {EventQueue} from '../model/events';
 
 import {AbstractClipboard, Clipboard, ClipboardListener} from './clipboard';
 import {EnvironmentVariables} from './environment';
-import {FakeErrorReporter, SentryErrorReporter} from './error_reporter';
+import {SentryErrorReporter} from './error_reporter';
 import {FakeOutlineConnection} from './fake_connection';
 import {main} from './main';
 import {OutlineServer} from './outline_server';
@@ -95,7 +95,7 @@ class CordovaPlatform implements OutlinePlatform {
     return this.hasDeviceSupport() ?
         new CordovaErrorReporter(
             env.APP_VERSION, env.APP_BUILD_NUMBER, env.SENTRY_DSN, env.SENTRY_NATIVE_DSN) :
-        new FakeErrorReporter();
+        new SentryErrorReporter(env.APP_VERSION, env.SENTRY_DSN, {});
   }
 
   hasSystemVpnSupport() {

--- a/www/app/error_reporter.ts
+++ b/www/app/error_reporter.ts
@@ -51,11 +51,3 @@ export class SentryErrorReporter implements OutlineErrorReporter {
     });
   }
 }
-
-export class FakeErrorReporter implements OutlineErrorReporter {
-  report(userFeedback: string, feedbackCategory: string, userEmail?: string): Promise<void> {
-    userEmail = userEmail || '(email not given)';
-    console.debug(`Reporting fake feedback: ${userFeedback} by ${userEmail}, ${feedbackCategory}`);
-    return Promise.resolve();
-  }
-}


### PR DESCRIPTION
* Removes the access key from the error message when parsing fails.
* Improves messaging for access key parsing failures on URL interception.
* Deprecates `FakeErrorReporter` in favor of  `SentryErrorReporter` for browser builds.