### PR TITLE
Add gulp watch task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -229,15 +229,15 @@ function reloadAppOrBrowser(done) {
     platform === 'browser'
     && typeof watchReloadMacosBrowser === 'string'
   ) {
-    const appleScriptCommand = (
-      watchReloadMacosBrowser.includes('Safari') && (
-        'set URL of front document to (URL of front document)'
-      )
-      || (watchReloadMacosBrowser.includes('Chrom') || watchReloadMacosBrowser.includes('Edge')) && (
-        'reload active tab of window 1'
-      )
-      || null
-    )
+    const appleScriptCommand = (() => {
+      if (watchReloadMacosBrowser.includes('Safari')) {
+        return 'set URL of front document to (URL of front document)';
+      }
+      if (watchReloadMacosBrowser.includes('Chrom') || watchReloadMacosBrowser.includes('Edge')) {
+        return 'reload active tab of window 1';
+      }
+      return null;
+    })();
 
     if (typeof appleScriptCommand === 'string') {
       runCommand(`osascript -e 'tell app "${watchReloadMacosBrowser}" to ${appleScriptCommand}'`);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -142,11 +142,11 @@ const transpileWebApp = gulp.series(
 // *certain things won't behave as you'd expect*, notably cordova-custom-config.
 function cordovaPlatformAdd() {
   // "platform add" fails if the platform has already been added.
-  return runCommand(`test -d platforms/${platform} || cordova platform add ${platform}`);
+  return runCommand(`test -d platforms/${platform} || yarn cordova platform add ${platform}`);
 }
 
 function cordovaPrepare() {
-  return runCommand(`cordova prepare ${platform}`);
+  return runCommand(`yarn cordova prepare ${platform}`);
 }
 
 function xcode() {
@@ -162,12 +162,12 @@ function cordovaCompile() {
   // cordova-ios@5.0.0. See https://github.com/apache/cordova-ios/issues/404.
   const compileArgs = platform === 'ios' ? '--device --buildFlag="-UseModernBuildSystem=0"' : '';
   const releaseArgs = isRelease ? platform === 'android' ?
-                                  `--release -- --keystore=${gutil.env.KEYSTORE} ` +
+                                  `--release --keystore=${gutil.env.KEYSTORE} ` +
               `--storePassword=${gutil.env.STOREPASS} --alias=${gutil.env.KEYALIAS} ` +
               `--password=${gutil.env.KEYPASS}` :
                                   '--release' :
                                   '';
-  return runCommand(`cordova compile ${platform} ${compileArgs} ${releaseArgs} -- ${platformArgs}`);
+  return runCommand(`yarn cordova compile ${platform} ${compileArgs} ${releaseArgs} ${platformArgs}`);
 }
 
 const setupWebApp = gulp.series(buildWebApp, transpileWebApp, writeEnvJson);

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "gulp-util": "^3.0.8",
     "husky": "^1.3.1",
     "jasmine": "^3.0.0",
+    "node-notifier": "^6.0.0",
     "polymer-build": "^2.1.1",
     "postcss-rtl": "^1.2.3",
     "posthtml-postcss": "^0.2.6",

--- a/src/electron/watch_action.sh
+++ b/src/electron/watch_action.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -eux
+#
+# Copyright 2018 The Outline Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Builds the project in watch mode, recompiling TS files on change.
+# See https://www.typescriptlang.org/docs/handbook/compiler-options.html
+
+yarn do src/www/build
+
+tsc -p src/electron --watch --preserveWatchOutput

--- a/src/www/watch_action.sh
+++ b/src/www/watch_action.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -eux
+#
+# Copyright 2018 The Outline Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Builds the project in watch mode, recompiling TS files on change.
+# See https://www.typescriptlang.org/docs/handbook/compiler-options.html
+
+tsc -p src/www --watch --preserveWatchOutput

--- a/yarn.lock
+++ b/yarn.lock
@@ -4820,6 +4820,11 @@ graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6,
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.0.tgz#8d8fdc73977cb04104721cb53666c1ca64cd328b"
   integrity sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==
 
+growly@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
+  integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
+
 gulp-babel@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/gulp-babel/-/gulp-babel-7.0.1.tgz#b9c8e29fa376b36c57989db820fc1c1715bb47cb"
@@ -5774,6 +5779,11 @@ is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
+
+is-wsl@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.1.1.tgz#4a1c152d429df3d441669498e2486d3596ebaf1d"
+  integrity sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==
 
 is-yarn-global@^0.3.0:
   version "0.3.0"
@@ -6829,6 +6839,17 @@ no-case@^2.2.0:
   integrity sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==
   dependencies:
     lower-case "^1.1.1"
+
+node-notifier@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-6.0.0.tgz#cea319e06baa16deec8ce5cd7f133c4a46b68e12"
+  integrity sha512-SVfQ/wMw+DesunOm5cKqr6yDcvUTDl/yc97ybGHMrteNEY6oekXpNpS3lZwgLlwz0FLgHoiW28ZpmBHUDg37cw==
+  dependencies:
+    growly "^1.3.0"
+    is-wsl "^2.1.1"
+    semver "^6.3.0"
+    shellwords "^0.1.1"
+    which "^1.3.1"
 
 node-pre-gyp@^0.12.0:
   version "0.12.0"
@@ -8738,6 +8759,11 @@ shelljs@^0.7.0:
     glob "^7.0.0"
     interpret "^1.0.0"
     rechoir "^0.6.2"
+
+shellwords@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
+  integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
Covers some of #641 

This adds a new gulp watch task that watches for changes in `www/ui_components/*.html` and `www/app/*.js` and rebuilds affected parts of the code. It deliberately excludes parts of the rebuild process (e.g. transpileBowerComponents) to reduce the build time, and is meant for UI development.

- If `--platform=browser` and the `--reload-macos-browser="Browser Name'` argument is passed, it use AppleScript (macOS-only) to reload the front tab of the named browser
- If `--platform=android` and the `--reinstall-android-app` argument is passed, it uses `adb` commands to reinstall and reload the built Android APK on the attached device.
- If the `--notify` argument is passed, it uses [node-notifier](https://github.com/mikaelbr/node-notifier) to trigger a system notification when the rebuild is complete.

I made these changes to support development of our internal fork. Because of this, I‘ve only developed against the browser and Android platforms, and haven’t done thorough compatibility testing. I’m also not very familiar with a lot of the codebase, so it’s very possible (even likely) that I’m overlooking something.

Please let me know if I can help, and feel free to cut parts of the code (e.g. notifications or AppleScript browser reloading) if the use case is too esoteric.