### PR TITLE
fix system tray icon status on disconnection

### DIFF
--- a/src/electron/process_manager.ts
+++ b/src/electron/process_manager.ts
@@ -297,6 +297,7 @@ function startLocalShadowsocksProxy(
       } else {
         console.info(`ss-local exited with code ${code}`);
       }
+      onDisconnected();
     });
   });
 }


### PR DESCRIPTION
We removed this notifcation in https://github.com/Jigsaw-Code/outline-client/pull/481 - can you remember why? It's preventing the system tray from being updated on disconnection.