### PR TITLE
bump version for windows release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "outline-client",
   "productName": "Outline Beta",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts": {
     "clean": "rm -rf build www/bower_components www/cordova_main.js node_modules platforms/* plugins/*",
     "precommit": "tslint -p . --fix; git-clang-format",


### PR DESCRIPTION
Apologies, forgot to do this as part of:
https://github.com/Jigsaw-Code/outline-client/pull/105

(merging TBR)