### PR TITLE
Android: enable auto-connect feature, always-on

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -24,6 +24,8 @@
     <allow-intent href="http://*/*" />
     <allow-intent href="https://*/*" />
     <preference name="android-minSdkVersion" value="21" />
+    <!-- TODO: uncomment the next line to enable Always On VPN -->
+    <!-- <preference name="android-targetSdkVersion" value="24" /> -->
     <preference name="AndroidLaunchMode" value="singleInstance" />
     <preference name="ShowSplashScreenSpinner" value="false" />
 

--- a/config.xml
+++ b/config.xml
@@ -24,8 +24,7 @@
     <allow-intent href="http://*/*" />
     <allow-intent href="https://*/*" />
     <preference name="android-minSdkVersion" value="21" />
-    <!-- TODO: uncomment the next line to enable Always On VPN -->
-    <!-- <preference name="android-targetSdkVersion" value="24" /> -->
+    <preference name="android-targetSdkVersion" value="24" />
     <preference name="AndroidLaunchMode" value="singleInstance" />
     <preference name="ShowSplashScreenSpinner" value="false" />
 

--- a/cordova-plugin-outline/android/java/org/outline/vpn/VpnConnectionStore.java
+++ b/cordova-plugin-outline/android/java/org/outline/vpn/VpnConnectionStore.java
@@ -19,11 +19,13 @@ import android.content.SharedPreferences;
 import java.util.logging.Logger;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.outline.OutlinePlugin;
 
 // Persistence layer for a single connection configuration. Uses |SharedPreferences| as the store.
 class VpnConnectionStore {
   private static final Logger LOG = Logger.getLogger(VpnConnectionStore.class.getName());
   private static final String CONNECTION_KEY = "connection";
+  private static final String CONNECTION_STATUS_KEY = "connectionStatus";
 
   private final SharedPreferences preferences;
 
@@ -60,4 +62,18 @@ class VpnConnectionStore {
     editor.remove(CONNECTION_KEY).commit();
   }
 
+  public OutlinePlugin.ConnectionStatus getConnectionStatus() {
+    final String connectionStatus = preferences.getString(
+        CONNECTION_STATUS_KEY, OutlinePlugin.ConnectionStatus.DISCONNECTED.toString());
+    return OutlinePlugin.ConnectionStatus.valueOf(connectionStatus);
+  }
+
+  public void setConnectionStatus(OutlinePlugin.ConnectionStatus status) {
+    if (status == null) {
+      LOG.severe("Received null connection status");
+      return;
+    }
+    SharedPreferences.Editor editor = preferences.edit();
+    editor.putString(CONNECTION_STATUS_KEY, status.toString()).commit();
+  }
 }

--- a/cordova-plugin-outline/plugin.xml
+++ b/cordova-plugin-outline/plugin.xml
@@ -32,7 +32,11 @@
         android:name="org.outline.vpn.VpnTunnelService"
         android:exported="false"
         android:label="@string/app_name"
-        android:permission="android.permission.BIND_VPN_SERVICE" />
+        android:permission="android.permission.BIND_VPN_SERVICE">
+        <intent-filter>
+          <action android:name="android.net.VpnService" />
+        </intent-filter>
+      </service>
 
       <!-- TODO: enable this component to enable the auto-connect feature -->
       <receiver android:name="org.outline.vpn.VpnServiceStarter" android:enabled="false">

--- a/cordova-plugin-outline/plugin.xml
+++ b/cordova-plugin-outline/plugin.xml
@@ -38,8 +38,7 @@
         </intent-filter>
       </service>
 
-      <!-- TODO: enable this component to enable the auto-connect feature -->
-      <receiver android:name="org.outline.vpn.VpnServiceStarter" android:enabled="false">
+      <receiver android:name="org.outline.vpn.VpnServiceStarter" android:enabled="true">
           <intent-filter>
             <action android:name="android.intent.action.BOOT_COMPLETED" />
           </intent-filter>


### PR DESCRIPTION
* Adds support for Always On VPN.
* Enables the auto-connect feature: automatically connects the VPN, unconditionally if the user has enabled Always On, or if the VPN was connected at shutdown. The latter behavior targets Lollipop and Marshmallow users, as Always On was introduced in Nougat.
* Does not perform connectivity checks when connecting at startup to avoid networking errors if the network is not ready.
* Persists the connection status to support both Always On and auto-connect - part of this code was already merged but not enabled.
