### PR TITLE
Check for updates every 6 hours

### DIFF
--- a/src/electron/index.ts
+++ b/src/electron/index.ts
@@ -226,9 +226,8 @@ app.on('ready', () => {
   } else {
     checkForUpdates();
 
-    // six hours
-    const time = 6 * 60 * 60 * 1000;
-    setInterval(checkForUpdates, time);
+    // Check every six hours
+    setInterval(checkForUpdates, 6 * 60 * 60 * 1000);
   }
 
   // Set the app to launch at startup to connect automatically in case of a showdown while proxying.

--- a/src/electron/index.ts
+++ b/src/electron/index.ts
@@ -224,15 +224,11 @@ app.on('ready', () => {
       submenu: [{role: 'reload'}, {role: 'forcereload'}, {role: 'toggledevtools'}]
     }]));
   } else {
+    checkForUpdates();
+
     // six hours
     const time = 6 * 60 * 60 * 1000;
-    setInterval(() => {
-      try {
-        autoUpdater.checkForUpdates();
-      } catch (e) {
-        console.error(`Failed to check for updates`, e);
-      }
-    }, time);
+    setInterval(checkForUpdates, time);
   }
 
   // Set the app to launch at startup to connect automatically in case of a showdown while proxying.
@@ -423,6 +419,14 @@ ipcMain.on('localizationResponse', (event: Event, localizationResult: {[key: str
   }
   createTrayIcon(ConnectionStatus.DISCONNECTED);
 });
+
+function checkForUpdates() {
+  try {
+    autoUpdater.checkForUpdates();
+  } catch (e) {
+    console.error(`Failed to check for updates`, e);
+  }
+}
 
 // Notify the UI of updates.
 autoUpdater.on('update-downloaded', (ev, info) => {

--- a/src/electron/index.ts
+++ b/src/electron/index.ts
@@ -228,7 +228,7 @@ app.on('ready', () => {
     const time = 6 * 60 * 60 * 1000;
     setInterval(() => {
       try {
-        autoUpdater.checkForUpdatesAndNotify();
+        autoUpdater.checkForUpdates();
       } catch (e) {
         console.error(`Failed to check for updates`, e);
       }

--- a/src/electron/index.ts
+++ b/src/electron/index.ts
@@ -224,12 +224,15 @@ app.on('ready', () => {
       submenu: [{role: 'reload'}, {role: 'forcereload'}, {role: 'toggledevtools'}]
     }]));
   } else {
-    // TODO: Run this periodically, e.g. every 4-6 hours.
-    try {
-      autoUpdater.checkForUpdates();
-    } catch (e) {
-      console.error(`Failed to check for updates`, e);
-    }
+    // six hours
+    const time = 6 * 60 * 60 * 1000;
+    setInterval(() => {
+      try {
+        autoUpdater.checkForUpdatesAndNotify();
+      } catch (e) {
+        console.error(`Failed to check for updates`, e);
+      }
+    }, time);
   }
 
   // Set the app to launch at startup to connect automatically in case of a showdown while proxying.


### PR DESCRIPTION
This accomplishes two goals

First, and directly, it helps us roll out upgrades faster.

Secondly, this is the first step towards getting a better understanding of the scale of use of Outline.  The second step will be to release our binaries on S3 instead of the outline-releases repo, giving us the ability to use their anonymized and aggregated Request Metrics.