### PR TITLE
Update Android Cordova to v7.1.4

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -138,8 +138,7 @@
         <release-native dsn="https://6a1e6e7371a64db59f5ba6c34a77d78c:568f6c78f9f94f91afba4aba05756001@sentry.io/159502" />
     </sentry>
 
-    <!-- TODO: v7.1.2 introduced a bug that prevents cordova-plugin-outline from being installed. Pin to v7.1.1 until v7.1.3 is released.  -->
-    <engine name="android" spec="7.1.1" />
+    <engine name="android" spec="~7.1.4" />
     <engine name="browser" spec="^4.1.0" />
     <!-- Depend on these commits until the next release. -->
     <engine name="ios" spec="https://github.com/apache/cordova-ios#7397337c" />

--- a/config.xml
+++ b/config.xml
@@ -138,7 +138,8 @@
         <release-native dsn="https://6a1e6e7371a64db59f5ba6c34a77d78c:568f6c78f9f94f91afba4aba05756001@sentry.io/159502" />
     </sentry>
 
-    <engine name="android" spec="^7.1.0" />
+    <!-- TODO: v7.1.2 introduced a bug that prevents cordova-plugin-outline from being installed. Pin to v7.1.1 until v7.1.3 is released.  -->
+    <engine name="android" spec="7.1.1" />
     <engine name="browser" spec="^4.1.0" />
     <!-- Depend on these commits until the next release. -->
     <engine name="ios" spec="https://github.com/apache/cordova-ios#7397337c" />


### PR DESCRIPTION
* Cordova Android v7.1.2 introduced a bug that prevents cordova-plugin-outline from being installed.
  * This issue has been fixed in v7.1.3.
  * See [cordova-android/#542](https://github.com/apache/cordova-android/pull/542) for more details.
* Update to v7.1.4 - latest npm version.