### PR TITLE
place executables in the same folder, now they both depend on cygwin.dll

### DIFF
--- a/electron/build_action.sh
+++ b/electron/build_action.sh
@@ -25,13 +25,16 @@ mkdir -p $OUTPUT
 rsync -ac build/{electron,www} $OUTPUT/
 
 # Copy binaries into the Electron folder.
-# The name of the destination folder must be kept in sync with the value
-# specified for --config.asarUnpack in package_action.sh.
+# The destination folder must be kept in sync with:
+#  - the value specified for --config.asarUnpack in package_action.sh
+#  - the value returned by process_manager.ts#pathToEmbeddedExe
 readonly BIN_DEST=$OUTPUT/electron/bin/win32
 mkdir -p $BIN_DEST
-rsync -ac --include '*.exe' --exclude='*' third_party/shadowsocks-libev/windows/ $BIN_DEST/ss-local
-rsync -ac --include '*.dll' --exclude='*' third_party/cygwin/ $BIN_DEST/ss-local
-rsync -ac --include '*/*.exe'  --exclude='*/*' tools/setsystemproxy $BIN_DEST/
+rsync -ac \
+  --include '*.exe' --include '*.dll' \
+  --exclude='*' \
+  third_party/shadowsocks-libev/windows/ tools/setsystemproxy/ third_party/cygwin/ \
+  $BIN_DEST
 
 # Version info and Sentry config.
 # In Electron, the path is relative to electron_index.html.

--- a/electron/package_action.sh
+++ b/electron/package_action.sh
@@ -19,6 +19,10 @@ yarn do electron/build
 cp package.json build/windows/
 scripts/environment_json.sh -p windows > build/windows/www/environment.json
 
+# --config.asarUnpack must be kept in sync with:
+#  - the destination path for the binaries in build_action.sh
+#  - the value returned by process_manager.ts#pathToEmbeddedExe
+
 electron-builder \
   --projectDir=build/windows \
   --config.asarUnpack=electron/bin \

--- a/electron/process_manager.ts
+++ b/electron/process_manager.ts
@@ -25,10 +25,12 @@ import * as url from 'url';
 import * as util from '../www/app/util';
 import * as errors from '../www/model/errors';
 
+// The returned path must be kept in sync with:
+//  - the destination path for the binaries in build_action.sh
+//  - the value specified for --config.asarUnpack in package_action.sh
 function pathToEmbeddedExe(basename: string) {
   return path.join(
-      __dirname.replace('app.asar', 'app.asar.unpacked'), 'bin', 'win32', basename,
-      `${basename}.exe`);
+      __dirname.replace('app.asar', 'app.asar.unpacked'), 'bin', 'win32', `${basename}.exe`);
 }
 
 // Three tools are required to launch the proxy on Windows:


### PR DESCRIPTION
My bad, I didn't test https://github.com/Jigsaw-Code/outline-client/pull/42 properly. `setsystemproxy.exe` depends on `cygwin.dll`. If it isn't present in the same folder, connection fails. Since `ss-local.exe` also depends on it, just place all three in the same folder.

Also, update the comments so that this doesn't happen again :-)