### PR TITLE
Apple: replace native hardcoded strings with NSLocalizedString

### DIFF
--- a/cordova-plugin-outline/apple/vpn/PacketTunnelProvider.m
+++ b/cordova-plugin-outline/apple/vpn/PacketTunnelProvider.m
@@ -78,9 +78,9 @@ NSString *const kMessageKeyOnDemand = @"is-on-demand";
   if (options == nil) {
     DDLogWarn(@"Received a connect request from preferences");
     NSString *msg = NSLocalizedStringWithDefaultValue(
-        @"vpn-disconnect", @"Outline", [NSBundle mainBundle],
+        @"vpn-connect", @"Outline", [NSBundle mainBundle],
         @"Please use the Outline app to connect.",
-        @"String shown when the user attempts to disconnect from settings");
+        @"Message shown in a system dialog when the user attempts to connect from settings");
     [self displayMessage:msg
         completionHandler:^(BOOL success) {
           completionHandler([NSError errorWithDomain:NEVPNErrorDomain

--- a/cordova-plugin-outline/apple/vpn/PacketTunnelProvider.m
+++ b/cordova-plugin-outline/apple/vpn/PacketTunnelProvider.m
@@ -77,8 +77,11 @@ NSString *const kMessageKeyOnDemand = @"is-on-demand";
   DDLogInfo(@"Starting tunnel");
   if (options == nil) {
     DDLogWarn(@"Received a connect request from preferences");
-    // TODO(alalama): l10n
-    [self displayMessage:@"Please use the Outline app to connect."
+    NSString *msg = NSLocalizedStringWithDefaultValue(
+        @"vpn-disconnect", @"Outline", [NSBundle mainBundle],
+        @"Please use the Outline app to connect.",
+        @"String shown when the user attempts to disconnect from settings");
+    [self displayMessage:msg
         completionHandler:^(BOOL success) {
           completionHandler([NSError errorWithDomain:NEVPNErrorDomain
                                                 code:NEVPNErrorConfigurationDisabled


### PR DESCRIPTION
We don't have translations yet, but this is a first l10n step.