### PR TITLE
skip TUN device name lookup on linux as the device name is fixed anyway

### DIFF
--- a/src/electron/process_manager.ts
+++ b/src/electron/process_manager.ts
@@ -47,23 +47,23 @@ const routingService = new routing.RoutingService();
 //  - badvpn-tun2socks.exe connects the SOCKS5 proxy to a TAP-like network interface
 //  - OutlineService configures the system to route via a TAP-like network device, must be installed
 
-let ssLocal: ChildProcess | undefined;
-let tun2socks: ChildProcess | undefined;
+let ssLocal: ChildProcess|undefined;
+let tun2socks: ChildProcess|undefined;
 let activeConnection: SerializableConnection;
 
 const PROXY_IP = '127.0.0.1';
 const SS_LOCAL_PORT = 1081;
 
-const TUN2SOCKS_TAP_DEVICE_NAME = 'outline-tap0';
+const TUN2SOCKS_DEVICE_NAME = isWindows ? 'outline-tap0' : 'outline-tun0';
 // TODO: read these from the network device!
-const TUN2SOCKS_TAP_DEVICE_IP = '10.0.85.2';
+const TUN2SOCKS_DEVICE_IP = '10.0.85.2';
 const TUN2SOCKS_VIRTUAL_ROUTER_IP = '10.0.85.1';
-const TUN2SOCKS_TAP_DEVICE_NETWORK = '10.0.85.0';
+const TUN2SOCKS_DEVICE_NETWORK = '10.0.85.0';
 const TUN2SOCKS_VIRTUAL_ROUTER_NETMASK = '255.255.255.0';
 
 const CREDENTIALS_TEST_DOMAINS = ['example.com', 'ietf.org', 'wikipedia.org'];
 const SS_LOCAL_TIMEOUT_SECS =
-  2 ^ 31 - 1;  // 32-bit INT_MAX; using Number.MAX_SAFE_VALUE may overflow
+    2 ^ 31 - 1;  // 32-bit INT_MAX; using Number.MAX_SAFE_VALUE may overflow
 const REACHABILITY_TEST_TIMEOUT_MS = 10000;
 const DNS_LOOKUP_TIMEOUT_MS = 10000;
 const UDP_FORWARDING_TEST_TIMEOUT_MS = 5000;
@@ -129,16 +129,12 @@ export function startVpn(
             });
       })
       .then(() => {
-        return getTunDeviceName();
-      })
-      .then((tunDeviceName) => {
-        return startTun2socks(tunDeviceName, isUdpSupported, onDisconnected);
+        return startTun2socks(isUdpSupported, onDisconnected);
       })
       .then(delay(isLinux ? WAIT_FOR_PROCESS_TO_START_MS : 0))
       .then(() => {
         return routingService.configureRouting(
-            TUN2SOCKS_VIRTUAL_ROUTER_IP, config.host || '', connectionStatusChanged,
-            isAutoConnect);
+            TUN2SOCKS_VIRTUAL_ROUTER_IP, config.host || '', connectionStatusChanged, isAutoConnect);
       })
       .then(() => {
         activeConnection = {id: '', config, isUdpSupported};
@@ -167,22 +163,23 @@ function testTapDevice() {
   //
   // reset
   // set global icmpredirects=disabled
-  // set interface interface="Ethernet" forwarding=enabled advertise=enabled nud=enabled ignoredefaultroutes=disabled
-  // set interface interface="outline-tap0" forwarding=enabled advertise=enabled nud=enabled ignoredefaultroutes=disabled
-  // add address name="outline-tap0" address=10.0.85.2 mask=255.255.255.0
+  // set interface interface="Ethernet" forwarding=enabled advertise=enabled nud=enabled
+  // ignoredefaultroutes=disabled set interface interface="outline-tap0" forwarding=enabled
+  // advertise=enabled nud=enabled ignoredefaultroutes=disabled add address name="outline-tap0"
+  // address=10.0.85.2 mask=255.255.255.0
   //
   // popd
   // # End of IPv4 configuration
   const lines = execSync(`netsh interface ipv4 dump`).toString().split('\n');
 
   // Find lines containing the TAP device name.
-  const tapLines = lines.filter(s => s.indexOf(TUN2SOCKS_TAP_DEVICE_NAME) !== -1);
+  const tapLines = lines.filter(s => s.indexOf(TUN2SOCKS_DEVICE_NAME) !== -1);
   if (tapLines.length < 1) {
     throw new Error(`TAP device not found`);
   }
 
   // Within those lines, search for the expected IP.
-  if (tapLines.filter(s => s.indexOf(TUN2SOCKS_TAP_DEVICE_IP) !== -1).length < 1) {
+  if (tapLines.filter(s => s.indexOf(TUN2SOCKS_DEVICE_IP) !== -1).length < 1) {
     throw new Error(`TAP device has wrong IP`);
   }
 }
@@ -193,12 +190,12 @@ function testTapDevice() {
 function checkConnectivity(config: cordova.plugins.outline.ServerConfig): Promise<string> {
   return lookupIp(config.host || '').then((ip: string) => {
     return isServerReachableByIp(ip, config.port || 0)
-      .then(() => {
-        return validateServerCredentials();
-      })
-      .then(() => {
-        return ip;
-      });
+        .then(() => {
+          return validateServerCredentials();
+        })
+        .then(() => {
+          return ip;
+        });
   });
 }
 // Uses the OS' built-in functions, i.e. /etc/hosts, et al.:
@@ -207,15 +204,15 @@ function checkConnectivity(config: cordova.plugins.outline.ServerConfig): Promis
 // Effectively a no-op if hostname is already an IP.
 function lookupIp(hostname: string): Promise<string> {
   return util.timeoutPromise(
-    new Promise<string>((fulfill, reject) => {
-      dns.lookup(hostname, 4, (e, address) => {
-        if (e) {
-          return reject(new errors.ServerUnreachable('could not resolve proxy server hostname'));
-        }
-        fulfill(address);
-      });
-    }),
-    DNS_LOOKUP_TIMEOUT_MS, 'DNS lookup');
+      new Promise<string>((fulfill, reject) => {
+        dns.lookup(hostname, 4, (e, address) => {
+          if (e) {
+            return reject(new errors.ServerUnreachable('could not resolve proxy server hostname'));
+          }
+          fulfill(address);
+        });
+      }),
+      DNS_LOOKUP_TIMEOUT_MS, 'DNS lookup');
 }
 
 // Resolves with true iff a TCP connection can be established with the Shadowsocks server.
@@ -231,24 +228,24 @@ export function isServerReachable(config: cordova.plugins.outline.ServerConfig) 
 // As #isServerReachable but does not perform a DNS lookup.
 export function isServerReachableByIp(serverIp: string, serverPort: number) {
   return util.timeoutPromise(
-    new Promise<void>((fulfill, reject) => {
-      const socket = new net.Socket();
-      socket
-        .connect(
-          { host: serverIp, port: serverPort },
-          () => {
-            socket.end();
-            fulfill();
-          })
-        .on('error', () => {
-          reject(new errors.ServerUnreachable());
-        });
-    }),
-    REACHABILITY_TEST_TIMEOUT_MS, 'Reachability check');
+      new Promise<void>((fulfill, reject) => {
+        const socket = new net.Socket();
+        socket
+            .connect(
+                {host: serverIp, port: serverPort},
+                () => {
+                  socket.end();
+                  fulfill();
+                })
+            .on('error', () => {
+              reject(new errors.ServerUnreachable());
+            });
+      }),
+      REACHABILITY_TEST_TIMEOUT_MS, 'Reachability check');
 }
 
 function startLocalShadowsocksProxy(
-  serverConfig: cordova.plugins.outline.ServerConfig, onDisconnected: () => void) {
+    serverConfig: cordova.plugins.outline.ServerConfig, onDisconnected: () => void) {
   return new Promise((resolve, reject) => {
     // ss-local -s x.x.x.x -p 65336 -k mypassword -m aes-128-cfb -l 1081 -u
     const ssLocalArgs = ['-l', SS_LOCAL_PORT.toString()];
@@ -310,40 +307,40 @@ function startLocalShadowsocksProxy(
 function validateServerCredentials() {
   return new Promise((fulfill, reject) => {
     const testDomain =
-      CREDENTIALS_TEST_DOMAINS[Math.floor(Math.random() * CREDENTIALS_TEST_DOMAINS.length)];
+        CREDENTIALS_TEST_DOMAINS[Math.floor(Math.random() * CREDENTIALS_TEST_DOMAINS.length)];
     socks.createConnection(
-      {
-        proxy: { ipaddress: PROXY_IP, port: SS_LOCAL_PORT, type: 5 },
-        target: { host: testDomain, port: 80 }
-      },
-      (e, socket) => {
-        if (e) {
-          reject(new errors.InvalidServerCredentials(
-            `could not connect to remote test website: ${e.message}`));
-          return;
-        }
-
-        socket.write(`HEAD / HTTP/1.1\r\nHost: ${testDomain}\r\n\r\n`);
-
-        socket.on('data', (data) => {
-          if (data.toString().startsWith('HTTP/1.1')) {
-            socket.end();
-            fulfill();
-          } else {
-            socket.end();
+        {
+          proxy: {ipaddress: PROXY_IP, port: SS_LOCAL_PORT, type: 5},
+          target: {host: testDomain, port: 80}
+        },
+        (e, socket) => {
+          if (e) {
             reject(new errors.InvalidServerCredentials(
-              `unexpected response from remote test website`));
+                `could not connect to remote test website: ${e.message}`));
+            return;
           }
-        });
 
-        socket.on('close', () => {
-          reject(new errors.InvalidServerCredentials(`could not connect to remote test website`));
-        });
+          socket.write(`HEAD / HTTP/1.1\r\nHost: ${testDomain}\r\n\r\n`);
 
-        // Sockets must be resumed before any data will come in, as they are paused right before
-        // this callback is fired.
-        socket.resume();
-      });
+          socket.on('data', (data) => {
+            if (data.toString().startsWith('HTTP/1.1')) {
+              socket.end();
+              fulfill();
+            } else {
+              socket.end();
+              reject(new errors.InvalidServerCredentials(
+                  `unexpected response from remote test website`));
+            }
+          });
+
+          socket.on('close', () => {
+            reject(new errors.InvalidServerCredentials(`could not connect to remote test website`));
+          });
+
+          // Sockets must be resumed before any data will come in, as they are paused right before
+          // this callback is fired.
+          socket.resume();
+        });
   });
 }
 
@@ -351,57 +348,57 @@ function validateServerCredentials() {
 function checkUdpForwardingEnabled(): Promise<boolean> {
   return new Promise((resolve, reject) => {
     socks.createConnection(
-      {
-        proxy: { ipaddress: PROXY_IP, port: SS_LOCAL_PORT, type: 5, command: 'associate' },
-        target: { host: '0.0.0.0', port: 0 },  // Specify the actual target once we get a response.
-      },
-      (err, socket, info) => {
-        if (err) {
-          reject(new errors.RemoteUdpForwardingDisabled(`could not connect to local proxy`));
-          return;
-        }
-        const dnsRequest = getDnsRequest();
-        const packet = socks.createUDPFrame({ host: '1.1.1.1', port: 53 }, dnsRequest);
-        const udpSocket = dgram.createSocket('udp4');
-
-        udpSocket.on('error', (e) => {
-          reject(new errors.RemoteUdpForwardingDisabled('UDP socket failure'));
-        });
-
-        udpSocket.on('message', (msg, info) => {
-          stopUdp();
-          resolve(true);
-        });
-
-        // Retry sending the query every second.
-        // TODO: logging here is a bit verbose
-        const intervalId = setInterval(() => {
-          try {
-            udpSocket.send(packet, info.port, info.host, (err) => {
-              if (err) {
-                console.error(`Failed to send data through UDP: ${err}`);
-              }
-            });
-          } catch (e) {
-            console.error(`Failed to send data through UDP ${e}`);
+        {
+          proxy: {ipaddress: PROXY_IP, port: SS_LOCAL_PORT, type: 5, command: 'associate'},
+          target: {host: '0.0.0.0', port: 0},  // Specify the actual target once we get a response.
+        },
+        (err, socket, info) => {
+          if (err) {
+            reject(new errors.RemoteUdpForwardingDisabled(`could not connect to local proxy`));
+            return;
           }
-        }, UDP_FORWARDING_TEST_RETRY_INTERVAL_MS);
+          const dnsRequest = getDnsRequest();
+          const packet = socks.createUDPFrame({host: '1.1.1.1', port: 53}, dnsRequest);
+          const udpSocket = dgram.createSocket('udp4');
 
-        const stopUdp = () => {
-          try {
-            clearInterval(intervalId);
-            udpSocket.close();
-          } catch (e) {
-            // Ignore; there may be multiple calls to this function.
-          }
-        };
+          udpSocket.on('error', (e) => {
+            reject(new errors.RemoteUdpForwardingDisabled('UDP socket failure'));
+          });
 
-        // Give up after the timeout elapses.
-        setTimeout(() => {
-          stopUdp();
-          resolve(false);
-        }, UDP_FORWARDING_TEST_TIMEOUT_MS);
-      });
+          udpSocket.on('message', (msg, info) => {
+            stopUdp();
+            resolve(true);
+          });
+
+          // Retry sending the query every second.
+          // TODO: logging here is a bit verbose
+          const intervalId = setInterval(() => {
+            try {
+              udpSocket.send(packet, info.port, info.host, (err) => {
+                if (err) {
+                  console.error(`Failed to send data through UDP: ${err}`);
+                }
+              });
+            } catch (e) {
+              console.error(`Failed to send data through UDP ${e}`);
+            }
+          }, UDP_FORWARDING_TEST_RETRY_INTERVAL_MS);
+
+          const stopUdp = () => {
+            try {
+              clearInterval(intervalId);
+              udpSocket.close();
+            } catch (e) {
+              // Ignore; there may be multiple calls to this function.
+            }
+          };
+
+          // Give up after the timeout elapses.
+          setTimeout(() => {
+            stopUdp();
+            resolve(false);
+          }, UDP_FORWARDING_TEST_TIMEOUT_MS);
+        });
   });
 }
 
@@ -412,8 +409,7 @@ async function handleUdpSupportChange(onDisconnected: () => void): Promise<void>
     console.info(`UDP support changed (${activeConnection.isUdpSupported} > ${isUdpSupported})`);
     activeConnection.isUdpSupported = isUdpSupported;
     await stopTun2socks();
-    const tunDeviceName = await getTunDeviceName();
-    await startTun2socks(tunDeviceName, activeConnection.isUdpSupported, onDisconnected);
+    await startTun2socks(activeConnection.isUdpSupported, onDisconnected);
   }
 }
 
@@ -427,15 +423,14 @@ function getDnsRequest() {
     0, 0,                             // [8-9]   NSCOUNT (number of name server records)
     0, 0,                             // [10-11] ARCOUNT (number of additional records)
     6, 103, 111, 111, 103, 108, 101,  // google
-    3, 99, 111, 109,                  // com
+    3, 99,  111, 109,                 // com
     0,                                // null terminator of FQDN (root TLD)
     0, 1,                             // QTYPE, set to A
     0, 1                              // QCLASS, set to 1 = IN (Internet)
   ]);
 }
 
-function startTun2socks(
-    tunDeviceName: string, isUdpSupported: boolean, onDisconnected: () => void): Promise<void> {
+function startTun2socks(isUdpSupported: boolean, onDisconnected: () => void): Promise<void> {
   return new Promise((resolve, reject) => {
     // ./badvpn-tun2socks.exe \
     //   --tundev "tap0901:outline-tap0:10.0.85.2:10.0.85.0:255.255.255.0" \
@@ -444,7 +439,11 @@ function startTun2socks(
     //   --socks5-udp --udp-relay-addr 127.0.0.1:1081 \
     //   --transparent-dns
     const args: string[] = [];
-    args.push('--tundev', tunDeviceName);
+    args.push(
+        '--tundev',
+        isWindows ? `tap0901:${TUN2SOCKS_DEVICE_NAME}:${TUN2SOCKS_DEVICE_IP}:${
+                        TUN2SOCKS_DEVICE_NETWORK}:${TUN2SOCKS_VIRTUAL_ROUTER_NETMASK}` :
+                    TUN2SOCKS_DEVICE_NAME);
     args.push('--netif-ipaddr', TUN2SOCKS_VIRTUAL_ROUTER_IP);
     args.push('--netif-netmask', TUN2SOCKS_VIRTUAL_ROUTER_NETMASK);
     args.push('--socks-server-addr', `${PROXY_IP}:${SS_LOCAL_PORT}`);
@@ -480,7 +479,7 @@ function startTun2socks(
             console.info('Restarting tun2socks...');
             setTimeout(() => {
               isUdpSupported = activeConnection.isUdpSupported || isUdpSupported;
-              startTun2socks(tunDeviceName, isUdpSupported, onDisconnected)
+              startTun2socks(isUdpSupported, onDisconnected)
                   .then(() => {
                     resolve();
                   })
@@ -542,17 +541,6 @@ export function teardownVpn() {
     }),
     stopProcesses()
   ]);
-}
-
-function getTunDeviceName(): Promise<string> {
-  if (isWindows) {
-    return Promise.resolve(`tap0901:${TUN2SOCKS_TAP_DEVICE_NAME}:${TUN2SOCKS_TAP_DEVICE_IP}:${
-        TUN2SOCKS_TAP_DEVICE_NETWORK}:${TUN2SOCKS_VIRTUAL_ROUTER_NETMASK}`);
-  } else if (isLinux) {
-    return routingService.getDeviceName();
-  } else {
-    return Promise.reject(new Error(`unsupported platform`));
-  }
 }
 
 function stopProcesses() {

--- a/src/electron/routing_service.ts
+++ b/src/electron/routing_service.ts
@@ -14,7 +14,6 @@
 
 import * as net from 'net';
 import * as os from 'os';
-import * as path from 'path';
 import * as sudo from 'sudo-prompt';
 
 import * as errors from '../www/model/errors';
@@ -38,7 +37,6 @@ interface RoutingServiceResponse {
 enum RoutingServiceAction {
   CONFIGURE_ROUTING = 'configureRouting',
   RESET_ROUTING = 'resetRouting',
-  GET_DEVICE_NAME = 'getDeviceName',
   STATUS_CHANGED = 'statusChanged'
 }
 
@@ -84,16 +82,6 @@ export class RoutingService {
       // Ignore, the service may have disconnected the pipe.
     }
     return this.sendRequest({action: RoutingServiceAction.RESET_ROUTING, parameters: {}});
-  }
-
-  // Returns the name of the device.
-  getDeviceName(): Promise<string> {
-    // This is used when we read tun device name from the daemon and the value
-    // comes in returnValue in the json.
-    return this.sendRequest({action: RoutingServiceAction.GET_DEVICE_NAME, parameters: {}})
-        .then((json) => {
-          return JSON.parse(json).returnValue;
-        });
   }
 
   // Helper method to perform IPC with the Windows Service. Prompts the user for admin permissions


### PR DESCRIPTION
As for https://github.com/Jigsaw-Code/outline-client/pull/509, this is in preparation for a significant refactoring of `process_manager.ts`. From looking at `outline_proxy_controller`, it turns out that the device name is fixed: let's do like the Windows client and assume we know the name.

BTW, removing the `GET_DEVICE_NAME` call from `outline_proxy_controller` is straightforward but unfortunately we don't have a good mechanism right now to keep `outline_proxy_controller` updated.