### PR TITLE
quit installer when not running as admin, to handle uac failures

### DIFF
--- a/electron/custom_install_steps.nsh
+++ b/electron/custom_install_steps.nsh
@@ -25,6 +25,23 @@ ${StrNSISToIO}
 !endif
 
 !macro customInstall
+  ; Normally, because we mark the installer binary as requiring administrator permissions, the
+  ; installer will be running with administrator permissions at this point. The exception is when
+  ; the system is running with the *lowest* (least safe) UAC setting in which case the installer
+  ; can progress to this point without administrator permissions.
+  ;
+  ; If that's the case, exit now so we don't waste time to trying to install the TAP device, etc.
+  ; Additionally, the client can detect their absence and prompt the user to reinstall.
+  ;
+  ; The returned value does *not* seem to be based on the user's current diaplay language.
+  UserInfo::GetAccountType
+  Pop $0
+  StrCmp $0 "Admin" isadmin
+  MessageBox MB_OK "Sorry, Outline requires administrator permissions."
+  Quit
+
+  isadmin:
+
   ; TAP device files.
   File /r "${PROJECT_DIR}\tap-windows6"
   File "${PROJECT_DIR}\electron\add_tap_device.bat"


### PR DESCRIPTION
Turns out when UAC is set really low - as it was in the VM I tested with - it basically doesn't work at all: either it launches as the current user without prompting or it prompts but won't recognise a admin account username/password. Weird. I see many reports on the internet about this, at least for Windows 7.

This adds a check and makes the installer quit.