### PR TITLE
If tsc fails during the build, display its error

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -130,19 +130,6 @@ function runCommand(command, options, done) {
   child.stderr.pipe(process.stderr);
 }
 
-function execSyncVerbosely(cmd) {
-  try {
-    return child_process.execSync(cmd).toString();
-  } catch (error) {
-    // tsc errors appear on stdout, not stderr (which is already shown)
-    console.log(`--- STDOUT ---`);
-    console.log(error.stdout.toString());
-    // Throwing the error is not really helpful (long error from gulp, distracting from the tsc error)
-    //throw error;
-    process.exit(1);
-  }
-}
-
 // Copies Babel polyfill from node_modules, as it needs to be included by cordova_index.html.
 function copyBabelPolyfill(config) {
   const babelPolyfill = 'node_modules/babel-polyfill/dist/polyfill.min.js';
@@ -225,7 +212,7 @@ function build(platform, config) {
   }
 
   // Build the web app.
-  execSyncVerbosely('yarn do src/www/build');
+  child_process.execSync('yarn do src/www/build', {stdio: 'inherit'});
 
   return merge_stream(
     bundleJs(browserifyInstance).pipe(gulp.dest(SRC_DIR))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -130,6 +130,17 @@ function runCommand(command, options, done) {
   child.stderr.pipe(process.stderr);
 }
 
+function execSyncVerbosely(cmd) {
+  try {
+    return child_process.execSync(cmd).toString();
+  } catch (error) {
+    // tsc errors appear on stdout, not stderr (which is already shown)
+    console.log(`--- STDOUT ---`);
+    console.log(error.stdout.toString());
+    throw error;
+  }
+}
+
 // Copies Babel polyfill from node_modules, as it needs to be included by cordova_index.html.
 function copyBabelPolyfill(config) {
   const babelPolyfill = 'node_modules/babel-polyfill/dist/polyfill.min.js';
@@ -212,7 +223,7 @@ function build(platform, config) {
   }
 
   // Build the web app.
-  child_process.execSync('yarn do src/www/build');
+  execSyncVerbosely('yarn do src/www/build');
 
   return merge_stream(
     bundleJs(browserifyInstance).pipe(gulp.dest(SRC_DIR))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -137,7 +137,9 @@ function execSyncVerbosely(cmd) {
     // tsc errors appear on stdout, not stderr (which is already shown)
     console.log(`--- STDOUT ---`);
     console.log(error.stdout.toString());
-    throw error;
+    // Throwing the error is not really helpful (long error from gulp, distracting from the tsc error)
+    //throw error;
+    process.exit(1);
   }
 }
 


### PR DESCRIPTION
Currently if `tsc` fails while the app is building, the build stops but the reason is not shown. We then need to run `tsc` separately to find out what went wrong.

~To help developers, this change will display the error from `tsc` whenever it fails. If `tsc` succeeds, it will display nothing (as it does now).~

----

An alternative solution would be to always display all of `tsc`s output, [as seen here](https://stackoverflow.com/a/31104898/99777). ~Let me know if you would prefer that approach.~ It has the advantage of being a one-liner. ✅ ✅ ✅ 👍

~But one advantage of the approach here: We could make the output even clearer by adding `process.exit()` instead of throwing the error. That would display only the relevant `tsc` error, and not gulp's noisy error, which is somewhat distracting for the developer in this situation.~

----

You know what screw it, I'm just going to add `{stdio: 'inherit'}`. Simple is better, and it's reasonably clear in the output. :)

Unexpectedly, `tsc` shows compilation errors on _stdout_. The solution here is just to tell execSync to display stdout too (it was already displaying stderr before).