### PR TITLE
re-generate the Android Docker image, to fix broken CB

### DIFF
--- a/tools/build/Dockerfile
+++ b/tools/build/Dockerfile
@@ -1,28 +1,31 @@
-# Many of the Android build tools require glibc and are
-# built for 32 bit systems. Running such binaries is a
-# lot easier on Ubuntu than on Alpine.  
-FROM ubuntu:18.04
+# Copyright 2019 The Outline Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-# We install curl because while wget may be much smaller,
-# some of the install scripts themselves invoke curl.
+# Though we normally prefer Alpine, many of the Android build tools require glibc.
+FROM debian:9
 
 # Notes on dependencies:
 #  - Bower requires git
 #  - gnupg is needed by the Node.js installer to add an Apt repository.
-#  - Specify openjdk-8-jre-headless explicitly to prevent versions >8
-#    from being installed, which aren't compatible with the Android tools.
-RUN apt update && apt install -y curl unzip openjdk-8-jdk openjdk-8-jre-headless gradle git gnupg rsync && apt clean
+#  - Several of Outline's build scripts require rsync.
+RUN apt update && apt dist-upgrade -y && apt install -y wget unzip openjdk-8-jdk-headless gradle git gnupg rsync && apt clean
 
-# Node.js.
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
-RUN apt install -y nodejs
-
-# Yarn.
-# Set this explicitly because $HOME is set to / by default
-# in Dockerfiles, confusing the yarn install script.
-ENV HOME /root
-RUN curl -sL https://yarnpkg.com/install.sh | bash -
-ENV PATH $HOME/.yarn/bin:${PATH}
+# Node.js and Yarn.
+RUN wget -qO- https://deb.nodesource.com/setup_10.x | bash -
+RUN wget -qO- https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN apt update && apt install -y nodejs yarn && apt clean
 
 # https://stackoverflow.com/questions/25672924/run-bower-from-root-user-its-possible-how
 RUN echo '{"allow_root": true}' > /root/.bowerrc
@@ -40,7 +43,7 @@ ENV CI=true
 # Android SDK ("command line tools only"):
 #   https://developer.android.com/studio/index.html#downloads
 # This is version 26.1.1.
-RUN curl -o /tmp/android-tools.zip https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip && \
+RUN wget -O /tmp/android-tools.zip https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip && \
     mkdir /opt/android-sdk && \
     unzip /tmp/android-tools.zip -d /opt/android-sdk && \
     rm /tmp/android-tools.zip
@@ -51,5 +54,5 @@ ENV ANDROID_HOME /opt/android-sdk
 #   https://developer.android.com/studio/releases/build-tools.html
 # To find the latest version's label:
 #   sdkmanager --list|grep build-tools
-ENV ANDROID_BUILD_TOOLS_VERSION 28.0.1
+ENV ANDROID_BUILD_TOOLS_VERSION 28.0.3
 RUN yes | sdkmanager "build-tools;${ANDROID_BUILD_TOOLS_VERSION}"

--- a/tools/build/build.sh
+++ b/tools/build/build.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-readonly IMAGE_NAME="quay.io/outline/build-android:2018-10-02@sha256:52af7e9245aea96a838249e133d739133ad1e0783a96c30b3289c56c0aef193c"
+readonly IMAGE_NAME="quay.io/outline/build-android:2019-02-01@sha256:83e3e5fa46926f1c4f87a59c185f5e17b3c870887931cd6358d81a357330fff3"
 BUILD=false
 PUBLISH=false
 


### PR DESCRIPTION
Bah, our Android build has been failing on Travis for a few days:
- last successful daily: https://github.com/Jigsaw-Code/outline-client/releases/tag/daily-2019-01-17
- first Travis failure: https://travis-ci.org/Jigsaw-Code/outline-client/jobs/485176565

The issue is that the Android SDK thinks we haven't accepted the license terms. I don't know exactly how this works (it must check the timestamp on `/opt/android-sdk/licenses/android-sdk-license` or something) but re-building the image seems to fix it. I also updated and culled a few deps - the image is a little smaller now.

One big thing to tackle soon is that `yarn gulp build` doesn't return a non-zero status when the script fails - wut!?