### PR TITLE
Only lint HTML files with prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "main": "build/electron/electron/index.js",
   "husky": {
     "hooks": {
-      "pre-commit": "yarn tslint --fix 'src/**/*.ts' && yarn git-clang-format && yarn pretty-quick --staged"
+      "pre-commit": "yarn tslint --fix 'src/**/*.ts' && yarn git-clang-format && yarn pretty-quick --staged --pattern '**/*.html'"
     }
   },
   "cordova": {


### PR DESCRIPTION
We don't want prettier to override tslint for TS files.