### PR TITLE
Prevent Android client from sending duplicate DNS queries

### DIFF
--- a/third_party/badvpn/tun2socks/tun2socks.c
+++ b/third_party/badvpn/tun2socks/tun2socks.c
@@ -1622,6 +1622,7 @@ int process_device_udp_packet (uint8_t *data, int data_len)
                  "failed to associate dns request id to local address");
             goto fail;
         }
+        return 1;
     }
 #endif
     if (options.udpgw_remote_server_addr) {


### PR DESCRIPTION
* This is not an issue in production since we haven't updated tun2socks for Android since making changes for Windows.
* Prevents the Android client from sending DNS queries through both transparent DNS and SOCKS UDP.