### PR TITLE
fix sudo-prompt error reporting, simplify call chain

### DIFF
--- a/www/types/sudo-prompt.d.ts
+++ b/www/types/sudo-prompt.d.ts
@@ -16,13 +16,11 @@
 // https://www.npmjs.com/package/sudo-prompt
 
 declare module 'sudo-prompt' {
-
   export interface SudoPromptOptions {
-    name?: string,
-    icns?: string
+    name?: string, icns?: string
   }
 
   export function exec(
       command: string, options?: SudoPromptOptions,
-      callback?: (error: Error, stdout: string|Buffer, stderr: string|Buffer) => void): void;
+      callback?: (error: string, stdout: string|Buffer, stderr: string|Buffer) => void): void;
 }


### PR DESCRIPTION
Had a report that I suspect is due to the user not having admin permissions but I can't be sure because sudo-prompt error reporting is currently broken. This addresses that, simplifies the call chain a bit (my bad, I was lazy last time I was in here), and removes the timeout - @alalamav I didn't see any evidence that it was necessary, can you remember the exact story?