### PR TITLE
automatically report TAP device installation failures

### DIFF
--- a/electron/add_tap_device.bat
+++ b/electron/add_tap_device.bat
@@ -46,12 +46,12 @@ wmic nic get netconnectionid /format:list | findstr "=" > %AFTER_DEVICES%
 :: Find the name of the new device:
 ::  - Use a temp file to save/load the result to avoid escaping issues.
 ::  - Pipe input from /dev/null to prevent Powershell hanging, waiting for EOF.
-powershell "(compare-object (cat %BEFORE_DEVICES%) (cat %AFTER_DEVICES%) | format-wide InputObject | out-string).split(\"=\")[1].trim()" > %DEVICE_DIFF% < NUL
+powershell "(compare-object (cat %BEFORE_DEVICES%) (cat %AFTER_DEVICES%) | format-wide InputObject | out-string).split(\"=\")[1].trim()" > %DEVICE_DIFF% <nul
 set /p NEW_DEVICE= < %DEVICE_DIFF%
 echo New TAP device name: %NEW_DEVICE%
 
 :: Rename the device.
-netsh interface set interface name = "%NEW_DEVICE%" newname = "%DEVICE_NAME%" >nul
+netsh interface set interface name = "%NEW_DEVICE%" newname = "%DEVICE_NAME%"
 if %errorlevel% neq 0 (
   echo Could not rename TAP device.
   exit /b 1
@@ -63,7 +63,7 @@ if %errorlevel% neq 0 (
 :: script will fail and the installer will show an error message to the user.
 :: TODO: Actually search the system for an unused subnet or make the subnet
 ::       configurable in the Outline client.
-netsh interface ip set address %DEVICE_NAME% static 10.0.85.2 255.255.255.0 >nul
+netsh interface ip set address %DEVICE_NAME% static 10.0.85.2 255.255.255.0
 if %errorlevel% neq 0 (
   echo Could not set TAP device subnet.
   exit /b 1
@@ -74,13 +74,13 @@ if %errorlevel% neq 0 (
 :: network device associated with the default gateway. This is good for us
 :: as it means we do not have to modify the DNS settings of any other network
 :: device in the system. Configure with OpenDNS and Dyn resolvers.
-netsh interface ip set dnsservers %DEVICE_NAME% static address=208.67.222.222 >nul
+netsh interface ip set dnsservers %DEVICE_NAME% static address=208.67.222.222
 if %errorlevel% neq 0 (
-  echo Could not configure TAP device DNS.
+  echo Could not configure TAP device primary DNS.
   exit /b 1
 )
-netsh interface ip add dnsservers %DEVICE_NAME% 216.146.35.35 index=2 >nul
+netsh interface ip add dnsservers %DEVICE_NAME% 216.146.35.35 index=2
 if %errorlevel% neq 0 (
-  echo Could not configure TAP device  secondary DNS.
+  echo Could not configure TAP device secondary DNS.
   exit /b 1
 )

--- a/electron/custom_install_steps.nsh
+++ b/electron/custom_install_steps.nsh
@@ -67,6 +67,8 @@ ${StrNSISToIO}
   ;    string that Sentry will like *and* can fit on one line, e.g.
   ;    "device not found\ncommand failed"; fortunately, StrFunc.nsh's StrNSISToIO does precisely
   ;    this.
+  ;  - RELEASE and SENTRY_DSN are defined in env.nsh which is generated at build time by
+  ;    {package,release}_action.sh.
 
   ; http://nsis.sourceforge.net/Docs/StrFunc/StrFunc.txt
   Var /GLOBAL FAILURE_MESSAGE
@@ -97,6 +99,8 @@ ${StrNSISToIO}
   nsExec::Exec "sc query OutlineService"
   Pop $0
   StrCmp $0 0 success
+  ; TODO: Trigger a Sentry report for service installation failure, too, and revisit
+  ;       the restart stuff in the TypeScript code.
   MessageBox MB_OK "Sorry, we could not configure your system to connect to Outline. Please try \
     running the installer again. If you still cannot install Outline, please get in touch with us \
     and let us know that OutlineService failed to install."

--- a/electron/custom_install_steps.nsh
+++ b/electron/custom_install_steps.nsh
@@ -12,11 +12,28 @@
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
 
+!include StrFunc.nsh
+!include WinVer.nsh
 !include x64.nsh
 
+!include env.nsh
+
+; StrFunc weirdness; this fix suggested here:
+; https://github.com/electron-userland/electron-builder/issues/888
+!ifndef BUILD_UNINSTALLER
+${StrNSISToIO}
+!endif
+
 !macro customInstall
+  ; TAP device files.
   File /r "${PROJECT_DIR}\tap-windows6"
   File "${PROJECT_DIR}\electron\add_tap_device.bat"
+
+  ; OutlineService files, stopping the service first in case it's still running.
+  nsExec::Exec "net stop OutlineService"
+  File "${PROJECT_DIR}\OutlineService.exe"
+  File "${PROJECT_DIR}\Newtonsoft.Json.dll"
+  File "${PROJECT_DIR}\electron\install_windows_service.bat"
 
   ; ExecToStack captures stdout:
   ;   http://nsis.sourceforge.net/Docs/nsExec/nsExec.txt
@@ -26,32 +43,63 @@
     nsExec::ExecToStack 'add_tap_device.bat i386'
   ${EndIf}
 
-  
   Pop $0
   Pop $1
   StrCmp $0 0 installservice
-  MessageBox MB_OK "Sorry, we could not configure your system to connect to Outline. Please try running the installer again.$\n$\nIf you still cannot install Outline, please get in touch with us and let us know that the TAP device failed to install with this error: $1"
-  ; TODO: Abort gracefully, i.e. uninstall, before exiting.
+  MessageBox MB_OK "Sorry, we could not configure your system to connect to Outline. Please try \
+    running the installer again. If you still cannot install Outline, please get in \
+    touch with us and let us know that the TAP device failed to install with this error:$\n$\n$1"
+
+  ; Submit a Sentry error event.
+  ;
+  ; This will get bundled into an issue named "could not install TAP device" with the following
+  ; attributes:
+  ;  - a single breadcrumb containing the output of add_tap_device.bat
+  ;  - Windows version, as a tag named "os" with a value identical in most cases to what the
+  ;    JavaScript Sentry client produces, e.g. "Windows 10.0.17134"
+  ;  - client version
+  ;
+  ; Note:
+  ;  - Sentry won't accept a breadcrumbs without a timestamp; fortunately, it accepts obviously
+  ;    bogus values so we don't have to fetch the real time.
+  ;  - Because nsExec::ExecToStack yields "NSIS strings" strings suitable for inclusion in, for
+  ;    example, a MessageBox, e.g. "device not found$\ncommand failed", we must convert it to a
+  ;    string that Sentry will like *and* can fit on one line, e.g.
+  ;    "device not found\ncommand failed"; fortunately, StrFunc.nsh's StrNSISToIO does precisely
+  ;    this.
+
+  ; http://nsis.sourceforge.net/Docs/StrFunc/StrFunc.txt
+  Var /GLOBAL FAILURE_MESSAGE
+  ${StrNSISToIO} $FAILURE_MESSAGE $1
+
+  ${WinVerGetMajor} $R0
+  ${WinVerGetMinor} $R1
+  ${WinVerGetBuild} $R2
+
+  ; http://nsis.sourceforge.net/Inetc_plug-in#post
+  inetc::post '{\
+    "message":"could not install TAP device",\
+    "release":"${RELEASE}",\
+    "tags":[\
+      ["os", "Windows $R0.$R1.$R2"]\
+    ],\
+    "breadcrumbs":[\
+      {"timestamp":1, "message":"$FAILURE_MESSAGE"}\
+    ]\
+  }' /TOSTACK ${SENTRY_DSN} /END
+
   Quit
 
   installservice:
-
-  ; Stop the service so we can extract the updated executable.
-  ; Note that ordinarily the uninstall steps, below, also stops the service.
-  ; This is for (really) old clients that don't have the uninstall step.
-  nsExec::Exec "net stop OutlineService"
-
-  File "${PROJECT_DIR}\OutlineService.exe"
-  File "${PROJECT_DIR}\Newtonsoft.Json.dll"
-  File "${PROJECT_DIR}\electron\install_windows_service.bat"
 
   nsExec::Exec install_windows_service.bat
 
   nsExec::Exec "sc query OutlineService"
   Pop $0
   StrCmp $0 0 success
-  MessageBox MB_OK "Sorry, we could not configure your system to connect to Outline. Please try running the installer again.$\n$\nIf you still cannot install Outline, please get in touch with us and let us know that OutlineService failed to install."
-  ; TODO: Abort gracefully, i.e. uninstall, before exiting.
+  MessageBox MB_OK "Sorry, we could not configure your system to connect to Outline. Please try \
+    running the installer again. If you still cannot install Outline, please get in touch with us \
+    and let us know that OutlineService failed to install."
   Quit
 
   success:

--- a/electron/package_action.sh
+++ b/electron/package_action.sh
@@ -17,7 +17,15 @@
 yarn do electron/build
 
 cp package.json build/windows/
+
+# Environment variables.
 scripts/environment_json.sh -p windows > build/windows/www/environment.json
+# TODO: Share code with environment_json.sh.
+mkdir -p build/windows/build
+cat > build/windows/build/env.nsh << EOF
+!define RELEASE "$(node -r fs -p 'JSON.parse(fs.readFileSync("package.json")).version;')"
+!define SENTRY_DSN "https://sentry.io/api/159503/store/?sentry_version=7&sentry_key=319145c481df41458bb6e84c1a99c9ff"
+EOF
 
 # Copy tap-windows6.
 cp -R third_party/tap-windows6/bin build/windows/tap-windows6

--- a/electron/package_action.sh
+++ b/electron/package_action.sh
@@ -20,7 +20,7 @@ cp package.json build/windows/
 
 # Environment variables.
 scripts/environment_json.sh -p windows > build/windows/www/environment.json
-# TODO: Share code with environment_json.sh.
+# TODO: Share code with environment_json.sh (this is the dev/debug Sentry DSN).
 mkdir -p build/windows/build
 cat > build/windows/build/env.nsh << EOF
 !define RELEASE "$(node -r fs -p 'JSON.parse(fs.readFileSync("package.json")).version;')"

--- a/electron/release_action.sh
+++ b/electron/release_action.sh
@@ -22,7 +22,15 @@
 yarn do electron/build
 
 cp package.json build/windows/
-scripts/environment_json.sh -p windows -r > build/windows/www/environment.json
+
+# Environment variables.
+scripts/environment_json.sh -p windows > build/windows/www/environment.json
+# TODO: Share code with environment_json.sh.
+mkdir -p build/windows/build
+cat > build/windows/build/env.nsh << EOF
+!define RELEASE "$(node -r fs -p 'JSON.parse(fs.readFileSync("package.json")).version;')"
+!define SENTRY_DSN "https://sentry.io/api/159502/store/?sentry_version=7&sentry_key=6a1e6e7371a64db59f5ba6c34a77d78c"
+EOF
 
 # Copy tap-windows6.
 cp -R third_party/tap-windows6/bin build/windows/tap-windows6


### PR DESCRIPTION
This should help us figure out why the TAP device won't install on some machines: submit a Sentry event each time the install fails, using basically the same approach as the server installer. Turns out NSIS includes a simple HTTP client so this wasn't as hard as I figured (initially I looked at `curl` but the Windows version is 1.5MB compressed!).

Each event includes:
- the output from `add_tap_device.bat`
- Windows version
- client version

Lots of NSIS trial and error but it seems to work on Win 7, 8, and 10.