### PR TITLE
Display default server name in notification when failing to retrieve server name

### DIFF
--- a/cordova-plugin-outline/android/java/org/outline/vpn/VpnTunnelService.java
+++ b/cordova-plugin-outline/android/java/org/outline/vpn/VpnTunnelService.java
@@ -565,8 +565,7 @@ public class VpnTunnelService extends VpnService {
 
   /* Returns the server's name from |serverConfig|. If the name is not present, it falls back to the
    * host name (IP address), or the application name if neither can be retrieved. */
-  private final String getServerName(final JSONObject serverConfig)
-      throws PackageManager.NameNotFoundException {
+  private final String getServerName(final JSONObject serverConfig) {
     try {
       String serverName = serverConfig.getString("name");
       if (serverName == null || serverName.equals("")) {

--- a/cordova-plugin-outline/android/java/org/outline/vpn/VpnTunnelService.java
+++ b/cordova-plugin-outline/android/java/org/outline/vpn/VpnTunnelService.java
@@ -576,7 +576,7 @@ public class VpnTunnelService extends VpnService {
     } catch (Exception e) {
       LOG.severe("Failed to get name property from server config.");
     }
-    return getApplicationName();
+    return getStringResource("server_default_name_outline");
   }
 
   /* Returns the application name. */

--- a/cordova-plugin-outline/android/resources/strings/values-ar/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-ar/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">جارٍ إعادة الاتصال...</string>
 	<string name="connected_server_state">متصل</string>
+	<string name="server_default_name_outline">خادم Outline</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-b+sr+Latn/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-b+sr+Latn/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">Veza se ponovo uspostavlja...</string>
 	<string name="connected_server_state">Povezano je</string>
+	<string name="server_default_name_outline">Outline server</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-bg/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-bg/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">Извършва се повторно свързване...</string>
 	<string name="connected_server_state">Установена е връзка</string>
+	<string name="server_default_name_outline">Сървър на Outline</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-ca/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-ca/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">S\'està tornant a connectar...</string>
 	<string name="connected_server_state">Connectat</string>
+	<string name="server_default_name_outline">Servidor d\'Outline</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-cs/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-cs/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">Nové připojování...</string>
 	<string name="connected_server_state">Připojeno</string>
+	<string name="server_default_name_outline">Server aplikace Outline</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-da/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-da/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">Genopretter forbindelsen...</string>
 	<string name="connected_server_state">Tilsluttet</string>
+	<string name="server_default_name_outline">Outline-server</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-de/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-de/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">Verbindung wird wiederhergestellt…</string>
 	<string name="connected_server_state">Verbunden</string>
+	<string name="server_default_name_outline">Outline-Server</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-el/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-el/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">Επανασύνδεση…</string>
 	<string name="connected_server_state">Συνδεδεμένος</string>
+	<string name="server_default_name_outline">Διακομιστής Outline</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-en/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-en/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">Reconnecting...</string>
 	<string name="connected_server_state">Connected</string>
+	<string name="server_default_name_outline">Outline Server</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-es/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-es/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">Volviendo a conectar…</string>
 	<string name="connected_server_state">Conectado</string>
+	<string name="server_default_name_outline">Servidor de Outline</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-fa/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-fa/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">درحال اتصال مجدد...</string>
 	<string name="connected_server_state">وصل شدید</string>
+	<string name="server_default_name_outline">سرور Outline</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-fi/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-fi/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">Yhdistetään uudelleen…</string>
 	<string name="connected_server_state">Yhdistetty</string>
+	<string name="server_default_name_outline">Outline-palvelin</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-fil/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-fil/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">Muling ikinokonekta...</string>
 	<string name="connected_server_state">Nakakonekta na</string>
+	<string name="server_default_name_outline">Server ng Outline</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-fr/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-fr/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">Reconnexion…</string>
 	<string name="connected_server_state">Connecté</string>
+	<string name="server_default_name_outline">Serveur Outline</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-he/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-he/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">החיבור מחדש מתבצע...</string>
 	<string name="connected_server_state">מחובר</string>
+	<string name="server_default_name_outline">שרת Outline</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-hi/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-hi/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">फिर से कनेक्ट किया जा रहा है...</string>
 	<string name="connected_server_state">कनेक्ट किया गया</string>
+	<string name="server_default_name_outline">Outline सर्वर</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-hr/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-hr/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">Ponovno povezivanje...</string>
 	<string name="connected_server_state">Povezano</string>
+	<string name="server_default_name_outline">Poslužitelj za Outline</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-hu/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-hu/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">Újracsatlakozás...</string>
 	<string name="connected_server_state">Csatlakoztatva</string>
+	<string name="server_default_name_outline">Outline-szerver</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-id/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-id/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">Menyambung kembali...</string>
 	<string name="connected_server_state">Tersambung</string>
+	<string name="server_default_name_outline">Server Outline</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-it/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-it/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">Riconnessione in corso...</string>
 	<string name="connected_server_state">Connesso</string>
+	<string name="server_default_name_outline">Server Outline</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-ja/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-ja/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">再接続しています...</string>
 	<string name="connected_server_state">接続しました</string>
+	<string name="server_default_name_outline">Outline サーバー</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-ko/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-ko/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">다시 연결하는 중...</string>
 	<string name="connected_server_state">연결됨</string>
+	<string name="server_default_name_outline">Outline 서버</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-lt/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-lt/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">Prisijungiama iš naujo...</string>
 	<string name="connected_server_state">Prisijungta</string>
+	<string name="server_default_name_outline">„Outline“ serveris</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-lv/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-lv/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">Notiek atkārtota savienojuma izveide...</string>
 	<string name="connected_server_state">Savienojums izveidots</string>
+	<string name="server_default_name_outline">Lietojumprogrammas Outline serveris</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-nl/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-nl/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">Opnieuw verbinding maken...</string>
 	<string name="connected_server_state">Verbonden</string>
+	<string name="server_default_name_outline">Outline-server</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-no/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-no/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">Kobler til på nytt …</string>
 	<string name="connected_server_state">Tilkoblet</string>
+	<string name="server_default_name_outline">Outline-tjener</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-pl/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-pl/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">Łączę się ponownie...</string>
 	<string name="connected_server_state">Połączono</string>
+	<string name="server_default_name_outline">Serwer Outline</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-pt-rBR/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-pt-rBR/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">Reconectando…</string>
 	<string name="connected_server_state">Conectado</string>
+	<string name="server_default_name_outline">Servidor do Outline</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-ro/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-ro/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">Se reconectează...</string>
 	<string name="connected_server_state">Conectat</string>
+	<string name="server_default_name_outline">Server Outline</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-ru/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-ru/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">Повторное подключение…</string>
 	<string name="connected_server_state">Подключен</string>
+	<string name="server_default_name_outline">Сервер Outline</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-sk/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-sk/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">Znova sa pripája…</string>
 	<string name="connected_server_state">Pripojené</string>
+	<string name="server_default_name_outline">Server služby Outline</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-sl/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-sl/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">Ponovno vzpostavljanje povezave …</string>
 	<string name="connected_server_state">Povezava je vzpostavljena</string>
+	<string name="server_default_name_outline">Strežnik Outline</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-sr/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-sr/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">Веза се поново успоставља...</string>
 	<string name="connected_server_state">Повезано је</string>
+	<string name="server_default_name_outline">Outline сервер</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-sv/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-sv/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">Återansluter …</string>
 	<string name="connected_server_state">Ansluten</string>
+	<string name="server_default_name_outline">Outline-server</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-th/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-th/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">กำลังเชื่อมต่อใหม่...</string>
 	<string name="connected_server_state">เชื่อมต่อแล้ว</string>
+	<string name="server_default_name_outline">เซิร์ฟเวอร์ Outline</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-tr/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-tr/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">Yeniden bağlanılıyor...</string>
 	<string name="connected_server_state">Bağlanıldı</string>
+	<string name="server_default_name_outline">Outline Sunucusu</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-uk/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-uk/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">Повторне підключення…</string>
 	<string name="connected_server_state">Підключено</string>
+	<string name="server_default_name_outline">Сервер Outline</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-ur/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-ur/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">دوبارہ منسلک ہو رہا ہے…</string>
 	<string name="connected_server_state">منسلک ہے</string>
+	<string name="server_default_name_outline">Outline سرور</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-vi/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-vi/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">Đang kết nối lại...</string>
 	<string name="connected_server_state">Đã kết nối</string>
+	<string name="server_default_name_outline">Máy chủ Outline</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-zh-rCN/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-zh-rCN/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">正在重新连接…</string>
 	<string name="connected_server_state">已连接</string>
+	<string name="server_default_name_outline">Outline 服务器</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-zh-rTW/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-zh-rTW/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">正在重新連線...</string>
 	<string name="connected_server_state">已連線</string>
+	<string name="server_default_name_outline">Outline 伺服器</string>
 </resources>

--- a/cordova-plugin-outline/android/resources/strings/values-zh/strings.xml
+++ b/cordova-plugin-outline/android/resources/strings/values-zh/strings.xml
@@ -5,4 +5,5 @@
 	<string name="activity_name">@string/launcher_name</string>
 	<string name="reconnecting_server_state">正在重新连接…</string>
 	<string name="connected_server_state">已连接</string>
+	<string name="server_default_name_outline">Outline 服务器</string>
 </resources>

--- a/scripts/l10n/import_native_android_strings.py
+++ b/scripts/l10n/import_native_android_strings.py
@@ -26,7 +26,8 @@ import sys
 # Keys to import.
 NATIVE_KEYS = [
   "connected_server_state",
-  "reconnecting_server_state"
+  "reconnecting_server_state",
+  "server_default_name_outline"
 ]
 XML_TEMPLATE = '''<?xml version='1.0' encoding='utf-8'?>
 <resources>


### PR DESCRIPTION
* Imports the localized default server name to native Android strings.
* Displays the default server name to in the notification when retrieving the server name from configuration fails.
* Aims to fix `Bad notification for startForeground: java.lang.IllegalArgumentException: Duplicate key in ArrayMap`, which occurs when using the app's name upon failure to retrieve the server name from config.