### PR TITLE
Configure TAP device DNS

### DIFF
--- a/electron/add_tap_device.bat
+++ b/electron/add_tap_device.bat
@@ -74,10 +74,14 @@ if %errorlevel% neq 0 (
 :: "own" set of DNS servers. Windows seems to use the DNS server(s) of the
 :: network device associated with the default gateway. This is good for us
 :: as it means we do not have to modify the DNS settings of any other network
-:: device in the system.
-:: TODO: Choose a random (public) DNS server.
-netsh interface ip set dnsservers %DEVICE_NAME% static address=8.8.8.8 >nul
+:: device in the system. Configure with OpenDNS and Dyn resolvers.
+netsh interface ip set dnsservers %DEVICE_NAME% static address=208.67.222.222 >nul
 if %errorlevel% neq 0 (
   echo Could not configure TAP device DNS.
+  exit /b 1
+)
+netsh interface ip add dnsservers %DEVICE_NAME% 216.146.35.35 index=2 >nul
+if %errorlevel% neq 0 (
+  echo Could not configure TAP device  secondary DNS.
   exit /b 1
 )

--- a/electron/build_action.sh
+++ b/electron/build_action.sh
@@ -33,7 +33,7 @@ mkdir -p $BIN_DEST
 rsync -ac \
   --include '*.exe' --include '*.dll' \
   --exclude='*' \
-  third_party/shadowsocks-libev/windows/ third_party/badvpn/windows/ third_party/cygwin/ \
+  third_party/shadowsocks-libev/windows/ third_party/badvpn/windows/ \
   third_party/newtonsoft/ tools/OutlineService/OutlineService/bin/Release/ \
   $BIN_DEST
 


### PR DESCRIPTION
* Sets the DNS resolvers of the TAP device to OpenDNS and Dyn resolvers, as in the other platforms.
* Fixes the build script by removing a reference to cygwin.