### PR TITLE
add beta to title bar on linux

### DIFF
--- a/src/www/electron_index.html
+++ b/src/www/electron_index.html
@@ -25,6 +25,9 @@
   <script src="bower_components/webcomponentsjs/webcomponents-loader.js"></script>
   <link rel="import" href="ui_components/app-root.html">
   <script>
+    if (require('os').platform() === 'linux') {
+      document.title = 'Outline Beta';
+    }
     require('./app/electron_main.js');
   </script>
 </head>


### PR DESCRIPTION
This is what we used to show in the Windows client's titlebar.

Alternative approaches:
- change the `productName` in `package.json`: this changes the storage directory used by Electron and this migration was very messy on Windows
- add another index HTML page, just for Linux client

This seemed easiest.