### PR TITLE
no need to specify browserwindow icon

### DIFF
--- a/src/electron/index.ts
+++ b/src/electron/index.ts
@@ -48,7 +48,6 @@ let localizedStrings: {[key: string]: string} = {
 
 const debugMode = process.env.OUTLINE_DEBUG === 'true';
 
-const iconPath = path.join(path.dirname(__dirname), 'icons/win/icon.ico');
 const trayIconImages = {
   connected: createTrayIconImage('logo.png'),
   disconnected: createTrayIconImage('logo_grayscale.png')
@@ -60,7 +59,7 @@ const enum Options {
 
 function createWindow(connectionAtShutdown?: SerializableConnection) {
   // Create the browser window.
-  mainWindow = new BrowserWindow({width: 360, height: 640, resizable: false, icon: iconPath});
+  mainWindow = new BrowserWindow({width: 360, height: 640, resizable: false});
 
   const pathToIndexHtml = path.join(app.getAppPath(), 'www', 'electron_index.html');
   const webAppUrl = new url.URL(`file://${pathToIndexHtml}`);


### PR DESCRIPTION
Once https://github.com/Jigsaw-Code/outline-client/pull/494 is merged, the window icon is the last user of `__dirname` which I'd like to replace throughout with `app.getAppPath()` - but it turns out there's no need to specify a window icon at all because if unspecified the app's icon will be used:
https://electronjs.org/docs/api/browser-window