### PR TITLE
travis is not uploading auto-update files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -146,8 +146,7 @@ deploy:
   file:
     - platforms/android/app/build/outputs/apk/**/*.apk
     - platforms/ios/Outline.ipa
-    - build/dist/*.exe
-    - build/dist/*.AppImage
+    - build/dist/*.*
   skip_cleanup: true
   on:
     tags: true


### PR DESCRIPTION
This will pull in the auto-update files, too (currently missing from https://github.com/Jigsaw-Code/outline-client/releases/tag/linux-v1.0.2, damn).