### PR TITLE
Accept our S3 invite URLs directly

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -47,14 +47,20 @@
         <splash density="xxhdpi" src="resources/splashscreen/android/splashscreen_xxhdpi.png" />
         <splash density="xxxhdpi" src="resources/splashscreen/android/splashscreen_xxxhdpi.png" />
 
-        <config-file parent="./application/activity/[@android:name='MainActivity']" target="AndroidManifest.xml">
+        <custom-config-file parent="./application/activity/[@android:name='MainActivity']" target="AndroidManifest.xml">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="ss" />
             </intent-filter>
-        </config-file>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="s3.amazonaws.com" android:path="/outline-vpn/invite.html" />
+            </intent-filter>
+        </custom-config-file>
     </platform>
 
     <!-- browser -->

--- a/www/app/app.ts
+++ b/www/app/app.ts
@@ -486,12 +486,12 @@ export class App {
           continue;
         }
         const fragment: string = decodeURIComponent(invite.hash);
-        const mark = '/invite/';
+        const mark = 'ss://';
         const index = fragment.indexOf(mark);
         if (index < 0) {
           return url;
         }
-        return fragment.slice(index + mark.length);
+        return fragment.substr(index);
       }
     } catch (e) {
       console.warn('Invalid invite', e);

--- a/www/ui_components/add-server-view.html
+++ b/www/ui_components/add-server-view.html
@@ -157,7 +157,7 @@
         <div class="title">[[localize('server-add-access-key')]]</div>
         <div class="faded">[[localize('server-add-instructions')]]</div>
       </div>
-      <paper-input id="accessKeyInput" class="shadow" label="[[localize('server-access-key-label', 'ssProtocol', 'ss://')]]" no-label-float value={{accessKey}} pattern="^ss://[A-Za-z0-9+/=][#]?.*$">
+      <paper-input id="accessKeyInput" class="shadow" label="[[localize('server-access-key-label', 'ssProtocol', 'ss://')]]" no-label-float value={{accessKey}} pattern="(^ss://[A-Za-z0-9+/=][#]?.*$)|(^https://s3.amazonaws.com/outline-vpn/(index.html)|(invite.html).*#.*/invite/ss.*$)">
         <iron-icon icon="communication:vpn-key" slot="suffix"></iron-icon>
       </paper-input>
       <div class="footer center top-divider">

--- a/www/ui_components/add-server-view.html
+++ b/www/ui_components/add-server-view.html
@@ -157,7 +157,7 @@
         <div class="title">[[localize('server-add-access-key')]]</div>
         <div class="faded">[[localize('server-add-instructions')]]</div>
       </div>
-      <paper-input id="accessKeyInput" class="shadow" label="[[localize('server-access-key-label', 'ssProtocol', 'ss://')]]" no-label-float value={{accessKey}} pattern="(^ss://[A-Za-z0-9+/=][#]?.*$)|(^https://s3.amazonaws.com/outline-vpn/(index.html)|(invite.html).*#.*/invite/ss.*$)">
+      <paper-input id="accessKeyInput" class="shadow" label="[[localize('server-access-key-label', 'ssProtocol', 'ss://')]]" no-label-float value={{accessKey}} pattern="((ss://)|(https://s3\.amazonaws\.com/outline-vpn/((index\.html.*[#].*/invite/)|(invite\.html.*[#]))ss)).*">
         <iron-icon icon="communication:vpn-key" slot="suffix"></iron-icon>
       </paper-input>
       <div class="footer center top-divider">


### PR DESCRIPTION
This should help in case users get confused about what to do with
an invite.  On Android it can also bypass S3 entirely.

This also fixes a bug with the existing intent filter on Android, which doesn't seem to be getting added to AndroidManifest.xml.

See https://github.com/Jigsaw-Code/outline-website/pull/86 and https://github.com/Jigsaw-Code/outline-server/pull/185.