### PR TITLE
Android: remove bypass subnet to allow connections in Lollipop

### DIFF
--- a/cordova-plugin-outline/android/resources/bypass_subnets.xml
+++ b/cordova-plugin-outline/android/resources/bypass_subnets.xml
@@ -149,6 +149,5 @@
     <item>203.128.0.0/9</item>
     <item>204.0.0.0/6</item>
     <item>208.0.0.0/4</item>
-    <item>224.0.0.0/4</item>
   </string-array>
 </resources>


### PR DESCRIPTION
* Android Lollipop (API 21-22) fails to establish a connection when adding the `224.0.0.0/4` route. 
* There should be no side-effects of removing this subnet, since these are [host group addresses](https://tools.ietf.org/html/rfc1112#section-4) used for multicasting.