### PR TITLE
Reverse connection animation motion

### DIFF
--- a/src/www/ui_components/server-connection-viz.html
+++ b/src/www/ui_components/server-connection-viz.html
@@ -26,7 +26,7 @@
           transform: rotate(0deg);
         }
         60%, 100% {
-          transform: rotate(360deg);
+          transform: rotate(-360deg);
         }
       }
       @keyframes rotate-backward-with-pause {


### PR DESCRIPTION
This fixes a pet peeve of mine: the connecting animation goes the wrong
way for what a radar sweep should look like!  Now the light part trails
the motion instead of leads it.

Video showing new rotation:

[![Demonstration of animation](https://img.youtube.com/vi/9WIVgDHZces/0.jpg)](https://youtu.be/9WIVgDHZces)