### PR TITLE
simplify powershell expression, now blank lines are stripped out

### DIFF
--- a/src/electron/add_tap_device.bat
+++ b/src/electron/add_tap_device.bat
@@ -39,7 +39,7 @@ set BEFORE_DEVICES=%tmp%\outlineinstaller-tap-devices-before.txt
 set AFTER_DEVICES=%tmp%\outlineinstaller-tap-devices-after.txt
 
 echo Storing current network device list...
-wmic nic where "netconnectionid like '%%'" get netconnectionid /format:list > %BEFORE_DEVICES%
+wmic nic where "netconnectionid is not null" get netconnectionid > %BEFORE_DEVICES%
 type %BEFORE_DEVICES%
 
 echo Creating TAP network device...
@@ -49,14 +49,13 @@ if %errorlevel% neq 0 (
   exit /b 1
 )
 echo Storing new network device list...
-wmic nic where "netconnectionid like '%%'" get netconnectionid /format:list > %AFTER_DEVICES%
+wmic nic where "netconnectionid is not null" get netconnectionid > %AFTER_DEVICES%
 type %AFTER_DEVICES%
 
 :: Find the name of the new device and rename it.
 ::
 :: Obviously, this command is a beast; roughly what it does, in this order, is:
 ::  - perform a diff on the before and after text files
-::  - split the left column, InputObject, on the equals (=) sign
 ::  - remove leading/trailing space and blank lines with trim()
 ::  - store the result in NEW_DEVICE
 ::  - print NEW_DEVICE, for debugging (though non-Latin characters may appear as ?)
@@ -68,7 +67,7 @@ type %AFTER_DEVICES%
 :: Note that we pipe input from /dev/null to prevent Powershell hanging forever
 :: waiting on EOF.
 echo Searching for new TAP network device name...
-powershell "(compare-object (cat %BEFORE_DEVICES%) (cat %AFTER_DEVICES%) | format-wide -autosize InputObject | out-string).split(\"=\")[1].trim() | set-variable NEW_DEVICE; write-host \"New TAP device name: ${NEW_DEVICE}\"; netsh interface set interface name = \"${NEW_DEVICE}\" newname = \"%DEVICE_NAME%\"" <nul
+powershell "(compare-object (cat %BEFORE_DEVICES%) (cat %AFTER_DEVICES%) | format-wide -autosize | out-string).trim() | set-variable NEW_DEVICE; write-host \"New TAP device name: ${NEW_DEVICE}\"; netsh interface set interface name = \"${NEW_DEVICE}\" newname = \"%DEVICE_NAME%\"" <nul
 if %errorlevel% neq 0 (
   echo Could not rename find or rename new TAP network device. >&2
   exit /b 1


### PR DESCRIPTION
A little followup to https://github.com/Jigsaw-Code/outline-client/pull/327, made possible by the input coming into Powershell already stripped of empty lines. Also replace `like '%%'` with `is not null`, for clarity (IMO).

@clementhk FYI (and thanks again)