### PR TITLE
Android: set minimum sdk version to 21

### DIFF
--- a/cordova-plugin-outline/android/java/build-extras.gradle
+++ b/cordova-plugin-outline/android/java/build-extras.gradle
@@ -2,3 +2,14 @@ dependencies {
   compile 'com.android.support:appcompat-v7:23.4.0'
   compile 'io.sentry:sentry-android:1.7.3'
 }
+
+// Set the minimum and target SDK versions; the values set in config.xml are not taking effect.
+// See https://github.com/apache/cordova-android/issues/686. This should not be necessary once we
+// upgrade to Cordova 8.
+allprojects {
+  project.ext {
+    defaultTargetSdkVersion=28
+    defaultCompileSdkVersion=28
+    defaultMinSdkVersion=21
+  }
+}


### PR DESCRIPTION
* Due to a bug in Cordova, the values for minimum and target SDK versions declared in config.xml are not taking effect in the built APK. As a result the minimum SDK version was set to 19, which is not supported.
* Overrides the versions through a custom Gradle build file.
* Verified that the built APK SDK versions expected though `aapt` and `apkanalyzer`.