### PR TITLE
Routing service improvements

### DIFF
--- a/src/electron/routing_service.ts
+++ b/src/electron/routing_service.ts
@@ -158,7 +158,7 @@ export class RoutingDaemon {
 
   // Parses JSON `data` as a `RoutingServiceResponse`. Logs the error and returns undefined on
   // failure.
-  private parseRoutingServiceResponse(data: Buffer) {
+  private parseRoutingServiceResponse(data: Buffer): RoutingServiceResponse|undefined {
     if (!data) {
       console.error('received empty response from routing service');
       return undefined;


### PR DESCRIPTION
* Handles routing service responses (JSON) parsing failiures to prevent the error from propagating to the user.
* Logs failures so we can fix the underlying problem (as reported on Linux #633) through feedback submissions.
* Fixes restarting the routing service (daemon) by attaching socket error/close listeners after the connection has been established. Enables the routing service restart behavior in Windows.
