### PR TITLE
Apple auto-connect

### DIFF
--- a/apple/xcode/osx/Outline/Classes/AppDelegate.m
+++ b/apple/xcode/osx/Outline/Classes/AppDelegate.m
@@ -21,7 +21,7 @@
 @property (strong, nonatomic) NSStatusItem *statusItem;
 @property (strong, nonatomic) NSPopover *popover;
 @property (strong, nonatomic) EventMonitor *eventMonitor;
-@property bool isShuttingDown;
+@property bool isSystemShuttingDown;
 @end
 
 @implementation AppDelegate
@@ -47,12 +47,13 @@
   // Don't ever show the default Cordova window, as we will display its content view in a popover.
   [self.window close];
 
-  [NSWorkspace.sharedWorkspace.notificationCenter addObserverForName:NSWorkspaceWillPowerOffNotification
-                                                              object:nil
-                                                               queue:nil
-                                                          usingBlock:^(NSNotification * _Nonnull n) {
-                                                            self.isShuttingDown = YES;
-                                                          }];
+  [NSWorkspace.sharedWorkspace.notificationCenter
+      addObserverForName:NSWorkspaceWillPowerOffNotification
+                  object:nil
+                   queue:nil
+              usingBlock:^(NSNotification *_Nonnull n) {
+                self.isSystemShuttingDown = YES;
+              }];
   [NSNotificationCenter.defaultCenter addObserverForName:OutlinePlugin.kVpnConnectedNotification
                                                   object:nil
                                                    queue:nil
@@ -102,13 +103,11 @@
   } else {
     [self showPopover];
   }
-
-  // TODO: uncomment to enable auto-connect feature.
-  // [self setAppLauncherEnabled:true];  // Enable app launcher to start on boot.
+  [self setAppLauncherEnabled:true];  // Enable app launcher to start on boot.
 }
 
 - (void)applicationWillTerminate:(NSNotification *)notification {
-  if (!self.isShuttingDown) {
+  if (!self.isSystemShuttingDown) {
     // Don't post a quit notification if the system is shutting down so the VPN is not stopped
     // and it auto-connects on startup.
     [[NSNotificationCenter defaultCenter] postNotificationName:OutlinePlugin.kAppQuitNotification

--- a/cordova-plugin-outline/apple/src/OutlineVpn.swift
+++ b/cordova-plugin-outline/apple/src/OutlineVpn.swift
@@ -45,6 +45,7 @@ class OutlineVpn: NSObject {
     static let errorCode = "errorCode"
     static let host = "host"
     static let port = "port"
+    static let isOnDemand = "is-on-demand"
   }
 
   // This must be kept in sync with:
@@ -171,7 +172,7 @@ class OutlineVpn: NSObject {
         config?[MessageKey.connectionId] = connectionId
       } else {
         // macOS app was started by launcher.
-        config = ["is-on-demand": "true"];
+        config = [MessageKey.isOnDemand: "true"];
       }
       let session = self.tunnelManager?.connection as! NETunnelProviderSession
       do {

--- a/cordova-plugin-outline/apple/vpn/OutlineConnectionStore.swift
+++ b/cordova-plugin-outline/apple/vpn/OutlineConnectionStore.swift
@@ -24,8 +24,7 @@ class OutlineConnectionStore: NSObject {
 
   private let defaults: UserDefaults?
 
-  // Constructs the store by creating a directory at |storeDirectoryUrl| if it does not exist.
-  // The caller is responsible for ensuring the path is writable.
+  // Constructs the store with UserDefaults as the storage.
   required init(appGroup: String) {
     defaults = UserDefaults(suiteName: appGroup)
     super.init()

--- a/cordova-plugin-outline/apple/vpn/PacketTunnelProvider.m
+++ b/cordova-plugin-outline/apple/vpn/PacketTunnelProvider.m
@@ -113,31 +113,33 @@ NSString *const kMessageKeyOnDemand = @"is-on-demand";
   // network unusable with no indication to the user. By bypassing the checks, the network would
   // still be unusable, but at least the user will have a visual indication that Outline is the
   // culprit and can explicitly disconnect.
-  [self.shadowsocks start:!isOnDemand
-               completion:^(ErrorCode errorCode) {
-                 if (errorCode == noError) {
-                   [self connectTunnel:[self getTunnelNetworkSettings]
-                            completion:^(NSError *error) {
-                              if (!error) {
-                                [self setupPacketTunnelFlow];
-                                [self startTun2SocksWithPort:kShadowsocksLocalPort];
-                                [self execAppCallbackForAction:kActionStart errorCode:noError];
+  [self.shadowsocks
+      startWithConnectivityChecks:!isOnDemand
+                       completion:^(ErrorCode errorCode) {
+                         if (errorCode == noError) {
+                           [self connectTunnel:[self getTunnelNetworkSettings]
+                                    completion:^(NSError *error) {
+                                      if (!error) {
+                                        [self setupPacketTunnelFlow];
+                                        [self startTun2SocksWithPort:kShadowsocksLocalPort];
+                                        [self execAppCallbackForAction:kActionStart
+                                                             errorCode:noError];
 
-                                [self.connectionStore save:connection];
-                                self.connectionStore.status = ConnectionStatusConnected;
-                              } else {
-                                [self execAppCallbackForAction:kActionStart
-                                                     errorCode:vpnPermissionNotGranted];
-                              }
-                              completionHandler(error);
-                            }];
-                 } else {
-                   [self execAppCallbackForAction:kActionStart errorCode:errorCode];
-                   completionHandler([NSError errorWithDomain:NEVPNErrorDomain
-                                                         code:NEVPNErrorConnectionFailed
-                                                     userInfo:nil]);
-                 }
-               }];
+                                        [self.connectionStore save:connection];
+                                        self.connectionStore.status = ConnectionStatusConnected;
+                                      } else {
+                                        [self execAppCallbackForAction:kActionStart
+                                                             errorCode:vpnPermissionNotGranted];
+                                      }
+                                      completionHandler(error);
+                                    }];
+                         } else {
+                           [self execAppCallbackForAction:kActionStart errorCode:errorCode];
+                           completionHandler([NSError errorWithDomain:NEVPNErrorDomain
+                                                                 code:NEVPNErrorConnectionFailed
+                                                             userInfo:nil]);
+                         }
+                       }];
 }
 
 - (void)stopTunnelWithReason:(NEProviderStopReason)reason
@@ -393,18 +395,19 @@ bool getIpAddressString(const struct sockaddr *sa, char *s, socklen_t maxbytes) 
       self.shadowsocks.config = [self getShadowsocksNetworkConfig];
       __weak PacketTunnelProvider *weakSelf = self;
       [self.shadowsocks
-               start:true
-          completion:^(ErrorCode errorCode) {
-            [weakSelf execAppCallbackForAction:kActionStart errorCode:errorCode];
-            if (errorCode != noError) {
-              DDLogWarn(@"Tearing down VPN");
-              [self cancelTunnelWithError:[NSError errorWithDomain:NEVPNErrorDomain
-                                                              code:NEVPNErrorConnectionFailed
-                                                          userInfo:nil]];
-              return;
-            }
-            [weakSelf.connectionStore save:self.connection];
-          }];
+          startWithConnectivityChecks:true
+                           completion:^(ErrorCode errorCode) {
+                             [weakSelf execAppCallbackForAction:kActionStart errorCode:errorCode];
+                             if (errorCode != noError) {
+                               DDLogWarn(@"Tearing down VPN");
+                               [self cancelTunnelWithError:
+                                         [NSError errorWithDomain:NEVPNErrorDomain
+                                                             code:NEVPNErrorConnectionFailed
+                                                         userInfo:nil]];
+                               return;
+                             }
+                             [weakSelf.connectionStore save:self.connection];
+                           }];
     }];
   }
 }

--- a/cordova-plugin-outline/apple/vpn/PacketTunnelProvider.m
+++ b/cordova-plugin-outline/apple/vpn/PacketTunnelProvider.m
@@ -36,6 +36,7 @@ NSString *const kMessageKeyConfig = @"config";
 NSString *const kMessageKeyErrorCode = @"errorCode";
 NSString *const kMessageKeyHost = @"host";
 NSString *const kMessageKeyPort = @"port";
+NSString *const kMessageKeyOnDemand = @"is-on-demand";
 
 @interface PacketTunnelProvider()
 @property (nonatomic) Shadowsocks *shadowsocks;
@@ -104,41 +105,39 @@ NSString *const kMessageKeyPort = @"port";
                                                  code:NEVPNErrorConfigurationReadWriteFailed
                                              userInfo:nil]);
   }
-  bool isOnDemand = options[@"is-on-demand"] != nil;
+  bool isOnDemand = options[kMessageKeyOnDemand] != nil;
   self.shadowsocks = [[Shadowsocks alloc] init:[self getShadowsocksNetworkConfig]];
   // Bypass connectivity checks for auto-connect. If the connection configuration is no longer
   // valid, the connectivity checks will fail. The system will keep calling this method due to
-  // on demand being enabled (the VPN process does not have permission to change it), rendering the
+  // On Demand being enabled (the VPN process does not have permission to change it), rendering the
   // network unusable with no indication to the user. By bypassing the checks, the network would
   // still be unusable, but at least the user will have a visual indication that Outline is the
   // culprit and can explicitly disconnect.
-  [self.shadowsocks
-      startWithConnectivityChecks:!isOnDemand
-                       completion:^(ErrorCode errorCode) {
-                         if (errorCode == noError) {
-                           [self connectTunnel:[self getTunnelNetworkSettings]
-                                    completion:^(NSError *error) {
-                                      if (!error) {
-                                        [self setupPacketTunnelFlow];
-                                        [self startTun2SocksWithPort:kShadowsocksLocalPort];
-                                        [self execAppCallbackForAction:kActionStart
-                                                             errorCode:noError];
+  [self.shadowsocks start:!isOnDemand
+               completion:^(ErrorCode errorCode) {
+                 if (errorCode == noError) {
+                   [self connectTunnel:[self getTunnelNetworkSettings]
+                            completion:^(NSError *error) {
+                              if (!error) {
+                                [self setupPacketTunnelFlow];
+                                [self startTun2SocksWithPort:kShadowsocksLocalPort];
+                                [self execAppCallbackForAction:kActionStart errorCode:noError];
 
-                                        [self.connectionStore save:connection];
-                                        self.connectionStore.status = ConnectionStatusConnected;
-                                      } else {
-                                        [self execAppCallbackForAction:kActionStart
-                                                             errorCode:vpnPermissionNotGranted];
-                                      }
-                                      completionHandler(error);
-                                    }];
-                         } else {
-                           [self execAppCallbackForAction:kActionStart errorCode:errorCode];
-                           completionHandler([NSError errorWithDomain:NEVPNErrorDomain
-                                                                 code:NEVPNErrorConnectionFailed
-                                                             userInfo:nil]);
-                         }
-                       }];
+                                [self.connectionStore save:connection];
+                                self.connectionStore.status = ConnectionStatusConnected;
+                              } else {
+                                [self execAppCallbackForAction:kActionStart
+                                                     errorCode:vpnPermissionNotGranted];
+                              }
+                              completionHandler(error);
+                            }];
+                 } else {
+                   [self execAppCallbackForAction:kActionStart errorCode:errorCode];
+                   completionHandler([NSError errorWithDomain:NEVPNErrorDomain
+                                                         code:NEVPNErrorConnectionFailed
+                                                     userInfo:nil]);
+                 }
+               }];
 }
 
 - (void)stopTunnelWithReason:(NEProviderStopReason)reason
@@ -234,11 +233,12 @@ NSString *const kMessageKeyPort = @"port";
 
 // Creates a OutlineConnection from options supplied in |config|, or retrieves the last working
 // connection from disk. Normally the app provides a connection configuration. However, when the VPN
-// is started from settings or on demand, the system launches this process without supplying a
+// is started from settings or On Demand, the system launches this process without supplying a
 // configuration, so it is necessary to retrieve a previously persisted connection from disk.
+// To learn more about On Demand see: https://help.apple.com/deployment/ios/#/iord4804b742.
 - (OutlineConnection *)retrieveConnection:(NSDictionary *)config {
   OutlineConnection *connection;
-  if (config != nil && !config[@"is-on-demand"]) {
+  if (config != nil && !config[kMessageKeyOnDemand]) {
     connection = [[OutlineConnection alloc] initWithId:config[kMessageKeyConnectionId] config:config];
   } else if (self.connectionStore != nil) {
     DDLogInfo(@"Retrieving connection from store.");
@@ -393,19 +393,18 @@ bool getIpAddressString(const struct sockaddr *sa, char *s, socklen_t maxbytes) 
       self.shadowsocks.config = [self getShadowsocksNetworkConfig];
       __weak PacketTunnelProvider *weakSelf = self;
       [self.shadowsocks
-          startWithConnectivityChecks:true
-                           completion:^(ErrorCode errorCode) {
-                             [weakSelf execAppCallbackForAction:kActionStart errorCode:errorCode];
-                             if (errorCode != noError) {
-                               DDLogWarn(@"Tearing down VPN");
-                               [self cancelTunnelWithError:
-                                         [NSError errorWithDomain:NEVPNErrorDomain
-                                                             code:NEVPNErrorConnectionFailed
-                                                         userInfo:nil]];
-                               return;
-                             }
-                             [weakSelf.connectionStore save:self.connection];
-                           }];
+               start:true
+          completion:^(ErrorCode errorCode) {
+            [weakSelf execAppCallbackForAction:kActionStart errorCode:errorCode];
+            if (errorCode != noError) {
+              DDLogWarn(@"Tearing down VPN");
+              [self cancelTunnelWithError:[NSError errorWithDomain:NEVPNErrorDomain
+                                                              code:NEVPNErrorConnectionFailed
+                                                          userInfo:nil]];
+              return;
+            }
+            [weakSelf.connectionStore save:self.connection];
+          }];
     }];
   }
 }

--- a/cordova-plugin-outline/apple/vpn/Shadowsocks.h
+++ b/cordova-plugin-outline/apple/vpn/Shadowsocks.h
@@ -34,10 +34,10 @@ extern const int kShadowsocksLocalPort;
 
 /**
  * Starts ss-local on a separate thread with the configuration supplied in the constructor.
- * Verifies that the server credentials are valid and that remote supports UDP forwarding, calling
- * |completion| with the result.
+ * If |performConnectivityChecks| is true, verifies that the server credentials are valid and that
+ * the remote supports UDP forwarding, calling |completion| with the result.
  */
-- (void)start:(void (^)(ErrorCode))completion;
+- (void)startWithConnectivityChecks:(bool)performConnectivityChecks completion:(void (^)(ErrorCode))completion;
 
 /**
  * Stops the thread running ss-local. Calls |completion| with the success of the operation.

--- a/cordova-plugin-outline/apple/vpn/Shadowsocks.h
+++ b/cordova-plugin-outline/apple/vpn/Shadowsocks.h
@@ -34,10 +34,11 @@ extern const int kShadowsocksLocalPort;
 
 /**
  * Starts ss-local on a separate thread with the configuration supplied in the constructor.
- * If |performConnectivityChecks| is true, verifies that the server credentials are valid and that
+ * If |checkConnectivity| is true, verifies that the server credentials are valid and that
  * the remote supports UDP forwarding, calling |completion| with the result.
  */
-- (void)start:(bool)performConnectivityChecks completion:(void (^)(ErrorCode))completion;
+- (void)startWithConnectivityChecks:(bool)checkConnectivity
+                         completion:(void (^)(ErrorCode))completion;
 
 /**
  * Stops the thread running ss-local. Calls |completion| with the success of the operation.

--- a/cordova-plugin-outline/apple/vpn/Shadowsocks.h
+++ b/cordova-plugin-outline/apple/vpn/Shadowsocks.h
@@ -37,7 +37,8 @@ extern const int kShadowsocksLocalPort;
  * If |performConnectivityChecks| is true, verifies that the server credentials are valid and that
  * the remote supports UDP forwarding, calling |completion| with the result.
  */
-- (void)startWithConnectivityChecks:(bool)performConnectivityChecks completion:(void (^)(ErrorCode))completion;
+- (void)startWithConnectivityChecks:(bool)performConnectivityChecks
+                         completion:(void (^)(ErrorCode))completion;
 
 /**
  * Stops the thread running ss-local. Calls |completion| with the success of the operation.

--- a/cordova-plugin-outline/apple/vpn/Shadowsocks.h
+++ b/cordova-plugin-outline/apple/vpn/Shadowsocks.h
@@ -37,8 +37,7 @@ extern const int kShadowsocksLocalPort;
  * If |performConnectivityChecks| is true, verifies that the server credentials are valid and that
  * the remote supports UDP forwarding, calling |completion| with the result.
  */
-- (void)startWithConnectivityChecks:(bool)performConnectivityChecks
-                         completion:(void (^)(ErrorCode))completion;
+- (void)start:(bool)performConnectivityChecks completion:(void (^)(ErrorCode))completion;
 
 /**
  * Stops the thread running ss-local. Calls |completion| with the success of the operation.

--- a/cordova-plugin-outline/apple/vpn/Shadowsocks.m
+++ b/cordova-plugin-outline/apple/vpn/Shadowsocks.m
@@ -77,8 +77,7 @@ const uint16_t kHttpPort = 80;
   return self;
 }
 
-- (void)startWithConnectivityChecks:(bool)performConnectivityChecks
-                         completion:(void (^)(ErrorCode))completion {
+- (void)start:(bool)performConnectivityChecks completion:(void (^)(ErrorCode))completion {
   self.performConnectivityChecks = performConnectivityChecks;
   dispatch_async(dispatch_get_main_queue(), ^{
     // Start ss-local from the main application thread.

--- a/cordova-plugin-outline/apple/vpn/Shadowsocks.m
+++ b/cordova-plugin-outline/apple/vpn/Shadowsocks.m
@@ -61,7 +61,7 @@ const uint16_t kHttpPort = 80;
 @property (nonatomic) bool serverCredentialsAreValid;
 @property (nonatomic) bool isServerReachable;
 @property (nonatomic) int udpForwardingNumChecks;
-@property(nonatomic) bool performConnectivityChecks;
+@property(nonatomic) bool checkConnectivity;
 @end
 
 @implementation Shadowsocks
@@ -77,8 +77,9 @@ const uint16_t kHttpPort = 80;
   return self;
 }
 
-- (void)start:(bool)performConnectivityChecks completion:(void (^)(ErrorCode))completion {
-  self.performConnectivityChecks = performConnectivityChecks;
+- (void)startWithConnectivityChecks:(bool)checkConnectivity
+                         completion:(void (^)(ErrorCode))completion {
+  self.checkConnectivity = checkConnectivity;
   dispatch_async(dispatch_get_main_queue(), ^{
     // Start ss-local from the main application thread.
     self.udpForwardingNumChecks = 0;
@@ -192,11 +193,11 @@ void *startShadowsocks(void *udata) {
  * Checks that the remote server is reachable, allows UDP forwarding, and the credentials are valid.
  * Synchronizes and parallelizes the execution of the connectivity checks and calls
  * |startCompletion| with the combined outcome.
- * Only performs the tests if |performConnectivityChecks| is true; otherwise calls |startCompletion|
+ * Only performs the tests if |checkConnectivity| is true; otherwise calls |startCompletion|
  * with success.
  */
 - (void) checkServerConnectivity {
-  if (!self.performConnectivityChecks) {
+  if (!self.checkConnectivity) {
     self.startCompletion(noError);
     return;
   }

--- a/cordova-plugin-outline/apple/vpn/Shadowsocks.m
+++ b/cordova-plugin-outline/apple/vpn/Shadowsocks.m
@@ -61,7 +61,7 @@ const uint16_t kHttpPort = 80;
 @property (nonatomic) bool serverCredentialsAreValid;
 @property (nonatomic) bool isServerReachable;
 @property (nonatomic) int udpForwardingNumChecks;
-@property (nonatomic) bool performConnectivityChecks;
+@property(nonatomic) bool performConnectivityChecks;
 @end
 
 @implementation Shadowsocks
@@ -77,7 +77,8 @@ const uint16_t kHttpPort = 80;
   return self;
 }
 
-- (void)startWithConnectivityChecks:(bool)performConnectivityChecks completion:(void (^)(ErrorCode))completion {
+- (void)startWithConnectivityChecks:(bool)performConnectivityChecks
+                         completion:(void (^)(ErrorCode))completion {
   self.performConnectivityChecks = performConnectivityChecks;
   dispatch_async(dispatch_get_main_queue(), ^{
     // Start ss-local from the main application thread.


### PR DESCRIPTION
* Enables the auto-connect feature for iOS and macOS. 
  * Configures the VPN to connect on demand to any available network, allowing the VPN to automatically connect on boot if it was connected at shutdown.
  * Enables the macOS launcher application to start the app's UI.
  * The VPN can no longer be managed through Settings/System Preferences.
* Bypasses the connectivity checks for auto-connect.