### PR TITLE
Replace 'credentials' in log messages

### DIFF
--- a/cordova-plugin-outline/android/java/org/outline/shadowsocks/ShadowsocksConnectivity.java
+++ b/cordova-plugin-outline/android/java/org/outline/shadowsocks/ShadowsocksConnectivity.java
@@ -73,7 +73,7 @@ public class ShadowsocksConnectivity {
    * test by issuing an HTTP HEAD request to a target domain.
    */
   public static boolean validateServerCredentials(final String localProxyIp, final int localProxyPort) {
-    LOG.fine("Starting credentials verification");
+    LOG.fine("Starting server creds. validation.");
     Socket socket = null;
     DataOutputStream outputStream = null;
     DataInputStream inputStream = null;
@@ -106,7 +106,7 @@ public class ShadowsocksConnectivity {
       final String httpResponse = reader.readLine();
       return httpResponse != null && httpResponse.startsWith("HTTP/1.1");
     } catch (IOException e) {
-      LOG.log(Level.WARNING, "Got exception in credentials check", e);
+      LOG.log(Level.WARNING, "Got exception in server creds. validation", e);
     } finally {
       closeSocket(socket);
     }

--- a/cordova-plugin-outline/android/java/org/outline/vpn/VpnTunnelService.java
+++ b/cordova-plugin-outline/android/java/org/outline/vpn/VpnTunnelService.java
@@ -316,7 +316,7 @@ public class VpnTunnelService extends VpnService {
         boolean isReachable = reachabilityCheckResult.get();
         boolean credentialsAreValid = credentialsCheckResult.get();
         LOG.info(String.format(Locale.ROOT,
-            "Server connectivity: UDP forwarding disabled, server %s, credentials %s",
+            "Server connectivity: UDP forwarding disabled, server %s, creds. %s",
             isReachable ? "reachable" : "unreachable", credentialsAreValid ? "valid" : "invalid"));
         if (credentialsAreValid) {
           return OutlinePlugin.ErrorCode.UDP_RELAY_NOT_ENABLED;


### PR DESCRIPTION
* Prevents Sentry from filtering messages due to sensitive word scrubbing.
* Only affects the Android client.