### PR TITLE
fix #136 (add word-break for long server names)

### DIFF
--- a/src/www/ui_components/server-card.html
+++ b/src/www/ui_components/server-card.html
@@ -69,6 +69,7 @@
 
       #serverName {
         line-height: 32px;
+        word-break: break-word;
       }
 
       #serverHost {


### PR DESCRIPTION
see #136 for more info

before:
![image](https://user-images.githubusercontent.com/12018713/47474522-076df580-d820-11e8-950b-9251c195e6af.png)
![image](https://user-images.githubusercontent.com/12018713/47474534-12c12100-d820-11e8-967f-2fa1db5de275.png)


after:
![image](https://user-images.githubusercontent.com/12018713/47474513-fb823380-d81f-11e8-862c-0183513696f6.png)
