### PR TITLE
fix for no window on startup when no stored connection

### DIFF
--- a/src/electron/index.ts
+++ b/src/electron/index.ts
@@ -250,8 +250,9 @@ app.on('ready', () => {
           createWindow(connection);
         })
         .catch((e) => {
-          // No connection at shutdown, or failure - either way, we need a main window.
-          createWindow();
+          // No connection at shutdown, or failure - either way, no need to start.
+          // TODO: Instead of quitting, how about creating the system tray icon?
+          app.quit();
         });
   } else {
     createWindow();

--- a/src/electron/index.ts
+++ b/src/electron/index.ts
@@ -243,19 +243,15 @@ app.on('ready', () => {
     app.setLoginItemSettings({openAtLogin: true, args: [Options.AUTOSTART]});
   }
 
-  // because autostart doesn't work for linux then we just assume we
-  // are auto started on linux
+  // TODO: --autostart is never set on Linux, what can we do?
   if (process.argv.includes(Options.AUTOSTART)) {
     connectionStore.load()
         .then((connection) => {
-          // The user was connected at shutdown. Create the main window and wait for the UI ready
-          // event to start the VPN.
           createWindow(connection);
         })
-        .catch((err) => {
-          // The user was not connected at shutdown.
-          // Quitting the app will reset the system proxy configuration before exiting.
-          console.log('The user was not connected at shutdown.');
+        .catch((e) => {
+          // No connection at shutdown, or failure - either way, we need a main window.
+          createWindow();
         });
   } else {
     createWindow();


### PR DESCRIPTION
This is bad: if there's a stored connection (from the last shutdown) then Outline doesn't create a windowand you have to kill the process and restart before it will do so. Reported here, I was finally able to reproduce when working on https://github.com/Jigsaw-Code/outline-client/pull/535:
https://github.com/Jigsaw-Code/outline-client/issues/501

Very simple fix, just verified it on my VM.