### PR TITLE
Remove outline (CSS) from focused server card UI elements

### DIFF
--- a/src/www/ui_components/server-card.html
+++ b/src/www/ui_components/server-card.html
@@ -40,6 +40,13 @@
         min-height: 300px;
       }
 
+      :focus {
+        /* Disable outline for focused elements; mainly affects the iOS WebView,
+         * where elements stay highlighted after user interaction.
+         */
+        outline: 0 !important;
+      }
+
       paper-card {
         width: 100%;
       }
@@ -116,7 +123,7 @@
           padding: 20% 0;
         }
       }
-      
+
     </style>
 
     <paper-card>


### PR DESCRIPTION
Fixes a bug in newer iOS webviews, where UI elements stay highlighted after user interaction.

![Screen Shot 2020-01-29 at 2 45 50 PM](https://user-images.githubusercontent.com/2132122/73392191-54ecd400-42a7-11ea-81d7-a8276fb2456c.png)
