### PR TITLE
Increase versions, build fixes for mobile beta release

### DIFF
--- a/apple/xcode/ios/Outline.xcodeproj/project.pbxproj
+++ b/apple/xcode/ios/Outline.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		FC28C299201BB4E9005FD743 /* OutlineVpn.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC28C297201BB4E9005FD743 /* OutlineVpn.swift */; };
 		FC28C29A201BB4F3005FD743 /* OutlineConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC28C295201BB4E9005FD743 /* OutlineConnection.swift */; };
 		FC28C2B32022268B005FD743 /* OutlineConnectionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC28C2B020222681005FD743 /* OutlineConnectionStore.swift */; };
+		FC8804E3235A4BE70072393B /* Tun2socks.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FC1ED84B220B8D8F0086CC4C /* Tun2socks.framework */; };
 		FC8C30DF1FA78FA9004262BE /* Sentry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FC8C30DE1FA78FA9004262BE /* Sentry.framework */; };
 		FC8C30E01FA78FA9004262BE /* Sentry.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FC8C30DE1FA78FA9004262BE /* Sentry.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		FC8C30F31FA7C2F4004262BE /* CocoaLumberjack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FC8C30EE1FA7C2D7004262BE /* CocoaLumberjack.framework */; };
@@ -42,8 +43,6 @@
 		FC8C31091FAA8032004262BE /* OutlineSentryLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC8C31081FAA8032004262BE /* OutlineSentryLogger.swift */; };
 		FC8C310B1FAA814A004262BE /* NetworkExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FC8C310A1FAA814A004262BE /* NetworkExtension.framework */; };
 		FC8C310C1FAA88FB004262BE /* NetworkExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FC8C310A1FAA814A004262BE /* NetworkExtension.framework */; };
-		FCDE2FA92326FCAC006C5B2C /* Tun2socks.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FC1ED84B220B8D8F0086CC4C /* Tun2socks.framework */; };
-		FCDE2FAE23270A59006C5B2C /* Tun2socks.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FC1ED84B220B8D8F0086CC4C /* Tun2socks.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -105,7 +104,6 @@
 				FC8C30E01FA78FA9004262BE /* Sentry.framework in Embed Frameworks */,
 				FC8C30F61FA7C2F4004262BE /* CocoaLumberjackSwift.framework in Embed Frameworks */,
 				FC8C30F41FA7C2F4004262BE /* CocoaLumberjack.framework in Embed Frameworks */,
-				FCDE2FAE23270A59006C5B2C /* Tun2socks.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -157,7 +155,6 @@
 		FC28C295201BB4E9005FD743 /* OutlineConnection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OutlineConnection.swift; path = "cordova-plugin-outline/OutlineConnection.swift"; sourceTree = "<group>"; };
 		FC28C297201BB4E9005FD743 /* OutlineVpn.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OutlineVpn.swift; path = "cordova-plugin-outline/OutlineVpn.swift"; sourceTree = "<group>"; };
 		FC28C2B020222681005FD743 /* OutlineConnectionStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OutlineConnectionStore.swift; path = Outline/Resources/vpn/OutlineConnectionStore.swift; sourceTree = SOURCE_ROOT; };
-		FC29A6A41FB522E1005E2599 /* Shadowsocks_iOS.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Shadowsocks_iOS.framework; path = "Outline/Plugins/cordova-plugin-outline/Shadowsocks_iOS.framework"; sourceTree = "<group>"; };
 		FC55AB411F4F960A0056F12C /* VpnExtension-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "VpnExtension-Info.plist"; path = "Outline/VpnExtension-Info.plist"; sourceTree = SOURCE_ROOT; };
 		FC8C30DE1FA78FA9004262BE /* Sentry.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sentry.framework; path = "Outline/Plugins/cordova-plugin-outline/Sentry.framework"; sourceTree = "<group>"; };
 		FC8C30EE1FA7C2D7004262BE /* CocoaLumberjack.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CocoaLumberjack.framework; path = "Outline/Plugins/cordova-plugin-outline/CocoaLumberjack.framework"; sourceTree = "<group>"; };
@@ -171,10 +168,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FCDE2FA92326FCAC006C5B2C /* Tun2socks.framework in Frameworks */,
 				FC8C30DF1FA78FA9004262BE /* Sentry.framework in Frameworks */,
 				301BF552109A68D80062928A /* libCordova.a in Frameworks */,
 				FC8C310C1FAA88FB004262BE /* NetworkExtension.framework in Frameworks */,
+				FC8804E3235A4BE70072393B /* Tun2socks.framework in Frameworks */,
 				FC8C30F51FA7C2F4004262BE /* CocoaLumberjackSwift.framework in Frameworks */,
 				1CE7466BA73B4CCB838EBE21 /* libz.tbd in Frameworks */,
 				FC8C30F31FA7C2F4004262BE /* CocoaLumberjack.framework in Frameworks */,
@@ -265,7 +262,6 @@
 			isa = PBXGroup;
 			children = (
 				FC1ED84B220B8D8F0086CC4C /* Tun2socks.framework */,
-				FC29A6A41FB522E1005E2599 /* Shadowsocks_iOS.framework */,
 				FC8C310A1FAA814A004262BE /* NetworkExtension.framework */,
 				941052A220F54953928FF2E2 /* libz.tbd */,
 				FC8C30EE1FA7C2D7004262BE /* CocoaLumberjack.framework */,

--- a/apple/xcode/ios/Outline/Outline-Info.plist
+++ b/apple/xcode/ios/Outline/Outline-Info.plist
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.2</string>
+	<string>1.3.3</string>
 	<key>CFBundleVersion</key>
-	<string>23</string>
+	<string>24</string>
   <key>CFBundleDevelopmentRegion</key>
   <string>English</string>
 	<key>CFBundleDisplayName</key>

--- a/apple/xcode/ios/Outline/VpnExtension-Info.plist
+++ b/apple/xcode/ios/Outline/VpnExtension-Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.2</string>
+	<string>1.3.3</string>
 	<key>CFBundleVersion</key>
-	<string>23</string>
+	<string>24</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/apple/xcode/osx/Outline.xcodeproj/project.pbxproj
+++ b/apple/xcode/osx/Outline.xcodeproj/project.pbxproj
@@ -53,9 +53,7 @@
 		FC8C30EB1FA7C0F6004262BE /* CocoaLumberjackSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FC8C30E51FA7C0E9004262BE /* CocoaLumberjackSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		FC8C30EC1FA7C106004262BE /* CocoaLumberjack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FC8C30E41FA7C0E9004262BE /* CocoaLumberjack.framework */; };
 		FC8C30FC1FA7DDCB004262BE /* OutlineSentryLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC8C30FB1FA7DDCB004262BE /* OutlineSentryLogger.swift */; };
-		FCDE2FAF23270AC1006C5B2C /* Tun2socks.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FC7B59BA223C585F00828002 /* Tun2socks.framework */; };
 		FCDE2FB023270B8C006C5B2C /* Tun2socks.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FC7B59BA223C585F00828002 /* Tun2socks.framework */; };
-		FCDE2FB123270B8C006C5B2C /* Tun2socks.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FC7B59BA223C585F00828002 /* Tun2socks.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -92,7 +90,6 @@
 				FC8C30DC1FA78E5E004262BE /* Sentry.framework in Embed Frameworks */,
 				FC8C30EB1FA7C0F6004262BE /* CocoaLumberjackSwift.framework in Embed Frameworks */,
 				FC8C30E91FA7C0F6004262BE /* CocoaLumberjack.framework in Embed Frameworks */,
-				FCDE2FB123270B8C006C5B2C /* Tun2socks.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -196,14 +193,13 @@
 				FC0799F92037545D00A1C822 /* ServiceManagement.framework in Frameworks */,
 				FC8C30EA1FA7C0F6004262BE /* CocoaLumberjackSwift.framework in Frameworks */,
 				70BD686318FFB04800A1EFCF /* libCordova.a in Frameworks */,
-				FCDE2FB023270B8C006C5B2C /* Tun2socks.framework in Frameworks */,
 				70BD686618FFB06500A1EFCF /* SystemConfiguration.framework in Frameworks */,
 				FC8C30E81FA7C0F6004262BE /* CocoaLumberjack.framework in Frameworks */,
 				70BD686718FFB06500A1EFCF /* WebKit.framework in Frameworks */,
 				70BD682718FFB02D00A1EFCF /* Cocoa.framework in Frameworks */,
 				FC8C30DB1FA78E5E004262BE /* Sentry.framework in Frameworks */,
 				FC5FF9501F3E1FD40032A745 /* NetworkExtension.framework in Frameworks */,
-				FCDE2FAF23270AC1006C5B2C /* Tun2socks.framework in Frameworks */,
+				FCDE2FB023270B8C006C5B2C /* Tun2socks.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/config.xml
+++ b/config.xml
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="org.outline.android.client" version="1.3.0" android-versionCode="26" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="org.outline.android.client" version="1.3.1" android-versionCode="29" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Outline</name>
     <description>
         Internet without borders (powered by Shadowsocks)

--- a/cordova-plugin-outline/android/scripts/copy_third_party.js
+++ b/cordova-plugin-outline/android/scripts/copy_third_party.js
@@ -19,6 +19,7 @@ const child_process = require('child_process');
 module.exports = function(context) {
   console.log('Copying Android third party source code');
   child_process.execSync('cp third_party/sentry-android/*.java plugins/cordova-plugin-outline/android/java/org/outline/log/');
+  child_process.execSync('mkdir -p plugins/cordova-plugin-outline/android/libs');
   child_process.execSync(
       `cp third_party/go-tun2socks/android/tun2socks.aar plugins/cordova-plugin-outline/android/libs/`);
   child_process.execSync(


### PR DESCRIPTION
* Note that the latest Android build number in production is 28.
* Fixes an Android build issue by creating a missing `libs` directory,.
* Fixes an Apple failure to strip symbols from the tun2socks framework by not embedding it. This seems to be an issue with Go/gomobile: https://github.com/golang/go/issues/28997.
