### PR TITLE
bump version numbers for android 1.2.9

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="org.outline.android.client" version="1.2.8" android-versionCode="19" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="org.outline.android.client" version="1.2.9" android-versionCode="20" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Outline</name>
     <description>
         Internet without borders (powered by Shadowsocks)


### PR DESCRIPTION
Several little things have gone into master since 1.2.8 so I'd prefer roll a whole new release, from master.