### PR TITLE
have the client restart the service when there is a pipe error

### DIFF
--- a/electron/build_action.sh
+++ b/electron/build_action.sh
@@ -31,11 +31,16 @@ rsync -ac build/{electron,www} $OUTPUT/
 readonly BIN_DEST=$OUTPUT/electron/bin/win32
 mkdir -p $BIN_DEST
 rsync -ac \
+  third_party/shadowsocks-libev/windows/ third_party/badvpn/windows/ \
+  $BIN_DEST
+
+# Copy files for OutlineService.
+cp electron/install_windows_service.bat $OUTPUT
+rsync -ac \
   --include '*.exe' --include '*.dll' \
   --exclude='*' \
-  third_party/shadowsocks-libev/windows/ third_party/badvpn/windows/ \
   third_party/newtonsoft/ tools/OutlineService/OutlineService/bin/ \
-  $BIN_DEST
+  $OUTPUT
 
 # Version info and Sentry config.
 # In Electron, the path is relative to electron_index.html.

--- a/electron/custom_install_steps.nsh
+++ b/electron/custom_install_steps.nsh
@@ -33,6 +33,11 @@
 
   installservice:
 
+  ; Stop the service so we can extract the updated executable.
+  ; Note that ordinarily the uninstall steps, below, also stops the service.
+  ; This is for (really) old clients that don't have the uninstall step.
+  nsExec::Exec "net stop OutlineService"
+
   File "${PROJECT_DIR}\OutlineService.exe"
   File "${PROJECT_DIR}\Newtonsoft.Json.dll"
   File "${PROJECT_DIR}\electron\install_windows_service.bat"

--- a/electron/custom_install_steps.nsh
+++ b/electron/custom_install_steps.nsh
@@ -33,18 +33,17 @@
 
   installservice:
 
-  ; Stop the service so we can extract the updated executable.
-  nsExec::Exec "net stop OutlineService"
-  Pop $0
-
-  File "${PROJECT_DIR}\electron\bin\win32\OutlineService.exe"
-  File "${PROJECT_DIR}\electron\bin\win32\Newtonsoft.Json.dll"
+  File "${PROJECT_DIR}\OutlineService.exe"
+  File "${PROJECT_DIR}\Newtonsoft.Json.dll"
   File "${PROJECT_DIR}\electron\install_windows_service.bat"
 
   nsExec::Exec install_windows_service.bat
+
+  nsExec::Exec "sc query OutlineService"
   Pop $0
   StrCmp $0 0 success
   MessageBox MB_OK "Sorry, we could not configure your system to connect to Outline. Please try running the installer again. If you still cannot install Outline, please get in touch with us."
+  ; TODO: Abort gracefully, i.e. uninstall, before exiting.
   Quit
 
   success:


### PR DESCRIPTION
_Sorry, this took longer than expected due to a faulty machine..._

This makes the client **reinstall and restart** OutlineService when it encounters a pipe error (currently it just restarts).

I refactored `install_windows_service.bat` into a "bounce the service" script, used by both installer and client.

Obviously, this should really just be the installer's job but by doing this in the client we'll get - in addition to helping those users with connection problems - much more debugging info.

Also do this for `EPIPE` errors, which have been showing up quite a bit.