### PR TITLE
Ignore intercepted Play Store referrer intent by checking URL protocol

### DIFF
--- a/src/www/app/app.ts
+++ b/src/www/app/app.ts
@@ -516,7 +516,7 @@ export class App {
 
   private registerUrlInterceptionListener(urlInterceptor: UrlInterceptor) {
     urlInterceptor.registerListener((url) => {
-      if (!url) {
+      if (!url || !url.startsWith('ss://')) {
         // This check is necessary to handle empty and malformed install-referrer URLs in Android.
         // TODO: Stop receiving install referrer intents so we can remove this.
         return console.debug(`Ignoring intercepted non-shadowsocks url`);

--- a/src/www/app/app.ts
+++ b/src/www/app/app.ts
@@ -517,7 +517,7 @@ export class App {
   private registerUrlInterceptionListener(urlInterceptor: UrlInterceptor) {
     urlInterceptor.registerListener((url) => {
       if (!url || !unwrapInvite(url).startsWith('ss://')) {
-        // This check is necessary to handle empty and malformed install-referrer URLs in Android
+        // This check is necessary to ignore empty and malformed install-referrer URLs in Android
         // while allowing ss:// and invite URLs.
         // TODO: Stop receiving install referrer intents so we can remove this.
         return console.debug(`Ignoring intercepted non-shadowsocks url`);

--- a/src/www/app/app.ts
+++ b/src/www/app/app.ts
@@ -516,8 +516,9 @@ export class App {
 
   private registerUrlInterceptionListener(urlInterceptor: UrlInterceptor) {
     urlInterceptor.registerListener((url) => {
-      if (!url || !url.startsWith('ss://')) {
-        // This check is necessary to handle empty and malformed install-referrer URLs in Android.
+      if (!url || !unwrapInvite(url).startsWith('ss://')) {
+        // This check is necessary to handle empty and malformed install-referrer URLs in Android
+        // while allowing ss:// and invite URLs.
         // TODO: Stop receiving install referrer intents so we can remove this.
         return console.debug(`Ignoring intercepted non-shadowsocks url`);
       }


### PR DESCRIPTION
* The webintent Cordova plugin intercepts referrer intents, broadcast when the app is installed from the Play Store.
* Not ignoring them causes the referrer extra to get interpreted as an `ss` URL and to display an 'invalid access key' error message. 
* Check that intercepted URLs start with `ss://` or are invite links.

FYI @sandrigo.