### PR TITLE
Update ShadowsocksConfig to v0.0.8

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "tests"
   ],
   "dependencies": {
-    "ShadowsocksConfig": "Jigsaw-Code/outline-shadowsocksconfig#^v0.0.6",
+    "ShadowsocksConfig": "Jigsaw-Code/outline-shadowsocksconfig#^v0.0.8",
     "app-layout": "PolymerElements/app-layout#^2.0.2",
     "app-localize-behavior": "PolymerElements/app-localize-behavior#^2.0.1",
     "app-route": "PolymerElements/app-route#^2.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "@sentry/electron": "^0.4.2",
-    "ShadowsocksConfig": "Jigsaw-Code/outline-shadowsocksconfig#^v0.0.6",
+    "ShadowsocksConfig": "Jigsaw-Code/outline-shadowsocksconfig#^v0.0.8",
     "babel-polyfill": "^6.26.0",
     "electron-promise-ipc": "^0.0.4",
     "electron-updater": "^2.21.0",

--- a/www/app/app.ts
+++ b/www/app/app.ts
@@ -211,10 +211,7 @@ export class App {
     try {
       shadowsocksConfig = SHADOWSOCKS_URI.parse(accessKey);
     } catch (error) {
-      // Remove any access keys from the error message so it is not logged to Sentry.
-      const message = !!error.message ?
-          error.message.replace(/ss:\/\/([A-Za-z0-9=]+)(@[0-9|.]+:[0-9]+)?(\/\?)?(#\w+)?/g, '') :
-          'Failed to parse access key';
+      const message = !!error.message ? error.message : 'Failed to parse access key';
       throw new errors.ServerUrlInvalid(message);
     }
     if (shadowsocksConfig.host.isIPv6) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -209,9 +209,9 @@ JSONStream@^1.0.3:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
 
-ShadowsocksConfig@Jigsaw-Code/outline-shadowsocksconfig#^v0.0.6:
-  version "0.0.6"
-  resolved "https://codeload.github.com/Jigsaw-Code/outline-shadowsocksconfig/tar.gz/8e1a019e706dc52bf7717a4f2965247f1c9a40fa"
+ShadowsocksConfig@Jigsaw-Code/outline-shadowsocksconfig#^v0.0.8:
+  version "0.0.8"
+  resolved "https://codeload.github.com/Jigsaw-Code/outline-shadowsocksconfig/tar.gz/57845b8295f1b8ba117d1d69efb7643ebe08dd15"
   dependencies:
     base-64 "^0.1.0"
     punycode "^1.4.1"


### PR DESCRIPTION
ShadowsocksConfig does not send the access key as with errors as of v0.0.7, so there is no longer the need to strip it.