### PR TITLE
Introduce support for landscape on iPads

### DIFF
--- a/apple/xcode/ios/Outline/Outline-Info.plist
+++ b/apple/xcode/ios/Outline/Outline-Info.plist
@@ -57,6 +57,9 @@
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Outline stubbornly stays in portrait mode on an iPad, resulting in having to tilt one's head 90 degrees like a quizzical poodle when using an iPad with an attached keyboard. This change supports Landscape mode on iPad devices only. 