### PR TITLE
Apple: re-enable LAN bypass, increase versions

### DIFF
--- a/apple/xcode/ios/Outline/Outline-Info.plist
+++ b/apple/xcode/ios/Outline/Outline-Info.plist
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.2</string>
+	<string>1.2.3</string>
 	<key>CFBundleVersion</key>
-	<string>12</string>
+	<string>13</string>
   <key>CFBundleDevelopmentRegion</key>
   <string>English</string>
 	<key>CFBundleDisplayName</key>

--- a/apple/xcode/ios/Outline/VpnExtension-Info.plist
+++ b/apple/xcode/ios/Outline/VpnExtension-Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.2</string>
+	<string>1.2.3</string>
 	<key>CFBundleVersion</key>
-	<string>12</string>
+	<string>13</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/apple/xcode/osx/Outline/Outline-Info.plist
+++ b/apple/xcode/osx/Outline/Outline-Info.plist
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.2</string>
+	<string>1.2.3</string>
 	<key>CFBundleVersion</key>
-	<string>13</string>
+	<string>14</string>
   <key>CFBundleDevelopmentRegion</key>
   <string>en</string>
   <key>CFBundleExecutable</key>

--- a/apple/xcode/osx/Outline/VpnExtension-Info.plist
+++ b/apple/xcode/osx/Outline/VpnExtension-Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.2</string>
+	<string>1.2.3</string>
 	<key>CFBundleVersion</key>
-	<string>13</string>
+	<string>14</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
 	<key>NSExtension</key>

--- a/cordova-plugin-outline/apple/vpn/PacketTunnelProvider.m
+++ b/cordova-plugin-outline/apple/vpn/PacketTunnelProvider.m
@@ -272,6 +272,7 @@ NSString *const kMessageKeyOnDemand = @"is-on-demand";
   NEIPv4Settings *ipv4Settings = [[NEIPv4Settings alloc] initWithAddresses:@[@"192.168.20.2"]
                                                                subnetMasks:@[@"255.255.255.0"]];
   ipv4Settings.includedRoutes = @[[NEIPv4Route defaultRoute]];
+  ipv4Settings.excludedRoutes = [self getExcludedIpv4Routes];
 
   // Although we don't support proxying IPv6 traffic, we need to set IPv6 routes so that the DNS
   // settings are respected on IPv6-only networks. Bind to a random unique local address (ULA).

--- a/cordova-plugin-outline/apple/vpn/Subnet.swift
+++ b/cordova-plugin-outline/apple/vpn/Subnet.swift
@@ -18,7 +18,6 @@ import Foundation
 @objcMembers
 class Subnet: NSObject {
   static let kReservedSubnets = [
-    "0.0.0.0/8",
     "10.0.0.0/8",
     "100.64.0.0/10",
     "169.254.0.0/16",


### PR DESCRIPTION
* Re-enables LAN bypass without excluding '0.0.0.0/8' route.
  * A beta build of the iOS client has been in TestFlight for a week, without any reported problems.
  * Tested both clients locally.
* Increases the build numbers for App Store submission.