### PR TITLE
fix tun2socks compilation on linux

### DIFF
--- a/third_party/badvpn/tun2socks/tun2socks.c
+++ b/third_party/badvpn/tun2socks/tun2socks.c
@@ -585,7 +585,7 @@ int main (int argc, char **argv)
         case LOGGER_SYSLOG:
             if (!BLog_InitSyslog(options.logger_syslog_ident, options.logger_syslog_facility)) {
                 fprintf(stderr, "Failed to initialize syslog logger\n");
-                goto fail0;
+                return 1;
             }
             break;
         #endif


### PR DESCRIPTION
Just a small thing I noticed when trying to compile tun2socks for Linux: this label doesn't exist in this function. Guess I missed this while getting compilation to work on Windows:
https://github.com/Jigsaw-Code/outline-client/pull/96