### PR TITLE
Release Apple clients v1.3.2

### DIFF
--- a/apple/xcode/ios/Outline/Outline-Info.plist
+++ b/apple/xcode/ios/Outline/Outline-Info.plist
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.1</string>
+	<string>1.3.2</string>
 	<key>CFBundleVersion</key>
-	<string>22</string>
+	<string>23</string>
   <key>CFBundleDevelopmentRegion</key>
   <string>English</string>
 	<key>CFBundleDisplayName</key>

--- a/apple/xcode/ios/Outline/VpnExtension-Info.plist
+++ b/apple/xcode/ios/Outline/VpnExtension-Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.1</string>
+	<string>1.3.2</string>
 	<key>CFBundleVersion</key>
-	<string>22</string>
+	<string>23</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/apple/xcode/osx/Outline/Outline-Info.plist
+++ b/apple/xcode/osx/Outline/Outline-Info.plist
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.1</string>
+	<string>1.3.2</string>
 	<key>CFBundleVersion</key>
-	<string>20</string>
+	<string>21</string>
   <key>CFBundleDevelopmentRegion</key>
   <string>en</string>
   <key>CFBundleExecutable</key>

--- a/apple/xcode/osx/Outline/VpnExtension-Info.plist
+++ b/apple/xcode/osx/Outline/VpnExtension-Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.1</string>
+	<string>1.3.2</string>
 	<key>CFBundleVersion</key>
-	<string>20</string>
+	<string>21</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
 	<key>NSExtension</key>


### PR DESCRIPTION
* Increases the iOS and macOS clients app version and build numbers.
* Note that this release is intentionally at the same commit as `[ios|macos]-v.1.3.1. We are updating the app store description, which requires a release. This is not at the tip of `alalama-go-tun2socks` to prevent releasing a half-completed migration to the Go network stack - preventing us from shipping two copies of Shadowsocks libraries (libev & Go).