### PR TITLE
remove the non-system VPN warning

### DIFF
--- a/www/app/cordova_main.ts
+++ b/www/app/cordova_main.ts
@@ -98,10 +98,6 @@ class CordovaPlatform implements OutlinePlatform {
         new SentryErrorReporter(env.APP_VERSION, env.SENTRY_DSN, {});
   }
 
-  hasSystemVpnSupport() {
-    return !CordovaPlatform.isBrowser();
-  }
-
   getUpdater() {
     return new AbstractUpdater();
   }

--- a/www/app/electron_main.ts
+++ b/www/app/electron_main.ts
@@ -90,9 +90,6 @@ main({
 
     return new ElectronErrorReporter(env.APP_VERSION, env.SENTRY_DSN);
   },
-  hasSystemVpnSupport() {
-    return false;
-  },
   getUpdater: () => {
     return new ElectronUpdater();
   }

--- a/www/app/main.ts
+++ b/www/app/main.ts
@@ -83,7 +83,7 @@ export function main(platform: OutlinePlatform) {
             const app = new App(
                 eventQueue, serverRepo, getRootEl(), debugMode, platform.getUrlInterceptor(),
                 platform.getClipboard(), platform.getErrorReporter(environmentVars), settings,
-                environmentVars, platform.hasSystemVpnSupport(), platform.getUpdater());
+                environmentVars, platform.getUpdater());
           },
           (e) => {
             onUnexpectedError(e);

--- a/www/app/platform.ts
+++ b/www/app/platform.ts
@@ -36,7 +36,5 @@ export interface OutlinePlatform {
 
   getErrorReporter(environment: EnvironmentVariables): OutlineErrorReporter;
 
-  hasSystemVpnSupport(): boolean;
-
   getUpdater(): Updater;
 }

--- a/www/messages/en.json
+++ b/www/messages/en.json
@@ -66,8 +66,6 @@
   "outline-plugin-error-generic-start-failure": "Something happened and we couldn’t connect. If this happens again, please submit feedback.",
   "outline-plugin-error-networking-error": "A networking error occurred. If this happens again, please submit feedback.",
   "tips": "Tips",
-  "non-system-vpn-warning-title": "Verify your browser connection",
-  "non-system-vpn-warning-detail": "Most browsers connect automatically with Outline, some do not.",
   "get-help": "Get help",
   "got-it": "Got it",
   "save": "save",

--- a/www/messages/es.json
+++ b/www/messages/es.json
@@ -66,8 +66,6 @@
   "outline-plugin-error-generic-start-failure": "Algo sucedió y no fue posible conectar al servidor, inténtalo de nuevo. Si el problema persiste, envía comentarios.",
   "outline-plugin-error-networking-error": "Ocurrió un error en la red, inténtalo de nuevo. Si el problema persiste, envía comentarios.",
   "tips": "Consejos",
-  "non-system-vpn-warning-title": "Verifica la conexión de tu navegador",
-  "non-system-vpn-warning-detail": "La mayoría de los navegadores se conectan automáticamente con Outline, otros no.",
   "get-help": "Ayuda",
   "got-it": "Entendido",
   "save": "guardar",

--- a/www/ui_components/servers-view.html
+++ b/www/ui_components/servers-view.html
@@ -16,7 +16,6 @@
 <link rel="import" href="../bower_components/paper-button/paper-button.html">
 <link rel="import" href="server-list.html">
 <link rel="import" href="server-connection-viz.html">
-<link rel="import" href="user-comms-dialog.html">
 
 <dom-module id="servers-view">
   <template>
@@ -90,7 +89,6 @@
         </div>
         <div class="footer subtle" inner-h-t-m-l="[[localize('server-create-your-own-zero-state', 'openLine', '<div>', 'closeLine', '</div>', 'outlineLink', '<a href=&quot;https://s3.amazonaws.com/outline-vpn/index.html&quot;>our website</a>')]]"></div>
       </div>
-      <user-comms-dialog id="nonSystemVpnWarning" localize="[[localize]]" title-localization-key="non-system-vpn-warning-title" detail-localization-key="non-system-vpn-warning-detail" link-url="https://s3.amazonaws.com/outline-vpn/index.html#/en/support/outlineWindowsProtection" fire-event-on-hide="NonSystemVpnWarningDismissed"></user-comms-dialog>
       <server-list id="serverList" hidden$="[[shouldShowZeroState]]" servers="{{servers}}" localize="[[localize]]" root-path="[[rootPath]]"></server-list>
     </div>
   </template>


### PR DESCRIPTION
This removes the "this is not a full VPN" warning from the Windows client. This leaves `user-comms-dialog.html` unused currently but I think that will change in future.