### PR TITLE
fix #347

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -148,7 +148,9 @@ function writeEnvJson(platform, config, isRelease) {
     throw new Error(`Failed to set up environment, no such path: ${config.targetDir}`);
   }
   const envFile = `${config.targetDir}/environment.json`;
-  runCommand(`scripts/environment_json.sh -p ${platform} ${isRelease ? '-r' : ''} > ${envFile}`, {}, function () {
+  const bashPathForWindows = process.platform.includes('win') ? 'sh ' : '';
+  const envScript = `${bashPathForWindows}scripts/environment_json.sh`;
+  runCommand(`${envScript} -p ${platform} ${isRelease ? '-r' : ''} > ${envFile}`, {}, function () {
     gutil.log(`Wrote ${envFile}`);
   });
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -148,8 +148,10 @@ function writeEnvJson(platform, config, isRelease) {
     throw new Error(`Failed to set up environment, no such path: ${config.targetDir}`);
   }
   const envFile = `${config.targetDir}/environment.json`;
-  const bashPathForWindows = process.platform.includes('win') ? 'sh ' : '';
-  const envScript = `${bashPathForWindows}scripts/environment_json.sh`;
+  let envScript  = 'scripts/environment_json.sh';
+  if (process.platform.includes('win')) {
+    envScript = `sh ${envScript}`;
+  }
   runCommand(`${envScript} -p ${platform} ${isRelease ? '-r' : ''} > ${envFile}`, {}, function () {
     gutil.log(`Wrote ${envFile}`);
   });


### PR DESCRIPTION
add check if system is running Windows, if so - add path for sh in scripts

see #347 for details

**TL;DR:**
This line 
https://github.com/Jigsaw-Code/outline-client/blob/cec7f69990bf4f0bd5e4b457c56dafe1df5d5ea4/gulpfile.js#L151

Didn't work for Windows, because Windows drops error:
```
'scripts' is not recognized as an internal or external command,
operable program or batch file.
```

 which causes `platforms/browser/www/environment.json` to be empty


Solution:
for Windows change command to `sh scripts/environment_json.sh`
via https://stackoverflow.com/questions/26522789/how-to-run-sh-on-windows-command-prompt


