### PR TITLE
Android: start the service on boot only if there was an active connection at shutdown

### DIFF
--- a/cordova-plugin-outline/android/java/org/outline/vpn/VpnServiceStarter.java
+++ b/cordova-plugin-outline/android/java/org/outline/vpn/VpnServiceStarter.java
@@ -18,6 +18,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
+import org.outline.OutlinePlugin;
 
 // Starts the VpnTunnelService on boot and after app updates. Receives broadcasts for
 // android.intent.action.BOOT_COMPLETED and android.intent.action.MY_PACKAGE_REPLACED.
@@ -26,6 +27,12 @@ public class VpnServiceStarter extends BroadcastReceiver {
 
   @Override
   public void onReceive(Context context, Intent intent) {
+    final VpnConnectionStore connectionStore = new VpnConnectionStore(context);
+    boolean wasConectedAtShutdown =
+        OutlinePlugin.ConnectionStatus.CONNECTED.equals(connectionStore.getConnectionStatus());
+    if (!wasConectedAtShutdown) {
+      return;
+    }
     Intent serviceIntent = new Intent(context, VpnTunnelService.class);
     serviceIntent.putExtra(AUTOSTART_EXTRA, true);
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/cordova-plugin-outline/android/java/org/outline/vpn/VpnTunnelService.java
+++ b/cordova-plugin-outline/android/java/org/outline/vpn/VpnTunnelService.java
@@ -97,13 +97,11 @@ public class VpnTunnelService extends VpnService {
     LOG.info(String.format(Locale.ROOT, "Starting VPN service: %s", intent));
     int superOnStartReturnValue = super.onStartCommand(intent, flags, startId);
     if (intent != null) {
-      boolean wasConectedAtShutdown =
-          OutlinePlugin.ConnectionStatus.CONNECTED.equals(connectionStore.getConnectionStatus());
       // VpnServiceStarter includes AUTOSTART_EXTRA in the intent if automatic start has occurred.
       boolean startedByVpnStarter =
           intent.getBooleanExtra(VpnServiceStarter.AUTOSTART_EXTRA, false);
       boolean startedByAlwaysOn = VpnService.SERVICE_INTERFACE.equals(intent.getAction());
-      if ((wasConectedAtShutdown && startedByVpnStarter) || startedByAlwaysOn) {
+      if (startedByVpnStarter || startedByAlwaysOn) {
         startLastSuccessfulConnectionOrExit();
       }
     }


### PR DESCRIPTION
* We're still seeing `RemoteServiceExceptions` because the VPN service exits early, without calling `startForeground` if there wasn't a connection at shutdown when started on boot.
* Moves the auto-start logic to `VpnServiceStarter` so it only starts the service if there was an active connection at shutdown
* Follow-up to #280.