### PR TITLE
workaround broken build in node 10.10.14.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "__COMMENTS__": [
     "Do not upgrade to Cordova 7 without fixing the resulting breakages",
-    "natives@1.1.3 for Gulp on Node 10+: https://github.com/gulpjs/gulp/issues/2162#issuecomment-385197164"
+    "natives@1.1.6 for Gulp 3.x on Node 10.x: https://github.com/gulpjs/gulp/issues/2162#issuecomment-385197164"
   ],
   "dependencies": {
     "@sentry/electron": "^0.8.1",
@@ -64,6 +64,6 @@
     "xml2js": "^0.4.17"
   },
   "resolutions": {
-    "natives": "1.1.3"
+    "natives": "1.1.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5174,9 +5174,10 @@ nan@^2.3.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
 
-natives@1.1.3, natives@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.3.tgz#44a579be64507ea2d6ed1ca04a9415915cf75558"
+natives@1.1.6, natives@^1.1.0:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.6.tgz#a603b4a498ab77173612b9ea1acdec4d980f00bb"
+  integrity sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==
 
 negotiator@0.6.1:
   version "0.6.1"


### PR DESCRIPTION
We finally ran into this:
https://github.com/Jigsaw-Code/outline-client/issues/377

The real fix, I think, is to move to Gulp 4 but, judging from having quickly tried it here, that will require some changes to our Gulpfile.

Fixes broken Travis:
https://travis-ci.org/Jigsaw-Code/outline-client/jobs/466707582