### PR TITLE
co-locate steps to make web app cordova-compatible

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,18 +26,15 @@ const gulpif = require('gulp-if');
 const gutil = require('gulp-util');
 const polymer_build = require('polymer-build');
 const source = require('vinyl-source-stream');
-const watchify = require('watchify');
 
-const SRC_DIR = 'www';
+const SRC_WWW = 'src/www';
+const DEST_WWW = 'www';
 
 const CONFIG_BY_PLATFORM = {
-  android: {
-    targetDir: `platforms/android/app/src/main/assets/${SRC_DIR}`,
-    platformArgs: '--gradleArg=-PcdvBuildMultipleApks=true'
-  },
-  browser: {targetDir: `platforms/browser/${SRC_DIR}`},
-  ios: {targetDir: `platforms/ios/${SRC_DIR}`, compileArgs: '--device'},
-  osx: {targetDir: `platforms/osx/${SRC_DIR}`}
+  android: {platformArgs: '--gradleArg=-PcdvBuildMultipleApks=true'},
+  browser: {},
+  ios: {compileArgs: '--device'},
+  osx: {}
 };
 
 function getConfigByPlatform(platform) {
@@ -58,22 +55,25 @@ function transpile(src, dest) {
       .pipe(gulp.dest(dest));
 }
 
+// Note: This is currently done "in-place", i.e. the components are downloaded to src/www and
+// transpiled there, but this seems to work just fine (idempodent).
 function transpileBowerComponents() {
   gutil.log('Transpiling Bower components');
   // Transpile bower_components with the exception of webcomponentsjs, which contains transpiled
   // polyfills, and minified files, which are generally already transpiled.
   const bowerComponentsSrc = [
-    'www/bower_components/**/*.html', 'www/bower_components/**/*.js',
-    '!www/bower_components/webcomponentsjs/**/*.js',
-    '!www/bower_components/webcomponentsjs/**/*.html', '!www/bower_components/**/*.min.js'
+    `${DEST_WWW}/bower_components/**/*.html`, `${DEST_WWW}/bower_components/**/*.js`,
+    `!${DEST_WWW}/bower_components/webcomponentsjs/**/*.js`,
+    `!${DEST_WWW}/bower_components/webcomponentsjs/**/*.html`,
+    `!${DEST_WWW}/bower_components/**/*.min.js`
   ];
-  const bowerComponentsDest = `${SRC_DIR}/bower_components`;
+  const bowerComponentsDest = `${DEST_WWW}/bower_components`;
   return transpile(bowerComponentsSrc, bowerComponentsDest);
 }
 
 function transpileUiComponents() {
   gutil.log('Transpiling UI components');
-  return transpile(['www/ui_components/*.html'], `${SRC_DIR}/ui_components`);
+  return transpile([`${SRC_WWW}/ui_components/*.html`], `${DEST_WWW}/ui_components`);
 }
 
 // See https://www.typescriptlang.org/docs/handbook/gulp.html
@@ -81,7 +81,7 @@ function getBrowserifyInstance() {
   return browserify({
     basedir: '.',
     debug: true,
-    entries: [`${SRC_DIR}/app/cordova_main.js`],
+    entries: [`${DEST_WWW}/app/cordova_main.js`],
     cache: {},
     packageCache: {}
   });
@@ -89,30 +89,13 @@ function getBrowserifyInstance() {
 
 function bundleJs(browserifyInstance) {
   gutil.log('Running browserify');
-  const notWatch = !gutil.env.watch;
   const log = gutil.log.bind(gutil, 'Browserify Error:');
   const bundle = browserifyInstance.bundle();
   bundle.once('error', function(...args) {
     log(...args);
-    if (notWatch) {
-      return process.exit(1);
-    }
+    return process.exit(1);
   });
   return bundle.pipe(source('cordova_main.js'));
-}
-
-// TODO: watch for changes in .html files too, not just .ts files
-function watch(browserifyInstance, config) {
-  const log = gutil.log.bind(gutil, 'Browserify:');
-  const watchified = watchify(browserifyInstance);
-  watchified.on('log', log);
-  watchified.on('update', function(deps) {
-    gutil.log(`The following dependencies were modified, rebuilding...
-      ${deps}`);
-    bundleJs(watchified).pipe(gulp.dest(config.targetDir));
-    gutil.log('Rebuilt');
-  });
-  return browserifyInstance;
 }
 
 function runCommand(command, options, done) {
@@ -129,7 +112,7 @@ function runCommand(command, options, done) {
 // Copies Babel polyfill from node_modules, as it needs to be included by cordova_index.html.
 function copyBabelPolyfill() {
   const babelPolyfill = 'node_modules/babel-polyfill/dist/polyfill.min.js';
-  runCommand(`cp -v ${babelPolyfill} ${SRC_DIR}/babel-polyfill.min.js`, {}, function() {
+  runCommand(`cp -v ${babelPolyfill} ${DEST_WWW}/babel-polyfill.min.js`, {}, function() {
     gutil.log(`Copied Babel polyfill.`);
   });
 }
@@ -139,7 +122,7 @@ function writeEnvJson(platform, isRelease) {
   // bash for Windows' (Cygwin's) benefit (sh can *not* run this script, at least on Alpine).
   runCommand(
       `bash scripts/environment_json.sh -p ${platform} ${isRelease ? '-r' : ''} > ${
-          SRC_DIR}/environment.json`,
+          DEST_WWW}/environment.json`,
       {}, function() {
         gutil.log(`Wrote environment.json`);
       });
@@ -190,24 +173,20 @@ gulp.task('build', function() {
 
 function build(platform, config) {
   const envVars = getReleaseEnvironmentVariables(platform);
-  const shouldWatch = !!gutil.env.watch;
-  let browserifyInstance = getBrowserifyInstance().transform('babelify', {
+  const browserifyInstance = getBrowserifyInstance().transform('babelify', {
     global: true,  // Transpile required node modules
     presets: ['env']
   });
-  if (shouldWatch) {
-    browserifyInstance = watch(browserifyInstance, config);
-  }
 
   // Build the web app.
   child_process.execSync('yarn do src/www/build', {stdio: 'inherit'});
 
   // Bundle the code starting at www/app/cordova_main.js -> www/cordova_main.js.
-  return bundleJs(browserifyInstance).pipe(gulp.dest(SRC_DIR)).on('finish', () => {
+  return bundleJs(browserifyInstance).pipe(gulp.dest(DEST_WWW)).on('finish', () => {
     copyBabelPolyfill();
     transpileBowerComponents().on('finish', function() {
       transpileUiComponents().on('finish', function() {
-        generateRtlCss(`${SRC_DIR}/ui_components/*.html`, `${SRC_DIR}/ui_components`)
+        generateRtlCss(`${SRC_WWW}/ui_components/*.html`, `${DEST_WWW}/ui_components`)
             .on('finish', function() {
               // cordova-custom-config isn't invoked as part of "cordova prepare" unless,
               // beforehand, the platform has been added.
@@ -231,17 +210,8 @@ function build(platform, config) {
                           `rsync -avzc apple/xcode/${platform}/ platforms/${platform}/` :
                           ':';
                       runCommand(syncXcode, {}, () => {
-                        runCommand(
-                            `cordova compile ${platform} ${compileArgs} ${releaseArgs} -- ${
-                                platformArgs}`,
-                            {}, function() {
-                              if (shouldWatch) {
-                                gutil.log('Running...');
-                                runCommand(`cordova run ${platform} --noprepare --nobuild`);
-                              } else {
-                                gutil.log('Done');
-                              }
-                            });
+                        runCommand(`cordova compile ${platform} ${compileArgs} ${releaseArgs} -- ${
+                            platformArgs}`);
                       });
                     });
                   });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -209,8 +209,8 @@ function build(platform, config) {
       transpileUiComponents().on('finish', function() {
         generateRtlCss(`${SRC_DIR}/ui_components/*.html`, `${SRC_DIR}/ui_components`)
             .on('finish', function() {
-              // cordova-custom-config isn't be invoked as part of "cordova prepare"
-              // unless, beforehand, the platform has been added.
+              // cordova-custom-config isn't invoked as part of "cordova prepare" unless,
+              // beforehand, the platform has been added.
               runCommand(
                   `test -d platforms/${platform} || cordova platform add ${platform}`, {},
                   function() {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "tslint": "^5.12.0",
     "typescript": "~3.1.0",
     "vinyl-source-stream": "^1.1.0",
-    "watchify": "^3.9.0",
     "xml2js": "^0.4.17"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -417,13 +417,6 @@ any-promise@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
 
-anymatch@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.0.tgz#a3e52fa39168c825ff57b0248126ce5a8ff95507"
-  dependencies:
-    arrify "^1.0.0"
-    micromatch "^2.1.5"
-
 app-builder-bin@2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-2.4.1.tgz#1e575eb0785160d87a9c6cc08d2bec2deeec511d"
@@ -637,10 +630,6 @@ astw@^2.0.0:
   resolved "https://registry.yarnpkg.com/astw/-/astw-2.2.0.tgz#7bd41784d32493987aeb239b6b4e1c57a873b917"
   dependencies:
     acorn "^4.0.3"
-
-async-each@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
 
 async-exit-hook@^2.0.1:
   version "2.0.1"
@@ -1216,10 +1205,6 @@ bignumber.js@^2.1.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-2.4.0.tgz#838a992da9f9d737e0f4b2db0be62bb09dd0c5e8"
 
-binary-extensions@^1.0.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.8.0.tgz#48ec8d16df4377eae5fa5884682480af4d95c774"
-
 binaryextensions@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-1.0.1.tgz#1e637488b35b58bda5f4774bf96a5212a8c90755"
@@ -1476,7 +1461,7 @@ browserify@13.3.0:
     vm-browserify "~0.0.1"
     xtend "^4.0.0"
 
-browserify@^14.0.0, browserify@^14.4.0:
+browserify@^14.4.0:
   version "14.4.0"
   resolved "https://registry.yarnpkg.com/browserify/-/browserify-14.4.0.tgz#089a3463af58d0e48d8cd4070b3f74654d5abca9"
   dependencies:
@@ -1742,21 +1727,6 @@ char-spinner@~1.0.1:
 chmodr@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/chmodr/-/chmodr-1.0.2.tgz#04662b932d0f02ec66deaa2b0ea42811968e3eb9"
-
-chokidar@^1.0.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
-  dependencies:
-    anymatch "^1.3.0"
-    async-each "^1.0.0"
-    glob-parent "^2.0.0"
-    inherits "^2.0.1"
-    is-binary-path "^1.0.0"
-    is-glob "^2.0.0"
-    path-is-absolute "^1.0.0"
-    readdirp "^2.0.0"
-  optionalDependencies:
-    fsevents "^1.0.0"
 
 chownr@~1.0.1:
   version "1.0.1"
@@ -3382,14 +3352,7 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
-fsevents@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.1.1.tgz#f19fd28f43eeaf761680e519a203c4d0b3d31aff"
-  dependencies:
-    nan "^2.3.0"
-    node-pre-gyp "^0.6.29"
-
-fstream-ignore@^1.0.0, fstream-ignore@^1.0.5:
+fstream-ignore@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/fstream-ignore/-/fstream-ignore-1.0.5.tgz#9c31dae34767018fe1d249b24dada67d092da105"
   dependencies:
@@ -3404,7 +3367,7 @@ fstream-npm@~1.1.1:
     fstream-ignore "^1.0.0"
     inherits "2"
 
-fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2, fstream@~1.0.10:
+fstream@^1.0.0, fstream@^1.0.2, fstream@~1.0.10:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.11.tgz#5c1fb1f117477114f0632a0eb4b71b3cb0fd3171"
   dependencies:
@@ -3438,19 +3401,6 @@ gauge@~2.6.0:
     aproba "^1.0.3"
     console-control-strings "^1.0.0"
     has-color "^0.1.7"
-    has-unicode "^2.0.0"
-    object-assign "^4.1.0"
-    signal-exit "^3.0.0"
-    string-width "^1.0.1"
-    strip-ansi "^3.0.1"
-    wide-align "^1.1.0"
-
-gauge@~2.7.3:
-  version "2.7.4"
-  resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
-  dependencies:
-    aproba "^1.0.3"
-    console-control-strings "^1.0.0"
     has-unicode "^2.0.0"
     object-assign "^4.1.0"
     signal-exit "^3.0.0"
@@ -4274,12 +4224,6 @@ is-absolute@^0.2.3:
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
-
-is-binary-path@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-1.0.1.tgz#75f16642b480f187a711c814161fd3a4a7655898"
-  dependencies:
-    binary-extensions "^1.0.0"
 
 is-buffer@^1.1.0, is-buffer@^1.1.5:
   version "1.1.5"
@@ -5127,7 +5071,7 @@ methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
-micromatch@^2.1.5, micromatch@^2.3.7:
+micromatch@^2.3.7:
   version "2.3.11"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
   dependencies:
@@ -5323,10 +5267,6 @@ mz@^2.6.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nan@^2.3.0:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
-
 natives@1.1.6, natives@^1.1.0:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.6.tgz#a603b4a498ab77173612b9ea1acdec4d980f00bb"
@@ -5365,20 +5305,6 @@ node-gyp@~3.6.0:
     tar "^2.0.0"
     which "1"
 
-node-pre-gyp@^0.6.29:
-  version "0.6.36"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz#db604112cb74e0d477554e9b505b17abddfab786"
-  dependencies:
-    mkdirp "^0.5.1"
-    nopt "^4.0.1"
-    npmlog "^4.0.2"
-    rc "^1.1.7"
-    request "^2.81.0"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^2.2.1"
-    tar-pack "^3.4.0"
-
 node-status-codes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/node-status-codes/-/node-status-codes-1.0.0.tgz#5ae5541d024645d32a58fcddc9ceecea7ae3ac2f"
@@ -5398,13 +5324,6 @@ nopt@3.0.1:
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.1.tgz#bce5c42446a3291f47622a370abbf158fbbacbfd"
   dependencies:
     abbrev "1"
-
-nopt@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
-  dependencies:
-    abbrev "1"
-    osenv "^0.1.4"
 
 normalize-git-url@~3.0.2:
   version "3.0.2"
@@ -5575,15 +5494,6 @@ npm@^2.10.x:
     ansi "~0.3.1"
     are-we-there-yet "~1.1.2"
     gauge "~1.2.5"
-
-npmlog@^4.0.2:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.0.tgz#dc59bee85f64f00ed424efb2af0783df25d1c0b5"
-  dependencies:
-    are-we-there-yet "~1.1.2"
-    console-control-strings "~1.1.0"
-    gauge "~2.7.3"
-    set-blocking "~2.0.0"
 
 "npmlog@~2.0.0 || ~3.1.0":
   version "3.1.2"
@@ -5758,12 +5668,6 @@ osx-release@^1.0.0:
   resolved "https://registry.yarnpkg.com/osx-release/-/osx-release-1.1.0.tgz#f217911a28136949af1bf9308b241e2737d3cd6c"
   dependencies:
     minimist "^1.1.0"
-
-outpipe@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/outpipe/-/outpipe-1.1.1.tgz#50cf8616365e87e031e29a5ec9339a3da4725fa2"
-  dependencies:
-    shell-quote "^1.4.2"
 
 p-defer@^1.0.0:
   version "1.0.0"
@@ -6432,7 +6336,7 @@ raven@^2.2.1:
     timed-out "4.0.1"
     uuid "3.0.0"
 
-rc@^1.0.1, rc@^1.1.2, rc@^1.1.6, rc@^1.1.7:
+rc@^1.0.1, rc@^1.1.2, rc@^1.1.6:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.1.tgz#2e03e8e42ee450b8cb3dce65be1bf8974e1dfd95"
   dependencies:
@@ -6537,7 +6441,7 @@ read@1, read@~1.0.1, read@~1.0.7:
   dependencies:
     mute-stream "~0.0.4"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.6:
   version "2.2.11"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.11.tgz#0796b31f8d7688007ff0b93a8088d34aa17c0f72"
   dependencies:
@@ -6622,15 +6526,6 @@ readdir-scoped-modules@^1.0.0:
     dezalgo "^1.0.0"
     graceful-fs "^4.1.2"
     once "^1.3.0"
-
-readdirp@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.1.0.tgz#4ed0ad060df3073300c48440373f72d1cc642d78"
-  dependencies:
-    graceful-fs "^4.1.2"
-    minimatch "^3.0.2"
-    readable-stream "^2.0.2"
-    set-immediate-shim "^1.0.1"
 
 readline2@^1.0.1:
   version "1.0.1"
@@ -6920,12 +6815,6 @@ rimraf@^2.2.8:
   dependencies:
     glob "^7.0.5"
 
-rimraf@^2.5.1, rimraf@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
-  dependencies:
-    glob "^7.0.5"
-
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.1.tgz#0f4584295c53a3628af7e6d79aca21ce57d1c6e7"
@@ -7068,10 +6957,6 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
 
-set-immediate-shim@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
-
 setprototypeof@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.3.tgz#66567e37043eeb4f04d91bd658c0cbefb55b8e04"
@@ -7110,7 +6995,7 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-shell-quote@^1.4.2, shell-quote@^1.6.1:
+shell-quote@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.6.1.tgz#f4781949cce402697127430ea3b3c5476f481767"
   dependencies:
@@ -7543,19 +7428,6 @@ table-layout@^0.3.0:
     typical "^2.6.0"
     wordwrapjs "^2.0.0-0"
 
-tar-pack@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/tar-pack/-/tar-pack-3.4.0.tgz#23be2d7f671a8339376cbdb0b8fe3fdebf317984"
-  dependencies:
-    debug "^2.2.0"
-    fstream "^1.0.10"
-    fstream-ignore "^1.0.5"
-    once "^1.3.3"
-    readable-stream "^2.1.4"
-    rimraf "^2.5.1"
-    tar "^2.2.1"
-    uid-number "^0.0.6"
-
 tar@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/tar/-/tar-1.0.2.tgz#8b0f6740f9946259de26a3ed9c9a22890dff023f"
@@ -7564,7 +7436,7 @@ tar@1.0.2:
     fstream "^1.0.2"
     inherits "2"
 
-tar@^2.0.0, tar@^2.2.1, tar@~2.2.1:
+tar@^2.0.0, tar@~2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
   dependencies:
@@ -7823,7 +7695,7 @@ typical@^2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/typical/-/typical-2.6.1.tgz#5c080e5d661cbbe38259d2e70a3c7253e873881d"
 
-uid-number@0.0.6, uid-number@^0.0.6:
+uid-number@0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
 
@@ -8148,18 +8020,6 @@ vm-browserify@~0.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
   dependencies:
     indexof "0.0.1"
-
-watchify@^3.9.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/watchify/-/watchify-3.9.0.tgz#f075fd2e8a86acde84cedba6e5c2a0bedd523d9e"
-  dependencies:
-    anymatch "^1.3.0"
-    browserify "^14.0.0"
-    chokidar "^1.0.0"
-    defined "^1.0.0"
-    outpipe "^1.1.0"
-    through2 "^2.0.0"
-    xtend "^4.0.0"
 
 wcwidth@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
The steps to make the web app "Cordova compatible" are intermixed with the Cordova build/prepare commands and operate on the files in `platforms/` rather than `www/`. This significantly complicates the Gulpfile. This PR moves them together, in anticipation of breaking them out to another build target altogether...basically, I'm chipping away at this file.