### PR TITLE
use netsh dump to search for TAP device

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "outline-client",
   "productName": "Outline",
-  "version": "1.2.15",
+  "version": "1.2.16",
   "scripts": {
     "clean": "rm -rf build www node_modules platforms/* plugins/*",
     "precommit": "tslint -p . --fix; git-clang-format",


### PR DESCRIPTION
Dammit, the `netsh` command I was using doesn't handle inactive devices - which is the case immediately before the VPN is brought up.

Followup to:
https://github.com/Jigsaw-Code/outline-client/pull/309