### PR TITLE
Update Android target version to 26

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ UI components are located in [www/ui_components](www/ui_components).  The app lo
 Additional requirements for Android:
 
 * Android Studio
-* Android SDK 23
+* Android SDK 26
 
 To build for android, run:
 

--- a/config.xml
+++ b/config.xml
@@ -24,7 +24,7 @@
     <allow-intent href="http://*/*" />
     <allow-intent href="https://*/*" />
     <preference name="android-minSdkVersion" value="21" />
-    <preference name="android-targetSdkVersion" value="24" />
+    <preference name="android-targetSdkVersion" value="26" />
     <preference name="AndroidLaunchMode" value="singleInstance" />
     <preference name="ShowSplashScreenSpinner" value="false" />
 


### PR DESCRIPTION
The Play Store requires that existing apps target version 26 or higher by November 1st 2018.