### PR TITLE
Windows installer improvements

### DIFF
--- a/electron/custom_install_steps.nsh
+++ b/electron/custom_install_steps.nsh
@@ -45,6 +45,7 @@
   Pop $0
   StrCmp $0 0 success
   MessageBox MB_OK "Sorry, we could not configure your system to connect to Outline. Please try running the installer again. If you still cannot install Outline, please get in touch with us."
+  Quit
 
   success:
 
@@ -53,3 +54,7 @@
 ; TODO: Remove the TAP device on uninstall. This is impossible to implement safely
 ;       with the bundled tapinstall.exe because it can only remove *all* devices
 ;       having hwid tap0901 and these may include non-Outline devices.
+!macro customUnInstall
+  nsExec::Exec "net stop OutlineService"
+  nsExec::Exec "sc delete OutlineService"
+!macroend

--- a/electron/install_windows_service.bat
+++ b/electron/install_windows_service.bat
@@ -25,7 +25,7 @@ if !errorlevel! equ 0 (
   sc delete OutlineService
   if !errorlevel! neq 0 (
     echo "Failed to uninstall OutlineService"
-    exit \b 1
+    exit /b 1
   )
 )
 
@@ -34,7 +34,7 @@ if !errorlevel! equ 0 (
 sc create OutlineService binpath= "%PWD%OutlineService.exe" displayname= "OutlineService" start= "auto"
 if !errorlevel! neq 0 (
   echo "Failed to install OutlineService"
-  exit \b 1
+  exit /b 1
 )
 
 :: Start the service to avoid requesting admin permissions in the app.


### PR DESCRIPTION
* Fixes the routing service installation script to properly communicate exit codes.
* Aborts installation when the service installation fails.
* Uninstalls the routing service.

(Credit to @trevj for spotting the bugs ⭐️🥇)