### PR TITLE
categorise plugin errors as regular/irregular, automatically report irregular

### DIFF
--- a/cordova-plugin-outline/outlinePlugin.js
+++ b/cordova-plugin-outline/outlinePlugin.js
@@ -57,6 +57,8 @@ const ERROR_CODE = {
   CONFIGURE_SYSTEM_PROXY_FAILURE: 10
 };
 
+// This must be kept in sync with the TypeScript definition:
+//   www/model/errors.ts
 function OutlinePluginError(errorCode) {
   this.errorCode = errorCode || ERROR_CODE.UNEXPECTED;
 }

--- a/electron/index.ts
+++ b/electron/index.ts
@@ -14,7 +14,7 @@
 
 import * as sentry from '@sentry/electron';
 import {app, BrowserWindow, dialog, ipcMain, Menu, MenuItemConstructorOptions, shell, Tray} from 'electron';
-import {PromiseIpc} from 'electron-promise-ipc';
+import * as promiseIpc from 'electron-promise-ipc';
 import {autoUpdater} from 'electron-updater';
 import * as path from 'path';
 import * as process from 'process';
@@ -22,9 +22,6 @@ import * as url from 'url';
 
 import {ConnectionStore, SerializableConnection} from './connection_store';
 import * as process_manager from './process_manager';
-
-// TODO: Figure out the TypeScript magic to use the default, export-ed instance.
-const myPromiseIpc = new PromiseIpc();
 
 // Used for the auto-connect feature. There will be a connection in store
 // if the user was connected at shutdown.
@@ -226,7 +223,7 @@ app.on('quit', () => {
   });
 });
 
-myPromiseIpc.on('is-reachable', (config: cordova.plugins.outline.ServerConfig) => {
+promiseIpc.on('is-reachable', (config: cordova.plugins.outline.ServerConfig) => {
   return process_manager.isServerReachable(config)
       .then(() => {
         return true;
@@ -268,12 +265,12 @@ function startVpn(config: cordova.plugins.outline.ServerConfig, id: string) {
       });
 }
 
-myPromiseIpc.on(
+promiseIpc.on(
     'start-proxying', (args: {config: cordova.plugins.outline.ServerConfig, id: string}) => {
       return startVpn(args.config, args.id);
     });
 
-myPromiseIpc.on('stop-proxying', () => {
+promiseIpc.on('stop-proxying', () => {
   return process_manager.teardownVpn();
 });
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@sentry/electron": "^0.8.1",
     "ShadowsocksConfig": "Jigsaw-Code/outline-shadowsocksconfig#^v0.0.8",
     "babel-polyfill": "^6.26.0",
-    "electron-promise-ipc": "^0.0.4",
+    "electron-promise-ipc": "^0.1.3",
     "electron-updater": "^2.21.0",
     "raven": "^2.2.1",
     "raven-js": "^3.20.1",

--- a/www/app/app.ts
+++ b/www/app/app.ts
@@ -23,7 +23,7 @@ import {EnvironmentVariables} from './environment';
 import {OutlineErrorReporter} from './error_reporter';
 import {getLocalizedErrorMessage, LocalizationFunction} from './i18n';
 import {OutlineServer} from './outline_server';
-import {PersistentServerRepository} from './persistent_server';
+import {PersistentServer, PersistentServerRepository} from './persistent_server';
 import {Settings, SettingsKey} from './settings';
 import {Updater} from './updater';
 import {UrlInterceptor} from './url_interceptor';
@@ -126,15 +126,12 @@ export class App {
     this.pullClipboardText();
   }
 
-  showLocalizedError(err?: Error, toastDuration = 10000) {
-    if (err && err.message) {
-      console.error(err.message);
-    }
+  showLocalizedError(e?: Error, toastDuration = 10000) {
+    // TODO: Why would these not be set?
     if (this.rootEl && this.rootEl.async && this.rootEl.showToast) {
-      const msg = getLocalizedErrorMessage(err || new errors.OutlineError(), this.localize);
-      // Defer this by 500ms so that this toast is shown after any toasts that get
-      // shown when any currently-in-flight domain events land (e.g. fake servers
-      // added).
+      const msg = getLocalizedErrorMessage(e, this.localize);
+      // Defer this by 500ms so that this toast is shown after any toasts that get shown when any
+      // currently-in-flight domain events land (e.g. fake servers added).
       this.rootEl.async(() => {
         this.rootEl.showToast(msg, toastDuration);
       }, 500);
@@ -311,19 +308,33 @@ export class App {
     this.serverRepo.rename(serverId, newName);
   }
 
-  private connectServer(event: CustomEvent) {
-    const [server, card] = this.getServerAndCardByServerId(event.detail.serverId);
+  private connectServer(event: CustomEvent): void {
+    const serverId = event.detail.serverId;
+    if (!serverId) {
+      throw new Error(`connectServer event had no server ID`);
+    }
+
+    const server = this.getServerByServerId(serverId);
+    const card = this.getCardByServerId(serverId);
+
+    console.log(`connecting to server ${serverId}`);
+
     card.state = 'CONNECTING';
-    return server.connect().then(
+    server.connect().then(
         () => {
           card.state = 'CONNECTED';
+          console.log(`connected to server ${serverId}`);
           this.rootEl.showToast(this.localize('server-connected', 'serverName', server.name));
           this.maybeShowAutoConnectDialog();
         },
-        (err: errors.OutlinePluginError) => {
-          console.error(`Failed to connect to server with plugin error: ${err.name}`);
+        (e) => {
           card.state = 'DISCONNECTED';
-          this.showLocalizedError(err);
+          this.showLocalizedError(e);
+          if (e instanceof errors.RegularNativeError) {
+            console.warn(`could not connect to server ${serverId}: ${e.name}`);
+          } else {
+            throw e;
+          }
         });
   }
 
@@ -348,17 +359,32 @@ export class App {
     this.settings.set(SettingsKey.AUTO_CONNECT_DIALOG_DISMISSED, 'true');
   }
 
-  private disconnectServer(event: CustomEvent) {
-    const [server, card] = this.getServerAndCardByServerId(event.detail.serverId);
+  private disconnectServer(event: CustomEvent): void {
+    const serverId = event.detail.serverId;
+    if (!serverId) {
+      throw new Error(`disconnectServer event had no server ID`);
+    }
+
+    const server = this.getServerByServerId(serverId);
+    const card = this.getCardByServerId(serverId);
+
+    console.log(`disconnecting from server ${serverId}`);
+
     card.state = 'DISCONNECTING';
-    return server.disconnect().then(
+    server.disconnect().then(
         () => {
           card.state = 'DISCONNECTED';
+          console.log(`disconnected from server ${serverId}`);
           this.rootEl.showToast(this.localize('server-disconnected', 'serverName', server.name));
         },
-        (err: errors.OutlinePluginError) => {
+        (e) => {
           card.state = 'CONNECTED';
-          this.showLocalizedError(err);
+          this.showLocalizedError(e);
+          if (e instanceof errors.RegularNativeError) {
+            console.warn(`could not disconnect from server ${serverId}: ${e.name}`);
+          } else {
+            throw e;
+          }
         });
   }
 
@@ -470,10 +496,19 @@ export class App {
     this.rootEl.changePage(this.rootEl.DEFAULT_PAGE);
   }
 
-  private getServerAndCardByServerId(serverId: string) {
+  // Returns the server having serverId, throws if the server cannot be found.
+  private getServerByServerId(serverId: string): PersistentServer {
     const server = this.serverRepo.getById(serverId);
-    const card = this.serverListEl.getServerCard(serverId);
-    return [server, card];
+    if (!server) {
+      throw new Error(`could not find server with ID ${serverId}`);
+    }
+    return server;
+  }
+
+  // Returns the card associated with serverId, throws if no such card exists.
+  // See server-list.html.
+  private getCardByServerId(serverId: string) {
+    return this.serverListEl.getServerCard(serverId);
   }
 
   private showLocalizedErrorInDefaultPage(err: Error) {

--- a/www/app/app.ts
+++ b/www/app/app.ts
@@ -308,6 +308,9 @@ export class App {
     this.serverRepo.rename(serverId, newName);
   }
 
+  // Note that as a top-level method (invoked via an event handler on the connect button) any
+  // exceptions thrown by this method will result in a console message and Sentry report. Certain
+  // "expected" exceptions are trapped here, e.g. invalid password, to avoid cluttering Sentry.
   private connectServer(event: CustomEvent): void {
     const serverId = event.detail.serverId;
     if (!serverId) {
@@ -359,6 +362,7 @@ export class App {
     this.settings.set(SettingsKey.AUTO_CONNECT_DIALOG_DISMISSED, 'true');
   }
 
+  // See the comments for #connectServer on how uncaught exceptions are handled here.
   private disconnectServer(event: CustomEvent): void {
     const serverId = event.detail.serverId;
     if (!serverId) {

--- a/www/app/electron_main.ts
+++ b/www/app/electron_main.ts
@@ -21,6 +21,7 @@ import {EventQueue} from '../model/events';
 import {AbstractClipboard, Clipboard, ClipboardListener} from './clipboard';
 import {EnvironmentVariables} from './environment';
 import {OutlineErrorReporter} from './error_reporter';
+import {FakeOutlineConnection} from './fake_connection';
 import {main} from './main';
 import {OutlineServer} from './outline_server';
 import {OutlinePlatform} from './platform';
@@ -75,7 +76,10 @@ main({
     return (serverId: string, config: cordova.plugins.outline.ServerConfig,
             eventQueue: EventQueue) => {
       return new OutlineServer(
-          serverId, config, new WindowsOutlineConnection(config, serverId), eventQueue);
+          serverId, config,
+          isWindows ? new WindowsOutlineConnection(config, serverId) :
+                      new FakeOutlineConnection(config, serverId),
+          eventQueue);
     };
   },
   getUrlInterceptor: () => {

--- a/www/app/i18n.ts
+++ b/www/app/i18n.ts
@@ -16,35 +16,35 @@ import * as errors from '../model/errors';
 
 export type LocalizationFunction = (...args: string[]) => string;
 
-export function getLocalizedErrorMessage(error: {}, localize: LocalizationFunction) {
+export function getLocalizedErrorMessage(e: Error = new Error(), localize?: LocalizationFunction) {
   if (!localize) {
     console.error('Localization function not available');
     return 'An unexpected error occurred. Please submit feedback.';
   }
   let messageLocalizationKey: string;
-  if (error instanceof errors.UnexpectedPluginError) {
+  if (e instanceof errors.UnexpectedPluginError) {
     messageLocalizationKey = 'outline-plugin-error-unexpected';
-  } else if (error instanceof errors.VpnPermissionNotGranted) {
+  } else if (e instanceof errors.VpnPermissionNotGranted) {
     messageLocalizationKey = 'outline-plugin-error-vpn-permission-not-granted';
-  } else if (error instanceof errors.InvalidServerCredentials) {
+  } else if (e instanceof errors.InvalidServerCredentials) {
     messageLocalizationKey = 'outline-plugin-error-invalid-server-credentials';
-  } else if (error instanceof errors.RemoteUdpForwardingDisabled) {
+  } else if (e instanceof errors.RemoteUdpForwardingDisabled) {
     messageLocalizationKey = 'outline-plugin-error-udp-forwarding-not-enabled';
-  } else if (error instanceof errors.ServerUnreachable) {
+  } else if (e instanceof errors.ServerUnreachable) {
     messageLocalizationKey = 'outline-plugin-error-server-unreachable';
-  } else if (error instanceof errors.OutlinePluginError) {
+  } else if (e instanceof errors.OutlinePluginError) {
     messageLocalizationKey = 'outline-plugin-error-networking-error';
-  } else if (error instanceof errors.FeedbackSubmissionError) {
+  } else if (e instanceof errors.FeedbackSubmissionError) {
     messageLocalizationKey = 'error-feedback-submission';
-  } else if (error instanceof errors.ServerUrlInvalid) {
+  } else if (e instanceof errors.ServerUrlInvalid) {
     messageLocalizationKey = 'error-invalid-access-key';
-  } else if (error instanceof errors.ServerIncompatible) {
+  } else if (e instanceof errors.ServerIncompatible) {
     messageLocalizationKey = 'error-server-incompatible';
-  } else if (error instanceof errors.OperationTimedOut) {
+  } else if (e instanceof errors.OperationTimedOut) {
     messageLocalizationKey = 'error-timeout';
-  } else if (error instanceof errors.ServerAlreadyAdded) {
+  } else if (e instanceof errors.ServerAlreadyAdded) {
     // Handle differently due to the use of localization parameters.
-    return localize('error-server-already-added', 'serverName', error.server.name);
+    return localize('error-server-already-added', 'serverName', e.server.name);
   } else {
     messageLocalizationKey = 'error-unexpected';
   }

--- a/www/app/main.ts
+++ b/www/app/main.ts
@@ -61,6 +61,7 @@ function createServerRepo(
     if (repo.getAll().length === 0) {
       repo.add({name: 'Fake Working Server', host: '127.0.0.1'});
       repo.add({name: 'Fake Broken Server', host: '192.0.2.1'});
+      repo.add({name: 'Fake Unreachable Server', host: '10.0.0.24'});
     }
   }
   return repo;

--- a/www/app/util.ts
+++ b/www/app/util.ts
@@ -14,12 +14,6 @@
 
 import * as errors from '../model/errors';
 
-export function sleep(ms: number) {
-  return new Promise<void>((resolve, reject) => {
-    setTimeout(resolve, ms);
-  });
-}
-
 // tslint:disable-next-line:no-any
 export function timeoutPromise(promise: Promise<any>, ms: number, name = '') {
   // tslint:disable-next-line:no-any

--- a/www/app/windows_connection.ts
+++ b/www/app/windows_connection.ts
@@ -13,11 +13,9 @@
 // limitations under the License.
 
 import {ipcRenderer} from 'electron';
-import {PromiseIpc} from 'electron-promise-ipc';
-import * as errors from '../model/errors';
+import * as promiseIpc from 'electron-promise-ipc';
 
-// TODO: Figure out the TypeScript magic to use the default, export-ed instance.
-const myPromiseIpc = new PromiseIpc();
+import * as errors from '../model/errors';
 
 export class WindowsOutlineConnection implements cordova.plugins.outline.Connection {
   private statusChangeListener: (status: ConnectionStatus) => void;
@@ -46,12 +44,12 @@ export class WindowsOutlineConnection implements cordova.plugins.outline.Connect
       this.handleStatusChange(ConnectionStatus.DISCONNECTED);
     });
 
-    return myPromiseIpc.send('start-proxying', {config: this.config, id: this.id})
+    return promiseIpc.send('start-proxying', {config: this.config, id: this.id})
         .then(() => {
           this.running = true;
         })
         .catch((e: Error) => {
-          throw new errors.OutlineNativeError(parseInt(e.message, 10));
+          throw new errors.OutlinePluginError(parseInt(e.message, 10));
         });
   }
 
@@ -60,7 +58,7 @@ export class WindowsOutlineConnection implements cordova.plugins.outline.Connect
       return Promise.resolve();
     }
 
-    return myPromiseIpc.send('stop-proxying').then(() => {
+    return promiseIpc.send('stop-proxying').then(() => {
       this.running = false;
     });
   }
@@ -70,7 +68,7 @@ export class WindowsOutlineConnection implements cordova.plugins.outline.Connect
   }
 
   isReachable(): Promise<boolean> {
-    return myPromiseIpc.send('is-reachable', this.config);
+    return promiseIpc.send('is-reachable', this.config);
   }
 
   onStatusChange(listener: (status: ConnectionStatus) => void): void {

--- a/www/model/errors.ts
+++ b/www/model/errors.ts
@@ -56,8 +56,11 @@ export class FeedbackSubmissionError extends OutlineError {
 }
 
 // Error thrown by "native" code.
+//
 // Must be kept in sync with its Cordova doppelganger:
 //   cordova-plugin-outline/outlinePlugin.js
+//
+// TODO: Rename this class, "plugin" is a poor name since the Electron apps do not have plugins.
 export class OutlinePluginError extends OutlineError {
   constructor(public readonly errorCode: ErrorCode) {
     super();

--- a/www/types/electron-promise-ipc.d.ts
+++ b/www/types/electron-promise-ipc.d.ts
@@ -16,10 +16,14 @@
 // https://www.npmjs.com/package/electron-promise-ipc
 
 declare module 'electron-promise-ipc' {
-  export class PromiseIpc {
+  // TODO: Export this class definition in addition to the default instance.
+  class PromiseIpc {
     constructor(args?: {maxTimeoutMs?: number});
     on(eventName: string, callback: Function): void;
     // tslint:disable-next-line:no-any
     send(eventName: string, arg?: {}): Promise<any>;
   }
+
+  const defaultInstance: PromiseIpc;
+  export = defaultInstance;
 }

--- a/www/types/outlinePlugin.d.ts
+++ b/www/types/outlinePlugin.d.ts
@@ -59,6 +59,7 @@ declare namespace cordova.plugins.outline {
     // server as dictated by its configuration. If there is another running
     // instance, broadcasts a disconnect event and stops the running connection.
     // In such case, restarts tunneling while preserving the VPN connection.
+    // Rejects with an OutlinePluginError.
     start(): Promise<void>;
 
     // Stops the connection and VPN service.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2669,9 +2669,9 @@ electron-osx-sign@0.4.10:
     minimist "^1.2.0"
     plist "^2.1.0"
 
-electron-promise-ipc@^0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/electron-promise-ipc/-/electron-promise-ipc-0.0.4.tgz#f65ae045f168c71f7af340f3341375d63cc5a8d1"
+electron-promise-ipc@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/electron-promise-ipc/-/electron-promise-ipc-0.1.3.tgz#aa63388988157737c79d51f65d111263da8b2b67"
   dependencies:
     bluebird "^3.4.7"
     is-electron-renderer "^2.0.1"


### PR DESCRIPTION
This introduces the idea of "regular" and "red flag" plugin exceptions. As discussed, the latter trigger a Sentry report. For now, there's just two "red flag" errors:
- could not start `ss-local.exe`
- could not modify the routing table

Both are Windows-specific. The first may be overkill, depending on how we decide to deal with virus checker-type software; I hope the second gives us a better idea of what kind of routing tables are out there.

The way I've implemented this, a Sentry report will now also be triggered for any other unexpected exceptions on connect/disconnect. I believe this is how Sentry is intended to be used :-)

I tackled this by diving into the code from `app.ts#connectServer` down and couldn't resist a few other bits and bobs along the way:
- `connectServer` and `disconnectServer` should not return anything, since they're (top-level methods, essentially) event handlers
- improve `electron-promise-ipc` typing
- clarify purpose of `OutlinePluginError`, comment which bits must be kept in sync
- factor out `getServerAndCardByServerId` into `getServerByServerId` and `getCardByServerId`, add typings
- when running in Electron on Linux/Mac, use `FakeOutlineConnection`
- some general improvements to `FakeOutlineConnection`
- move the "convert number to Error" code into `errors.ts` (making it a kind of static constructor)