### PR TITLE
remove parameter to add_tap_device.bat, only install files for the system's architecture

### DIFF
--- a/src/electron/add_tap_device.bat
+++ b/src/electron/add_tap_device.bat
@@ -12,8 +12,6 @@
 :: See the License for the specific language governing permissions and
 :: limitations under the License.
 
-:: Accepts one argument, the system's architecture (amd64 or i386).
-
 @echo off
 
 set DEVICE_NAME=outline-tap0

--- a/src/electron/add_tap_device.bat
+++ b/src/electron/add_tap_device.bat
@@ -43,7 +43,7 @@ wmic nic where "netconnectionid is not null" get netconnectionid > %BEFORE_DEVIC
 type %BEFORE_DEVICES%
 
 echo Creating TAP network device...
-tap-windows6\%1\tapinstall install tap-windows6\%1\OemVista.inf tap0901
+tap-windows6\tapinstall install tap-windows6\OemVista.inf tap0901
 if %errorlevel% neq 0 (
   echo Could not create TAP network device. >&2
   exit /b 1

--- a/src/electron/custom_install_steps.nsh
+++ b/src/electron/custom_install_steps.nsh
@@ -51,12 +51,13 @@ ${StrRep}
 
   ; TAP device files.
   File "${PROJECT_DIR}\electron\add_tap_device.bat"
-  SetOutPath "tap-windows6"
+  SetOutPath "$INSTDIR\tap-windows6"
   ${If} ${RunningX64}
     File /r "${PROJECT_DIR}\tap-windows6\amd64\*"
   ${Else}
     File /r "${PROJECT_DIR}\tap-windows6\i386\*"
   ${EndIf}
+  SetOutPath -
 
   ReadEnvStr $0 COMSPEC
   ; ExecToStack captures both stdout and stderr from the script, in the order output.

--- a/src/electron/custom_install_steps.nsh
+++ b/src/electron/custom_install_steps.nsh
@@ -43,14 +43,7 @@ ${StrRep}
 
   isadmin:
 
-  ; OutlineService files, stopping the service first in case it's still running.
-  nsExec::Exec "net stop OutlineService"
-  File "${PROJECT_DIR}\OutlineService.exe"
-  File "${PROJECT_DIR}\Newtonsoft.Json.dll"
-  File "${PROJECT_DIR}\electron\install_windows_service.bat"
-
   ; TAP device files.
-  File "${PROJECT_DIR}\electron\add_tap_device.bat"
   SetOutPath "$INSTDIR\tap-windows6"
   ${If} ${RunningX64}
     File /r "${PROJECT_DIR}\tap-windows6\amd64\*"
@@ -58,9 +51,16 @@ ${StrRep}
     File /r "${PROJECT_DIR}\tap-windows6\i386\*"
   ${EndIf}
   SetOutPath -
+  File "${PROJECT_DIR}\electron\add_tap_device.bat"
 
-  ReadEnvStr $0 COMSPEC
+  ; OutlineService files, stopping the service first in case it's still running.
+  nsExec::Exec "net stop OutlineService"
+  File "${PROJECT_DIR}\OutlineService.exe"
+  File "${PROJECT_DIR}\Newtonsoft.Json.dll"
+  File "${PROJECT_DIR}\electron\install_windows_service.bat"
+
   ; ExecToStack captures both stdout and stderr from the script, in the order output.
+  ReadEnvStr $0 COMSPEC
   nsExec::ExecToStack '$0 /c add_tap_device.bat'
 
   Pop $0

--- a/src/electron/custom_install_steps.nsh
+++ b/src/electron/custom_install_steps.nsh
@@ -43,23 +43,24 @@ ${StrRep}
 
   isadmin:
 
-  ; TAP device files.
-  File /r "${PROJECT_DIR}\tap-windows6"
-  File "${PROJECT_DIR}\electron\add_tap_device.bat"
-
   ; OutlineService files, stopping the service first in case it's still running.
   nsExec::Exec "net stop OutlineService"
   File "${PROJECT_DIR}\OutlineService.exe"
   File "${PROJECT_DIR}\Newtonsoft.Json.dll"
   File "${PROJECT_DIR}\electron\install_windows_service.bat"
 
-  ; ExecToStack captures both stdout and stderr from the script, in the order output.
-  ReadEnvStr $0 COMSPEC
+  ; TAP device files.
+  File "${PROJECT_DIR}\electron\add_tap_device.bat"
+  SetOutPath "tap-windows6"
   ${If} ${RunningX64}
-    nsExec::ExecToStack '$0 /c add_tap_device.bat amd64'
+    File /r "${PROJECT_DIR}\tap-windows6\amd64\*"
   ${Else}
-    nsExec::ExecToStack '$0 /c add_tap_device.bat i386'
+    File /r "${PROJECT_DIR}\tap-windows6\i386\*"
   ${EndIf}
+
+  ReadEnvStr $0 COMSPEC
+  ; ExecToStack captures both stdout and stderr from the script, in the order output.
+  nsExec::ExecToStack '$0 /c add_tap_device.bat'
 
   Pop $0
   Pop $1


### PR DESCRIPTION
Motivated by:
https://github.com/Jigsaw-Code/outline-client/pull/341

Two benefits of this change:
- Outlinen will occupy (slightly) less space on disk when installed
- `tapinstall.exe` will appear in the same location on disk for 32 and 64 bit users, potentially making rescue and manual intervention instructions easier