### PR TITLE
Fix Shadowsocks start failure messaging

### DIFF
--- a/resources/master_messages.json
+++ b/resources/master_messages.json
@@ -365,10 +365,6 @@
     "message": "We can’t seem to connect to your server. Please check that you are connected to the internet and try again.",
     "description": "An error message shown when the user tries to connect to a server that cannot be reached for some reason."
   },
-  "outline_plugin_error_generic_start_failure": {
-    "message": "Something happened and we couldn’t connect. If this happens again, please submit feedback.",
-    "description": "A general error message when failing to connect to a server."
-  },
   "outline-plugin-error-admin-permissions": {
     "message": "Outline needs admin permissions in order to run. If you don't have admin permissions, please try again after restarting your Windows computer or ask your system administrator for help.",
     "description": "An error message when the application is not granted administrator permissions."

--- a/resources/master_messages.json
+++ b/resources/master_messages.json
@@ -345,10 +345,6 @@
     "message": "Sorry, we were unable to submit your feedback. Please check that you are connected to the internet and try again.",
     "description": "An error message shown when the user is trying to send feedback to the application developers but it is failing."
   },
-  "outline_plugin_error_unexpected": {
-    "message": "Sorry, an unexpected error occurred. If this happens again, please submit feedback.",
-    "description": "A generic error message shown when the cause is not known."
-  },
   "outline_plugin_error_vpn_permission_not_granted": {
     "message": "Outline needs your permission to set up a VPN connection to the server. Please try again, or submit feedback if you need help.",
     "description": "An error message shown when the application does not have the proper operating system permission to create a VPN connection. Outline is the product name and can be found in the translation glossary."

--- a/www/app/app.ts
+++ b/www/app/app.ts
@@ -131,9 +131,7 @@ export class App {
     let buttonHandler: () => void;
     let buttonLink: string;
 
-    if (e instanceof errors.UnexpectedPluginError) {
-      messageKey = 'outline-plugin-error-unexpected';
-    } else if (e instanceof errors.VpnPermissionNotGranted) {
+    if (e instanceof errors.VpnPermissionNotGranted) {
       messageKey = 'outline-plugin-error-vpn-permission-not-granted';
     } else if (e instanceof errors.InvalidServerCredentials) {
       messageKey = 'outline-plugin-error-invalid-server-credentials';

--- a/www/app/app.ts
+++ b/www/app/app.ts
@@ -149,14 +149,11 @@ export class App {
       messageKey = 'error-server-incompatible';
     } else if (e instanceof errors.OperationTimedOut) {
       messageKey = 'error-timeout';
-    } else if (e instanceof errors.ShadowsocksStartFailure) {
-      if (this.isWindows()) {
-        messageKey = 'outline-plugin-error-antivirus';
-        buttonKey = 'fix-this';
-        buttonLink = 'https://s3.amazonaws.com/outline-vpn/index.html#/en/support/antivirusBlock';
-      } else {
-        messageKey = 'outline-plugin-error-generic-start-failure';
-      }
+    } else if (e instanceof errors.ShadowsocksStartFailure && this.isWindows()) {
+      // Fall through to `error-unexpected` for other platforms.
+      messageKey = 'outline-plugin-error-antivirus';
+      buttonKey = 'fix-this';
+      buttonLink = 'https://s3.amazonaws.com/outline-vpn/index.html#/en/support/antivirusBlock';
     } else if (e instanceof errors.ConfigureSystemProxyFailure) {
       messageKey = 'outline-plugin-error-routing-tables';
       buttonKey = 'submit-feedback';

--- a/www/app/app.ts
+++ b/www/app/app.ts
@@ -150,10 +150,13 @@ export class App {
     } else if (e instanceof errors.OperationTimedOut) {
       messageKey = 'error-timeout';
     } else if (e instanceof errors.ShadowsocksStartFailure) {
-      // TODO: only display this message if running on Windows.
-      messageKey = 'outline-plugin-error-antivirus';
-      buttonKey = 'fix-this';
-      buttonLink = 'https://s3.amazonaws.com/outline-vpn/index.html#/en/support/antivirusBlock';
+      if (this.isWindows()) {
+        messageKey = 'outline-plugin-error-antivirus';
+        buttonKey = 'fix-this';
+        buttonLink = 'https://s3.amazonaws.com/outline-vpn/index.html#/en/support/antivirusBlock';
+      } else {
+        messageKey = 'outline-plugin-error-generic-start-failure';
+      }
     } else if (e instanceof errors.ConfigureSystemProxyFailure) {
       messageKey = 'outline-plugin-error-routing-tables';
       buttonKey = 'submit-feedback';
@@ -386,7 +389,7 @@ export class App {
   }
 
   private maybeShowAutoConnectDialog() {
-    if (!('cordova' in window)) {
+    if (!this.isWindows()) {
       // NOTE: auto-connect doesn't currently work in Windows because the executable requires
       // admin rights and cannot be automatically started on boot.
       return;
@@ -558,5 +561,9 @@ export class App {
   private showLocalizedErrorInDefaultPage(err: Error) {
     this.changeToDefaultPage();
     this.showLocalizedError(err);
+  }
+
+  private isWindows() {
+    return !('cordova' in window);
   }
 }


### PR DESCRIPTION
Displays a different message (antivirus) for Windows than other clients when Shadowsocks fails to start.