### PR TITLE
Use single intent filter for URL interception

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -53,11 +53,6 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="ss" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="https" android:host="s3.amazonaws.com" android:path="/outline-vpn/invite.html" />
             </intent-filter>
         </custom-config-file>


### PR DESCRIPTION
Fixes URL interception for `ss://` links in Android.