### PR TITLE
Improve logic to handle new available networks

### DIFF
--- a/cordova-plugin-outline/android/java/org/outline/vpn/VpnTunnel.java
+++ b/cordova-plugin-outline/android/java/org/outline/vpn/VpnTunnel.java
@@ -14,6 +14,9 @@
 
 package org.outline.vpn;
 
+import android.net.ConnectivityManager;
+import android.net.Network;
+import android.os.Build;
 import android.os.ParcelFileDescriptor;
 import android.net.VpnService;
 import java.io.IOException;
@@ -82,6 +85,11 @@ public class VpnTunnel {
               .addDnsServer(dnsResolverAddress)
               .addDisallowedApplication(vpnService.getPackageName());
 
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        final Network activeNetwork =
+            vpnService.getSystemService(ConnectivityManager.class).getActiveNetwork();
+        builder.setUnderlyingNetworks(new Network[] {activeNetwork});
+      }
       // In absence of an API to remove routes, instead of adding the default route (0.0.0.0/0),
       // retrieve the list of subnets that excludes those reserved for special use.
       final ArrayList<Subnet> reservedBypassSubnets = getReservedBypassSubnets();

--- a/cordova-plugin-outline/android/java/org/outline/vpn/VpnTunnelService.java
+++ b/cordova-plugin-outline/android/java/org/outline/vpn/VpnTunnelService.java
@@ -353,10 +353,7 @@ public class VpnTunnelService extends VpnService {
       NetworkInfo activeNetworkInfo = connectivityManager.getActiveNetworkInfo();
       LOG.fine(String.format(Locale.ROOT, "Network available: %s\nActive network: %s", networkInfo,
           activeNetworkInfo));
-      if (networkInfo == null || !networkEquals(networkInfo, activeNetworkInfo)) {
-        return;
-      } else if (activeNetworkInfo != null
-          && activeNetworkInfo.getState() != NetworkInfo.State.CONNECTED) {
+      if (networkInfo == null || networkInfo.getState() != NetworkInfo.State.CONNECTED) {
         return;
       }
       broadcastVpnConnectivityChange(OutlinePlugin.ConnectionStatus.CONNECTED);
@@ -383,19 +380,6 @@ public class VpnTunnelService extends VpnService {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
         setUnderlyingNetworks(null);
       }
-    }
-
-    // Returns whether the underlying networks of NetworkInfo objects are equal.
-    // NetworkInfo.equals performs identity comparison, which is not useful in this context.
-    private boolean networkEquals(final NetworkInfo a, final NetworkInfo b) {
-      if (a == null || b == null) {
-        return false;
-      }
-      final String aExtraInfo = a.getExtraInfo();
-      final String bExtraInfo = b.getExtraInfo();
-      boolean extraInfoIsEqual = aExtraInfo == null ? bExtraInfo == null
-                                                    : aExtraInfo.equals(bExtraInfo);
-      return extraInfoIsEqual && a.getType() == b.getType() && a.getState() == b.getState();
     }
   }
 

--- a/cordova-plugin-outline/android/java/org/outline/vpn/VpnTunnelService.java
+++ b/cordova-plugin-outline/android/java/org/outline/vpn/VpnTunnelService.java
@@ -350,9 +350,7 @@ public class VpnTunnelService extends VpnService {
     @Override
     public void onAvailable(Network network) {
       NetworkInfo networkInfo = connectivityManager.getNetworkInfo(network);
-      NetworkInfo activeNetworkInfo = connectivityManager.getActiveNetworkInfo();
-      LOG.fine(String.format(Locale.ROOT, "Network available: %s\nActive network: %s", networkInfo,
-          activeNetworkInfo));
+      LOG.fine(String.format(Locale.ROOT, "Network available: %s", networkInfo));
       if (networkInfo == null || networkInfo.getState() != NetworkInfo.State.CONNECTED) {
         return;
       }

--- a/cordova-plugin-outline/android/java/org/outline/vpn/VpnTunnelService.java
+++ b/cordova-plugin-outline/android/java/org/outline/vpn/VpnTunnelService.java
@@ -359,6 +359,11 @@ public class VpnTunnelService extends VpnService {
 
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
         // Indicate that traffic will be sent over the current active network.
+        // Although setting the underlying network to an available network may not seem like the
+        // correct behavior, this method has been observed only to fire only when a preferred
+        // network becomes available. It will not fire, for example, when the mobile network becomes
+        // available if WiFi is the active network. Additionally, `getActiveNetwork` and
+        // `getActiveNetworkInfo` have been observed to return the underlying network set by us.
         setUnderlyingNetworks(new Network[] {network});
       }
     }


### PR DESCRIPTION
* When a VPN is established, `connectivityManager.getActiveNetworkInfo()`, returns the underlying network set by the VPN. 
* Use the network passed to `onAvailable` to set the underlying network instead of the active network, and do not perform a comparison between them.
* This change properly sets the VPN's underlying network for Android API 23+, meaning that apps that require WiFi connectivity now work correctly with the VPN.
* Tested that network changes are still handled on Android API <23.