### PR TITLE
Fix iOS build with workaround for Xcode 10/cordova-ios compatibility

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -156,7 +156,9 @@ function xcode() {
 
 function cordovaCompile() {
   const platformArgs = platform === 'android' ? '--gradleArg=-PcdvBuildMultipleApks=true' : '';
-  const compileArgs = platform === 'ios' ? '--device' : '';
+  // Use flag -UseModernBuildSystem=0 as a workaround for Xcode 10 compatibility until upgrading to
+  // cordova-ios@5.0.0. See https://github.com/apache/cordova-ios/issues/404.
+  const compileArgs = platform === 'ios' ? '--device --buildFlag="-UseModernBuildSystem=0"' : '';
   const releaseArgs = isRelease ? platform === 'android' ?
                                   `--release -- --keystore=${gutil.env.KEYSTORE} ` +
               `--storePassword=${gutil.env.STOREPASS} --alias=${gutil.env.KEYALIAS} ` +


### PR DESCRIPTION
* cordova-ios < 5.0.0 fails to compile the project via command line after moving to Xcode 10.
* This workaround preserves the compatibility between cordova-ios < 5.0.0 and  Xcode 10 until we upgrade to cordova-ios@5.0.0 (which requires cordova 8).
* Note that builds from the Xcode project are not affected by this change and were working since updating to Xcode 10.