### PR TITLE
Migrate TAP device name detection to batch

### DIFF
--- a/src/electron/add_tap_device.bat
+++ b/src/electron/add_tap_device.bat
@@ -116,7 +116,7 @@ exit /b 0
 echo Testing that the network device "%~1" is visible to netsh...
 netsh interface ip show interfaces | find "%~1" >nul 2>&1
 if %errorlevel% equ 0 exit /b 0
-for /l %%N (1, 1, 6) do (
+for /l %%N in (1, 1, 6) do (
   echo Waiting... %%N
   :: timeout doesn't like the environment created by nsExec::ExecToStack and exits with:
   :: "ERROR: Input redirection is not supported, exiting the process immediately."

--- a/src/electron/add_tap_device.bat
+++ b/src/electron/add_tap_device.bat
@@ -51,18 +51,20 @@ echo Found TAP device name: "%TAP_NAME%"
 
 :: We've occasionally seen delays before netsh will "see" the new device, at least for
 :: purposes of configuring IP and DNS ("netsh interface show interface name=xxx" does not
-:: seem to be affected). Attempt to rename even if waiting timed out.
+:: seem to be affected).
 call :wait_for_device "%TAP_NAME%"
 
+:: Attempt to rename the device even if waiting timed out.
 netsh interface set interface name= "%TAP_NAME%" newname= "%DEVICE_NAME%"
 if %errorlevel% neq 0 (
   echo Could not rename TAP device. >&2
   exit /b 1
 )
 
-:: Wait for the new name to propagate to netsh. Attempt to configure even if waiting timed out.
+:: Wait for the new name to propagate to netsh.
 call :wait_for_device "%DEVICE_NAME%"
 
+:: Attempt to configure the device even if waiting timed out.
 :configure
 
 :: Try to enable the device, in case it's somehow been disabled.

--- a/src/electron/add_tap_device.bat
+++ b/src/electron/add_tap_device.bat
@@ -116,8 +116,8 @@ exit /b 0
 echo Testing that the network device "%~1" is visible to netsh...
 netsh interface ip show interfaces | find "%~1" >nul 2>&1
 if %errorlevel% equ 0 exit /b 0
-for /l %%n in (1, 1, 6) do (
-  echo Waiting... %%n
+for /l %%N (1, 1, 6) do (
+  echo Waiting... %%N
   :: timeout doesn't like the environment created by nsExec::ExecToStack and exits with:
   :: "ERROR: Input redirection is not supported, exiting the process immediately."
   waitfor /t 10 thisisnotarealsignalname >nul 2>&1

--- a/src/electron/add_tap_device.bat
+++ b/src/electron/add_tap_device.bat
@@ -51,7 +51,7 @@ echo Found TAP device name: "%TAP_NAME%"
 
 :: We've occasionally seen delays before netsh will "see" the new device, at least for
 :: purposes of configuring IP and DNS ("netsh interface show interface name=xxx" does not
-:: seem to be affected).
+:: seem to be affected). Attempt to rename even if waiting timed out.
 call :wait_for_device "%TAP_NAME%"
 
 netsh interface set interface name= "%TAP_NAME%" newname= "%DEVICE_NAME%"
@@ -60,7 +60,7 @@ if %errorlevel% neq 0 (
   exit /b 1
 )
 
-:: Wait for the new name to propagate to netsh.
+:: Wait for the new name to propagate to netsh. Attempt to configure even if waiting timed out.
 call :wait_for_device "%DEVICE_NAME%"
 
 :configure

--- a/src/electron/custom_install_steps.nsh
+++ b/src/electron/custom_install_steps.nsh
@@ -53,11 +53,7 @@ ${StrRep}
   ${EndIf}
   SetOutPath -
   File "${PROJECT_DIR}\src\electron\add_tap_device.bat"
-  ${If} ${RunningX64}
-    File /r "${PROJECT_DIR}\tools\find_tap_name\bin\amd64\find_tap_name.exe"
-  ${Else}
-    File /r "${PROJECT_DIR}\tools\find_tap_name\bin\386\find_tap_name.exe"
-  ${EndIf}
+  File "${PROJECT_DIR}\src\electron\find_tap_device_name.bat"
 
   ; OutlineService files, stopping the service first in case it's still running.
   nsExec::Exec "net stop OutlineService"

--- a/src/electron/find_tap_device_name.bat
+++ b/src/electron/find_tap_device_name.bat
@@ -34,26 +34,26 @@ if %errorlevel% neq 0 (
 
 set TIMESTAMP=0
 set NAME=
-for /f "tokens=*" %%k in ('type "%NET_ADAPTERS_FILE%"') do (
+for /f "tokens=*" %%K in ('type "%NET_ADAPTERS_FILE%"') do (
   :: Retrieve the adapter's network config ID.
-  set ADAPTER_KEY=%%k
-  for /f "tokens=3" %%i in ('reg query !ADAPTER_KEY! /v "NetCfgInstanceId"') do (
-    set NET_CONFIG_ID=%%i
+  set ADAPTER_KEY=%%K
+  for /f "tokens=3" %%I in ('reg query !ADAPTER_KEY! /v "NetCfgInstanceId"') do (
+    set NET_CONFIG_ID=%%I
   )
 
   :: Retrieve the adapter's install timestamp.
-  for /f "tokens=3" %%t in ('reg query !ADAPTER_KEY! /v "InstallTimeStamp"') do (
-    set ADAPTER_TIMESTAMP=%%t
+  for /f "tokens=3" %%T in ('reg query !ADAPTER_KEY! /v "InstallTimeStamp"') do (
+    set ADAPTER_TIMESTAMP=%%T
   )
 
   :: Retrieve the adapter's name.
   set ADAPTER_CONFIG_KEY=!NET_CONFIG_KEY!\!NET_CONFIG_ID!\Connection
-  for /f "tokens=3*" %%n in ('reg query !ADAPTER_CONFIG_KEY! /v "Name"') do (
-    :: If the name contains spaces our tokenization will store the rest of the name in %%o.
-    if [%%o] == [] (
-      set ADAPTER_NAME=%%n
+  for /f "tokens=3*" %%N in ('reg query !ADAPTER_CONFIG_KEY! /v "Name"') do (
+    :: If the name contains spaces our tokenization will store the rest of the name in %%O.
+    if [%%O] == [] (
+      set ADAPTER_NAME=%%N
     ) else (
-      set ADAPTER_NAME=%%n %%o
+      set ADAPTER_NAME=%%N %%O
     )
   )
 

--- a/src/electron/find_tap_device_name.bat
+++ b/src/electron/find_tap_device_name.bat
@@ -1,0 +1,80 @@
+:: Copyright 2020 The Outline Authors
+::
+:: Licensed under the Apache License, Version 2.0 (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+::
+::      http://www.apache.org/licenses/LICENSE-2.0
+::
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
+
+:: Queries the registry in order to retrieve the most recently installed TAP network adapter's name.
+:: Accepts a single argument, the name of an environment variable to store the adapter's name.
+:: Exits with a non-zero exit code on failure.
+:: Usage example: find_tap_name.bat TAP_NAME
+
+@echo off
+setlocal enabledelayedexpansion
+
+set NET_ADAPTERS_KEY=HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Class\{4D36E972-E325-11CE-BFC1-08002BE10318}
+set NET_CONFIG_KEY=HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Network\{4D36E972-E325-11CE-BFC1-08002BE10318}
+set NET_ADAPTERS_FILE="%tmp%\netadapters.txt"
+
+:: Find all network adapters that match the "tap0901" component ID and store their registry path in a file.
+:: Note that adapter keys are increasing four-digit integers, padded with leading zeros.
+reg query %NET_ADAPTERS_KEY% /s /f "tap0901" /e /d | findstr "HKEY.*\\[0-9][0-9][0-9][0-9]$" > %NET_ADAPTERS_FILE%
+if %errorlevel% neq 0 (
+  echo Could not find TAP network adapter in the registry. >&2
+  exit /b 1
+)
+
+set TIMESTAMP=0
+set NAME=
+for /f "tokens=*" %%k in ('type "%NET_ADAPTERS_FILE%"') do (
+  :: Retrieve the adapter's network config ID.
+  set ADAPTER_KEY=%%k
+  for /f "tokens=3" %%i in ('reg query !ADAPTER_KEY! /v "NetCfgInstanceId"') do (
+    set NET_CONFIG_ID=%%i
+  )
+
+  :: Retrieve the adapter's install timestamp.
+  for /f "tokens=3" %%t in ('reg query !ADAPTER_KEY! /v "InstallTimeStamp"') do (
+    set ADAPTER_TIMESTAMP=%%t
+  )
+
+  :: Retrieve the adapter's name.
+  set ADAPTER_CONFIG_KEY=!NET_CONFIG_KEY!\!NET_CONFIG_ID!\Connection
+  for /f "tokens=3*" %%n in ('reg query !ADAPTER_CONFIG_KEY! /v "Name"') do (
+    :: If the name contains spaces our tokenization will store the rest of the name in %%o.
+    if [%%o] == [] (
+      set ADAPTER_NAME=%%n
+    ) else (
+      set ADAPTER_NAME=%%n %%o
+    )
+  )
+
+  :: Ensure we found the adapter's install timestamp and name.
+  if not [!ADAPTER_TIMESTAMP!] == [] (
+    if not [!ADAPTER_NAME!] == [] (
+      echo Found adapter "!ADAPTER_NAME!", !ADAPTER_TIMESTAMP!
+      :: Store the adapter's name if it's the most recently installed one.
+      if !ADAPTER_TIMESTAMP! gtr !TIMESTAMP! (
+        set TIMESTAMP=!ADAPTER_TIMESTAMP!
+        set NAME=!ADAPTER_NAME!
+      )
+    )
+  )
+)
+
+if [!NAME!] == [] (
+  echo Could not find TAP adapter name. >&2
+  exit /b 1
+)
+echo TAP device name: "!NAME!"
+
+endlocal & set "%1=%NAME%"
+exit /b 0


### PR DESCRIPTION
- Migrates the TAP device name detection to a batch script following reports that the Go binaries fail to run on some environments.
- Waits for the TAP device to be visible to `netsh` after installing it and after renaming it. `netsh` not recognizing the adapter has been the leading cause of TAP install failures.
