### PR TITLE
iOS: fix remote packaging

### DIFF
--- a/apple/fastlane/Gemfile
+++ b/apple/fastlane/Gemfile
@@ -14,4 +14,4 @@
 
 source 'https://rubygems.org'
 
-gem 'fastlane', '~>2.84.0'
+gem 'fastlane', '~>2.140.0'

--- a/apple/scripts/install_fastlane.sh
+++ b/apple/scripts/install_fastlane.sh
@@ -36,9 +36,8 @@ shift $((OPTIND-1))
 
 PLATFORM_DIR=platforms/$PLATFORM/
 if [ ! -d $PLATFORM_DIR ]; then
-  # Generate the Xcode project through Cordova. Don't fail here; fastlane will
-  # configure and build the project.
-  yarn gulp build --platform=$PLATFORM --release || true
+  # Generate the Xcode project through Cordova.
+  yarn gulp setup --platform=$PLATFORM
 fi
 
 # Install the fastlane scripts and metadata.

--- a/apple/scripts/install_fastlane.sh
+++ b/apple/scripts/install_fastlane.sh
@@ -36,8 +36,9 @@ shift $((OPTIND-1))
 
 PLATFORM_DIR=platforms/$PLATFORM/
 if [ ! -d $PLATFORM_DIR ]; then
-  # Generate the Xcode project through Cordova.
-  yarn gulp build --platform=$PLATFORM --release
+  # Generate the Xcode project through Cordova. Don't fail here; fastlane will
+  # configure and build the project.
+  yarn gulp build --platform=$PLATFORM --release || true
 fi
 
 # Install the fastlane scripts and metadata.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -170,9 +170,8 @@ function cordovaCompile() {
   return runCommand(`cordova compile ${platform} ${compileArgs} ${releaseArgs} -- ${platformArgs}`);
 }
 
-const cordovaBuild = gulp.series(cordovaPrepare, xcode, cordovaCompile);
-
-const packageWithCordova = gulp.series(cordovaPlatformAdd, cordovaBuild);
+const setupWebApp = gulp.series(buildWebApp, transpileWebApp, writeEnvJson);
+const setupCordova = gulp.series(cordovaPlatformAdd, cordovaPrepare, xcode);
 
 //////////////////
 //////////////////
@@ -190,4 +189,5 @@ function writeEnvJson() {
       WEBAPP_OUT}/environment.json`);
 }
 
-exports.build = gulp.series(buildWebApp, transpileWebApp, writeEnvJson, packageWithCordova);
+exports.build = gulp.series(setupWebApp, setupCordova, cordovaCompile);
+exports.setup = gulp.series(setupWebApp, setupCordova);


### PR DESCRIPTION
* Fixes iOS packaging on Travis by only generating the Xcode project instead of attempting to build it. Currently this step fails because provisioning has not been configured through fastlane. 
* Updates fastlane to v2.140.0.