### PR TITLE
Fix type mismatches in OutlineEvent.

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "postcss-rtl": "^1.2.3",
     "posthtml-postcss": "^0.2.6",
     "tslint": "^5.12.0",
-    "typescript": "~3.1.0",
+    "typescript": "^3.6.4",
     "vinyl-source-stream": "^2.0.0",
     "xml2js": "^0.4.17"
   },

--- a/src/www/model/events.ts
+++ b/src/www/model/events.ts
@@ -60,8 +60,9 @@ export class EventQueue {
   }
 
   // Registers a listener for events of the type of the given constructor.
-  // tslint:disable-next-line: no-any
-  subscribe<T extends OutlineEvent>(eventConstructor: {new(...args: any[]): T}, listener: OutlineEventListener<T>) {
+  subscribe<T extends OutlineEvent>(
+      // tslint:disable-next-line: no-any
+      eventConstructor: {new(...args: any[]): T}, listener: OutlineEventListener<T>) {
     let listeners = this.listenersByEventType.get(eventConstructor.name);
     if (!listeners) {
       listeners = [];

--- a/yarn.lock
+++ b/yarn.lock
@@ -9429,10 +9429,10 @@ typedarray@^0.0.6, typedarray@~0.0.5:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@~3.1.0:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
-  integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
+typescript@^3.6.4:
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
+  integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
 
 typical@^2.6.0, typical@^2.6.1:
   version "2.6.1"


### PR DESCRIPTION
A parameter of type `(interface {}) => void` can't take a function of type
`(interface {param: some_type}) => void` as an argument.  I'm not sure why,
this seems like a bug in Typescript's type system, but this seems common
enough that I'd expect there's an explanation.

Luckily, all `OutlineEvent`s take `server: Server` as a parameter.  This creates
the issue, however, that we are trying to get the constructor of an
interface which only says it has a Server parameter -- not a constructor
which takes it.  So we create a `ServerConstructible `interface specifying
types which take Servers as parameters and have them publicly available,
and then get its constructor through `Object.getPrototypeOf()`

This error occurs on more recent versions of typescript than we were using.  This PR also upgrades Typescript version.

[Playground link demonstrating the issue](http://www.typescriptlang.org/play/?ssl=16&ssc=24&pln=1&pc=1#code/JYOwLgpgTgZghgYwgAgKIFsAOYCeyDeyAvgFAkIA2cAztcgJJYUToTh3BMtth0bZ58JZCOQIA9iGpgoAVwRhxUABSZZAIwrAEyagC5dM0AHMAlAVKkSuTCgAqcANYRq-XMgC8yZRANuc5h4AfMgAbuLAACYA3GQwsiAKwJLIDs7UjJjMrOBKPgaZ2TzUpgbhURZxCUkpMMpgBmku-uaEVnVNGVw5ilCmsSTxiWDJIMiQ3r5oWLilYRGRlZDKIBAA7gzdxcoARDum-WRAA)

[StackOverflow where I ask why this is the case](https://stackoverflow.com/questions/58458982/why-cant-a-parameter-of-function-type-take-an-argument-whose-parameters-impleme)

I also remove unused classes