### PR TITLE
fix for varying column widths in wmic output

### DIFF
--- a/src/electron/add_tap_device.bat
+++ b/src/electron/add_tap_device.bat
@@ -55,7 +55,8 @@ type %AFTER_DEVICES%
 :: Find the name of the new device and rename it.
 ::
 :: Obviously, this command is a beast; roughly what it does, in this order, is:
-::  - perform a diff on the before and after text files
+::  - perform a diff on the *trimmed* (in case wmic uses different column widths) before and after
+::    text files
 ::  - remove leading/trailing space and blank lines with trim()
 ::  - store the result in NEW_DEVICE
 ::  - print NEW_DEVICE, for debugging (though non-Latin characters may appear as ?)
@@ -67,7 +68,7 @@ type %AFTER_DEVICES%
 :: Note that we pipe input from /dev/null to prevent Powershell hanging forever
 :: waiting on EOF.
 echo Searching for new TAP network device name...
-powershell "(compare-object (cat %BEFORE_DEVICES%) (cat %AFTER_DEVICES%) | format-wide -autosize | out-string).trim() | set-variable NEW_DEVICE; write-host \"New TAP device name: ${NEW_DEVICE}\"; netsh interface set interface name = \"${NEW_DEVICE}\" newname = \"%DEVICE_NAME%\"" <nul
+powershell "(compare-object (cat %BEFORE_DEVICES%).trim() (cat %AFTER_DEVICES%).trim() | format-wide -autosize | out-string).trim() | set-variable NEW_DEVICE; write-host \"New TAP device name: ${NEW_DEVICE}\"; netsh interface set interface name = \"${NEW_DEVICE}\" newname = \"%DEVICE_NAME%\"" <nul
 if %errorlevel% neq 0 (
   echo Could not find or rename new TAP network device. >&2
   exit /b 1

--- a/src/electron/add_tap_device.bat
+++ b/src/electron/add_tap_device.bat
@@ -69,7 +69,7 @@ type %AFTER_DEVICES%
 echo Searching for new TAP network device name...
 powershell "(compare-object (cat %BEFORE_DEVICES%) (cat %AFTER_DEVICES%) | format-wide -autosize | out-string).trim() | set-variable NEW_DEVICE; write-host \"New TAP device name: ${NEW_DEVICE}\"; netsh interface set interface name = \"${NEW_DEVICE}\" newname = \"%DEVICE_NAME%\"" <nul
 if %errorlevel% neq 0 (
-  echo Could not rename find or rename new TAP network device. >&2
+  echo Could not find or rename new TAP network device. >&2
   exit /b 1
 )
 


### PR DESCRIPTION
I see quite a few failures due to `wmic` varying the width output in the before and after cases; this runs trim() on the wmic files, fixing the issue. Also, fix a typo.