### PR TITLE
show reinstall message when routing daemon cannot be reached

### DIFF
--- a/src/electron/routing_service.ts
+++ b/src/electron/routing_service.ts
@@ -87,7 +87,10 @@ export class RoutingDaemon {
           const message: RoutingServiceResponse = JSON.parse(data.toString());
           if (message.action !== RoutingServiceAction.CONFIGURE_ROUTING ||
               message.statusCode !== RoutingServiceStatusCode.SUCCESS) {
-            // TODO: concrete error
+            // NOTE: This will rarely occur because the connectivity tests
+            //       performed when the user clicks "CONNECT" should detect when
+            //       the system is offline and that, currently, is pretty much
+            //       the only time the routing service will fail.
             reject(new Error(message.errorMessage));
             newSocket.end();
             return;
@@ -105,7 +108,7 @@ export class RoutingDaemon {
 
       const initialErrorHandler = () => {
         if (!(isLinux && retry)) {
-          reject(new Error(`routing daemon is not running`));
+          reject(new errors.SystemConfigurationException(`routing daemon is not running`));
           return;
         }
 


### PR DESCRIPTION
Virtually the only unexpected connection error I'm seeing so far with https://github.com/Jigsaw-Code/outline-client/pull/555 at 20% is that the routing daemon is not running. I forgot to throw the correct error. Also, clarify the other "connection time" error thrown by this class.