### PR TITLE
Fix race between URL interception and clipboard server import

### DIFF
--- a/src/www/app/app.ts
+++ b/src/www/app/app.ts
@@ -289,10 +289,12 @@ export class App {
   }
 
   private confirmAddServer(accessKey: string, fromClipboard = false) {
+    const addServerView = this.rootEl.$.addServerView;
     accessKey = unwrapInvite(accessKey);
     if (fromClipboard && accessKey in this.ignoredAccessKeys) {
-      console.debug('Ignoring access key');
-      return;
+      return console.debug('Ignoring access key');
+    } else if (fromClipboard && addServerView.isAddingServer()) {
+      return console.debug('Already adding a server');
     }
     // Expect SHADOWSOCKS_URI.parse to throw on invalid access key; propagate any exception.
     let shadowsocksConfig = null;
@@ -316,7 +318,6 @@ export class App {
       password: shadowsocksConfig.password.data,
       name,
     };
-    const addServerView = this.rootEl.$.addServerView;
     if (!this.serverRepo.containsServer(serverConfig)) {
       // Only prompt the user to add new servers.
       try {

--- a/src/www/ui_components/add-server-view.html
+++ b/src/www/ui_components/add-server-view.html
@@ -221,6 +221,9 @@
         this.$.addServerSheet.close();
         this.$.serverDetectedSheet.open();
       },
+      isAddingServer: function() {
+        return this.$.serverDetectedSheet.opened;
+      },
       close: function() {
         this.$.addServerSheet.close();
         this.$.serverDetectedSheet.close();


### PR DESCRIPTION
* When the app is invoked via URL interception (`ss://` protocol handler) the passed server information is parsed. But as soon as the received information is shown, the clipboard is parsed as well and if it contains Outline server information, the clipboard data will overwrite the latest server information.
* This PR fixes this race and does not allow for clipboard data to override the server import from URL interception.
