### PR TITLE
more explicit trim, for older versions of windows

### DIFF
--- a/src/electron/add_tap_device.bat
+++ b/src/electron/add_tap_device.bat
@@ -75,7 +75,7 @@ type "%AFTER_DEVICES%"
 :: Note that we pipe input from /dev/null to prevent Powershell hanging forever
 :: waiting on EOF.
 echo Searching for new TAP network device name...
-powershell "(compare-object (cat \"%BEFORE_DEVICES%\").trim() (cat \"%AFTER_DEVICES%\").trim() | format-wide -autosize | out-string).trim() | set-variable NEW_DEVICE; write-host \"New TAP device name: ${NEW_DEVICE}\"; netsh interface set interface name = \"${NEW_DEVICE}\" newname = \"%DEVICE_NAME%\"" <nul
+powershell "(compare-object (cat \"%BEFORE_DEVICES%\" | foreach-object {$_.trim()}) (cat \"%AFTER_DEVICES%\" | foreach-object {$_.trim()}) | format-wide -autosize | out-string).trim() | set-variable NEW_DEVICE; write-host \"New TAP device name: ${NEW_DEVICE}\"; netsh interface set interface name = \"${NEW_DEVICE}\" newname = \"%DEVICE_NAME%\"" <nul
 if %errorlevel% neq 0 (
   echo Could not find or rename new TAP network device. >&2
   exit /b 1


### PR DESCRIPTION
A new issue in 1.2.18, installation is failing on Windows 7 in certain cases because `.trim()` can't be found. It didn't make much sense to me at first but my guess is that because `get-content`/`cat` returns an array, `.trim()` "magically" works on Win 8/10 due to some automatic type conversion - but not always on Windows 7. This PR trims each line one by one.

Followup to:
https://github.com/Jigsaw-Code/outline-client/pull/360