### PR TITLE
Pull updates from per-platform directories

### DIFF
--- a/src/electron/release_linux_action.sh
+++ b/src/electron/release_linux_action.sh
@@ -31,4 +31,4 @@ electron-builder \
   --config src/electron/electron-builder.json \
   --config.extraMetadata.version=$(scripts/semantic_version.sh -p linux) \
   --config.publish.provider=generic \
-  --config.publish.url=https://s3.amazonaws.com/outline-releases/client
+  --config.publish.url=https://s3.amazonaws.com/outline-releases/client/linux

--- a/src/electron/release_windows_action.sh
+++ b/src/electron/release_windows_action.sh
@@ -40,4 +40,4 @@ electron-builder \
   --config.extraMetadata.version=$(scripts/semantic_version.sh -p windows) \
   --config.win.certificateSubjectName='Jigsaw Operations LLC' \
   --config.publish.provider=generic \
-  --config.publish.url=https://s3.amazonaws.com/outline-releases/client
+  --config.publish.url=https://s3.amazonaws.com/outline-releases/client/windows


### PR DESCRIPTION
This corresponds with https://github.com/Jigsaw-Code/outline-releases/pull/133.  See there for rationale

We will need to merge both, then cut a release of the client, then wait for requests to client/foo to go to zero before stopping publishing to both locations.