### PR TITLE
fix connection error reporting due to change in electron-promise-ipc

### DIFF
--- a/src/electron/index.ts
+++ b/src/electron/index.ts
@@ -341,7 +341,6 @@ function sendConnectionStatus(status: ConnectionStatus, connectionId: string) {
 promiseIpc.on(
     'start-proxying', (args: {config: cordova.plugins.outline.ServerConfig, id: string}) => {
       return startVpn(args.config, args.id).catch((e) => {
-        // electron-promise-ipc can only propagate primitives to the renderer process.
         console.error(`could not connect: ${e.name} (${e.message})`);
         throw errors.toErrorCode(e);
       });

--- a/src/www/app/outline_server.ts
+++ b/src/www/app/outline_server.ts
@@ -59,13 +59,12 @@ export class OutlineServer implements PersistentServer {
 
   connect(): Promise<void> {
     return this.connection.start().catch((e) => {
-      // Since "instanceof OutlinePluginError" may not work for errors originating from Sentry,
-      // inspect this field directly.
+      // e originates in "native" code: either Cordova or Electron's main process.
+      // Because of this, we cannot assume "instanceof OutlinePluginError" will work.
       if (e.errorCode) {
         throw errors.fromErrorCode(e.errorCode);
-      } else {
-        throw new Error(`native code did not set errorCode`);
       }
+      throw e;
     });
   }
 

--- a/src/www/app/windows_connection.ts
+++ b/src/www/app/windows_connection.ts
@@ -17,6 +17,7 @@ import * as promiseIpc from 'electron-promise-ipc';
 
 import * as errors from '../model/errors';
 
+// TODO: Rename this class - it's also used on Linux.
 export class WindowsOutlineConnection implements cordova.plugins.outline.Connection {
   private statusChangeListener: ((status: ConnectionStatus) => void)|null = null;
 
@@ -48,8 +49,12 @@ export class WindowsOutlineConnection implements cordova.plugins.outline.Connect
         .then(() => {
           this.running = true;
         })
-        .catch((e: Error) => {
-          throw new errors.OutlinePluginError(parseInt(e.message, 10));
+        .catch((e: errors.ErrorCode|Error) => {
+          if (typeof e === 'number') {
+            throw new errors.OutlinePluginError(e);
+          } else {
+            throw e;
+          }
         });
   }
 


### PR DESCRIPTION
Bah, https://github.com/Jigsaw-Code/outline-client/pull/497 broke connection error reporting: apparently `electron-promise-ipc` now serialises exceptions, so the conversion in `windows_connection.ts` was wrong.