### PR TITLE
Upgrade cordova-android from 5.2.2 to 7.1.0

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -118,7 +118,7 @@
     <plugin name="com.borismus.webintent" spec="https://github.com/cordova-misc/cordova-webintent.git#v1.1.0" />
     <plugin name="cordova-plugin-whitelist" spec="1" />
     <plugin name="cordova-plugin-splashscreen" spec="~5.0.2" />
-    <plugin name="cordova-custom-config" spec="~4.0.2" />
+    <plugin name="cordova-custom-config" spec="^5.0.2" />
     <plugin name="cordova-plugin-outline" spec="./cordova-plugin-outline" />
     <plugin name="cordova-plugin-device" spec="~1.1.6" />
     <plugin name="cordova-plugin-statusbar" spec="~2.2.3" />
@@ -132,7 +132,7 @@
         <release-native dsn="https://6a1e6e7371a64db59f5ba6c34a77d78c:568f6c78f9f94f91afba4aba05756001@sentry.io/159502" />
     </sentry>
 
-    <engine name="android" spec="~5.2.2" />
+    <engine name="android" spec="^7.1.0" />
     <engine name="browser" spec="^4.1.0" />
     <!-- Depend on these commits until the next release. -->
     <engine name="ios" spec="https://github.com/apache/cordova-ios#7397337c" />

--- a/cordova-plugin-outline/plugin.xml
+++ b/cordova-plugin-outline/plugin.xml
@@ -21,13 +21,13 @@
       </feature>
     </config-file>
 
-    <config-file target="AndroidManifest.xml" parent="/manifest">
+    <config-file target="app/src/main/AndroidManifest.xml" parent="/manifest">
       <uses-permission android:name="android.permission.INTERNET" />
       <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
       <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     </config-file>
 
-    <config-file target="AndroidManifest.xml" parent="/manifest/application">
+    <config-file target="app/src/main/AndroidManifest.xml" parent="/manifest/application">
       <service
         android:name="org.outline.vpn.VpnTunnelService"
         android:exported="false"
@@ -52,31 +52,32 @@
 
     <source-file
       src="android/java/org/outline/OutlinePlugin.java"
-      target-dir="src/org/outline" />
+      target-dir="app/src/main/java/org/outline" />
     <source-file
       src="android/java/org/outline/vpn"
-      target-dir="src/org/outline/vpn" />
+      target-dir="app/src/main/java/org/outline" />
     <source-file
       src="android/java/org/outline/shadowsocks"
-      target-dir="src/org/outline/shadowsocks" />
+      target-dir="app/src/main/java/org/outline" />
     <source-file
       src="android/java/org/outline/tun2socks"
-      target-dir="src/org/outline/tun2socks" />
+      target-dir="app/src/main/java/org/outline" />
     <source-file
       src="android/java/org/outline/log"
-      target-dir="src/org/outline/log" />
+      target-dir="app/src/main/java/org/outline" />
+
     <source-file
       src="android/libs/armeabi-v7a/libss-local.so"
-      target-dir="libs/armeabi-v7a" />
+      target-dir="app/src/main/jniLibs/armeabi-v7a" />
     <source-file
       src="android/libs/armeabi-v7a/libtun2socks.so"
-      target-dir="libs/armeabi-v7a" />
+      target-dir="app/src/main/jniLibs/armeabi-v7a" />
     <source-file
       src="android/libs/x86/libss-local.so"
-      target-dir="libs/x86" />
+      target-dir="app/src/main/jniLibs/x86" />
     <source-file
       src="android/libs/x86/libtun2socks.so"
-      target-dir="libs/x86" />
+      target-dir="app/src/main/jniLibs/x86" />
 
     <resource-file src="android/resources/small_icon.png" target="res/drawable/small_icon.png" />
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -34,7 +34,7 @@ const SRC_DIR = 'www';
 
 const CONFIG_BY_PLATFORM = {
   android: {
-    targetDir: `platforms/android/assets/${SRC_DIR}`,
+    targetDir: `platforms/android/app/src/main/assets/${SRC_DIR}`,
     platformArgs: '--gradleArg=-PcdvBuildMultipleApks=true'
   },
   browser: {targetDir: `platforms/browser/${SRC_DIR}`},

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -38,10 +38,7 @@ const CONFIG_BY_PLATFORM = {
     platformArgs: '--gradleArg=-PcdvBuildMultipleApks=true'
   },
   browser: {targetDir: `platforms/browser/${SRC_DIR}`},
-  ios: {
-    targetDir: `platforms/ios/${SRC_DIR}`,
-    compileArgs: '--device'
-  },
+  ios: {targetDir: `platforms/ios/${SRC_DIR}`, compileArgs: '--device'},
   osx: {targetDir: `platforms/osx/${SRC_DIR}`}
 };
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "browserify": "^14.4.0",
     "clang-format": "^1.0.55",
     "cordova": "^6.5.0",
-    "cordova-custom-config": "^4.0.2",
+    "cordova-custom-config": "^5.0.2",
     "electron": "^1.8.6",
     "electron-builder": "^20.13.3",
     "electron-icon-maker": "^0.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1198,21 +1198,11 @@ boxen@^1.2.1:
     term-size "^1.2.0"
     widest-line "^1.0.0"
 
-bplist-creator@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/bplist-creator/-/bplist-creator-0.0.4.tgz#4ac0496782e127a85c1d2026a4f5eb22a7aff991"
-  dependencies:
-    stream-buffers "~0.2.3"
-
 bplist-creator@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/bplist-creator/-/bplist-creator-0.0.7.tgz#37df1536092824b87c42f957b01344117372ae45"
   dependencies:
     stream-buffers "~2.2.0"
-
-bplist-parser@0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/bplist-parser/-/bplist-parser-0.0.6.tgz#38da3471817df9d44ab3892e27707bbbd75a11b9"
 
 bplist-parser@0.1.1, bplist-parser@^0.1.0:
   version "0.1.1"
@@ -1971,17 +1961,17 @@ cordova-create@^1.0.1:
     shelljs "0.3.0"
     valid-identifier "0.0.1"
 
-cordova-custom-config@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/cordova-custom-config/-/cordova-custom-config-4.0.2.tgz#76e88a40ad213754069f2e64981e9167a597dfee"
+cordova-custom-config@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/cordova-custom-config/-/cordova-custom-config-5.0.2.tgz#43e751d0c9d20845f57ace227c82c26668662eff"
   dependencies:
     colors "^1.1.2"
     elementtree "^0.1.6"
     lodash "^4.3.0"
-    plist "^1.2.0"
+    plist xiangpingmeng/plist.js
     shelljs "^0.7.0"
     tostr "^0.1.0"
-    xcode "^0.8.9"
+    xcode "^1.0.0"
 
 cordova-fetch@1.0.2:
   version "1.0.2"
@@ -5185,10 +5175,6 @@ node-status-codes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/node-status-codes/-/node-status-codes-1.0.0.tgz#5ae5541d024645d32a58fcddc9ceecea7ae3ac2f"
 
-node-uuid@1.4.7:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.7.tgz#6da5a17668c4b3dd59623bda11cf7fa4c1f60a6f"
-
 node-uuid@~1.4.0, node-uuid@~1.4.7:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.8.tgz#b040eb0923968afabf8d32fb1f17f1167fdab907"
@@ -5772,10 +5758,6 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-pegjs@0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/pegjs/-/pegjs-0.9.0.tgz#f6aefa2e3ce56169208e52179dfe41f89141a369"
-
 pegjs@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/pegjs/-/pegjs-0.10.0.tgz#cf8bafae6eddff4b5a7efb185269eaaf4610ddbd"
@@ -5830,21 +5812,21 @@ pkginfo@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.4.0.tgz#349dbb7ffd38081fcadc0853df687f0c7744cd65"
 
-plist@1.2.0, plist@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/plist/-/plist-1.2.0.tgz#084b5093ddc92506e259f874b8d9b1afb8c79593"
-  dependencies:
-    base64-js "0.0.8"
-    util-deprecate "1.0.2"
-    xmlbuilder "4.0.0"
-    xmldom "0.1.x"
-
 plist@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/plist/-/plist-2.0.1.tgz#0a32ca9481b1c364e92e18dc55c876de9d01da8b"
   dependencies:
     base64-js "1.1.2"
     xmlbuilder "8.2.2"
+    xmldom "0.1.x"
+
+plist@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/plist/-/plist-1.2.0.tgz#084b5093ddc92506e259f874b8d9b1afb8c79593"
+  dependencies:
+    base64-js "0.0.8"
+    util-deprecate "1.0.2"
+    xmlbuilder "4.0.0"
     xmldom "0.1.x"
 
 plist@^2.1.0:
@@ -5861,6 +5843,15 @@ plist@^3.0.1:
   dependencies:
     base64-js "^1.2.3"
     xmlbuilder "^9.0.7"
+    xmldom "0.1.x"
+
+plist@xiangpingmeng/plist.js:
+  version "1.2.0"
+  resolved "https://codeload.github.com/xiangpingmeng/plist.js/tar.gz/5ccd600b0b7fd3ae204edc9e69c1c30406d07747"
+  dependencies:
+    base64-js "0.0.8"
+    util-deprecate "1.0.2"
+    xmlbuilder "4.0.0"
     xmldom "0.1.x"
 
 plugin-error@^1.0.0:
@@ -6869,14 +6860,6 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
-simple-plist@0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/simple-plist/-/simple-plist-0.1.4.tgz#10eb51b47e33c556eb8ec46d5ee64d64e717db5d"
-  dependencies:
-    bplist-creator "0.0.4"
-    bplist-parser "0.0.6"
-    plist "1.2.0"
-
 simple-plist@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/simple-plist/-/simple-plist-0.2.1.tgz#71766db352326928cf3a807242ba762322636723"
@@ -7029,10 +7012,6 @@ stream-browserify@^2.0.0:
   dependencies:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
-
-stream-buffers@~0.2.3:
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/stream-buffers/-/stream-buffers-0.2.6.tgz#181c08d5bb3690045f69401b9ae6a7a0cf3313fc"
 
 stream-buffers@~2.2.0:
   version "2.2.0"
@@ -7972,17 +7951,17 @@ write-file-atomic@^2.0.0:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
 
-xcode@^0.8.9:
-  version "0.8.9"
-  resolved "https://registry.yarnpkg.com/xcode/-/xcode-0.8.9.tgz#ec6765f70e9dccccc9f6e9a5b9b4e7e814b4cf35"
-  dependencies:
-    node-uuid "1.4.7"
-    pegjs "0.9.0"
-    simple-plist "0.1.4"
-
 xcode@^0.9.0:
   version "0.9.3"
   resolved "https://registry.yarnpkg.com/xcode/-/xcode-0.9.3.tgz#910a89c16aee6cc0b42ca805a6d0b4cf87211cf3"
+  dependencies:
+    pegjs "^0.10.0"
+    simple-plist "^0.2.1"
+    uuid "3.0.1"
+
+xcode@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/xcode/-/xcode-1.0.0.tgz#e1f5b1443245ded38c180796df1a10fdeda084ec"
   dependencies:
     pegjs "^0.10.0"
     simple-plist "^0.2.1"


### PR DESCRIPTION
This fixes a build incompatibility with recent versions of
the Android SDK.  It also enables some new features of
cordova-android, like Java 8 support.