### PR TITLE
fix netsh wait

### DIFF
--- a/src/electron/add_tap_device.bat
+++ b/src/electron/add_tap_device.bat
@@ -85,14 +85,14 @@ if %errorlevel% neq 0 (
 :: purposes of configuring IP and DNS ("netsh interface show interface name=xxx" does not
 :: seem to be affected).
 echo Testing that the new TAP network device is visible to netsh...
-netsh interface show interface name=%DEVICE_NAME% >nul
+netsh interface ip show interfaces | find "%DEVICE_NAME%" >nul
 if %errorlevel% equ 0 goto :configure
 
 :loop
 echo waiting...
-timeout /t 1 >nul
-netsh interface show interface name=%DEVICE_NAME% >nul
-if %errorlevel% neq 1 goto :loop
+timeout /t 10 >nul
+netsh interface ip show interfaces | find "%DEVICE_NAME%" >nul
+if %errorlevel% neq 0 goto :loop
 
 :configure
 echo Configuring new TAP network device...


### PR DESCRIPTION
(finally, i hope)
* change `netsh interface show interface name=xxx` to `netsh interface ip show interfaces | find "%DEVICE_NAME%"` because ` netsh interface show interface name=xxx` doesn't have delay
* increase timeout
* fix check for error level