### PR TITLE
accidentally hard-coded the architecture in TAP installer script

### DIFF
--- a/electron/add_tap_device.bat
+++ b/electron/add_tap_device.bat
@@ -26,7 +26,7 @@ if %errorlevel% equ 0 (
 )
 
 :: Add the device.
-tap-windows6\amd64\tapinstall install tap-windows6\%1\OemVista.inf tap0901 >nul
+tap-windows6\%1\tapinstall install tap-windows6\%1\OemVista.inf tap0901 >nul
 if %errorlevel% neq 0 (
   echo Could not create TAP device.
   exit /b 1


### PR DESCRIPTION
Spotted this just now on a 32 bit VM.