### PR TITLE
Set the VPN's underlying network

### DIFF
--- a/cordova-plugin-outline/android/java/org/outline/vpn/VpnTunnelService.java
+++ b/cordova-plugin-outline/android/java/org/outline/vpn/VpnTunnelService.java
@@ -362,6 +362,11 @@ public class VpnTunnelService extends VpnService {
       }
       broadcastVpnConnectivityChange(OutlinePlugin.ConnectionStatus.CONNECTED);
       displayPersistentNotification(null, OutlinePlugin.ConnectionStatus.CONNECTED);
+
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        // Indicate that traffic will be sent over the current active network.
+        setUnderlyingNetworks(new Network[] {connectivityManager.getActiveNetwork()});
+      }
     }
 
     @Override
@@ -375,6 +380,10 @@ public class VpnTunnelService extends VpnService {
       }
       broadcastVpnConnectivityChange(OutlinePlugin.ConnectionStatus.RECONNECTING);
       displayPersistentNotification(null, OutlinePlugin.ConnectionStatus.RECONNECTING);
+
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        setUnderlyingNetworks(null);
+      }
     }
 
     // Returns whether the underlying networks of NetworkInfo objects are equal.

--- a/cordova-plugin-outline/android/java/org/outline/vpn/VpnTunnelService.java
+++ b/cordova-plugin-outline/android/java/org/outline/vpn/VpnTunnelService.java
@@ -365,7 +365,7 @@ public class VpnTunnelService extends VpnService {
 
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
         // Indicate that traffic will be sent over the current active network.
-        setUnderlyingNetworks(new Network[] {connectivityManager.getActiveNetwork()});
+        setUnderlyingNetworks(new Network[] {network});
       }
     }
 


### PR DESCRIPTION
More accurately reports the VPN's network capabilities by marking the VPN as using the current active network. This is [particularly relevant](https://developer.android.com/about/versions/pie/android-9.0-changes-all#network-capabilities-vpn) in Android 9.

Addresses #265.