### PR TITLE
Enable every orientations for iOS

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -72,6 +72,7 @@
 
     <!-- iOS -->
     <platform name="ios">
+        <preference name="orientation" value="all" />
         <preference name="deployment-target" value="9.0" />
         <preference name="DisallowOverscroll" value="true" />
         <preference name="StatusBarOverlaysWebView" value="false" />


### PR DESCRIPTION
This avoids interrupting of the current device's rotation by entering/leaving the App, particularly on iPad in landscape mode.