### PR TITLE
Remove Sentry API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,13 @@ To build for Windows, run:
     yarn do src/electron/build
 
 Unlike the Android and Apple clients, the Windows build uses the Electron framework, rather than Cordova.
+
+## Error reporting
+
+To enable error reporting through [Sentry](https://sentry.io/) for local builds, run:
+``` bash
+export SENTRY_DSN=[Sentry development API key]
+[platform-specific build command]
+```
+
+Release builds on CI are configured with a production Sentry API key.

--- a/config.xml
+++ b/config.xml
@@ -120,12 +120,4 @@
         <icon src="resources/icons/osx/icon-512.png" width="512" height="512" />
         <icon src="resources/icons/osx/icon-1024.png" width="1024" height="1024" />
     </platform>
-
-    <!-- Sentry error reporting keys -->
-    <sentry>
-        <dev dsn="https://319145c481df41458bb6e84c1a99c9ff@sentry.io/159503" />
-        <release dsn="https://6a1e6e7371a64db59f5ba6c34a77d78c@sentry.io/159502" />
-        <dev-native dsn="https://319145c481df41458bb6e84c1a99c9ff:73cc3261d25e44ac90221e7d9ad30b24@sentry.io/159503" />
-        <release-native dsn="https://6a1e6e7371a64db59f5ba6c34a77d78c:568f6c78f9f94f91afba4aba05756001@sentry.io/159502" />
-    </sentry>
 </widget>

--- a/scripts/environment_json.sh
+++ b/scripts/environment_json.sh
@@ -74,6 +74,13 @@ function pull_from_osx_plist() {
   pull_from_plist "apple/xcode/osx/Outline/Outline-Info.plist" $1
 }
 
+function validate_env_vars() {
+  if [[ -z ${SENTRY_DSN:-} ]]; then
+    echo "SENTRY_DSN is undefined."
+    exit 1
+  fi
+}
+
 case $PLATFORM in
   android | browser)
     APP_VERSION=$(pull_from_config_xml 'result.widget.$["version"]')
@@ -94,10 +101,14 @@ case $PLATFORM in
   *) usage ;;
 esac
 
+if [[$TYPE == "release"]]; then
+  validate_env_vars
+fi
+
 cat << EOM
 {
   "APP_VERSION": "$APP_VERSION",
   "APP_BUILD_NUMBER": "$APP_BUILD_NUMBER",
-  "SENTRY_DSN": "$(pull_from_config_xml result.widget.sentry[0].$TYPE[0].$.dsn)"
+  "SENTRY_DSN": "${SENTRY_DSN:-}"
 }
 EOM

--- a/scripts/environment_json.sh
+++ b/scripts/environment_json.sh
@@ -98,7 +98,6 @@ cat << EOM
 {
   "APP_VERSION": "$APP_VERSION",
   "APP_BUILD_NUMBER": "$APP_BUILD_NUMBER",
-  "SENTRY_DSN": "$(pull_from_config_xml result.widget.sentry[0].$TYPE[0].$.dsn)",
-  "SENTRY_NATIVE_DSN": "$(pull_from_config_xml result.widget.sentry[0][\"$TYPE-native\"][0].$.dsn)"
+  "SENTRY_DSN": "$(pull_from_config_xml result.widget.sentry[0].$TYPE[0].$.dsn)"
 }
 EOM

--- a/scripts/environment_json.sh
+++ b/scripts/environment_json.sh
@@ -101,7 +101,7 @@ case $PLATFORM in
   *) usage ;;
 esac
 
-if [[$TYPE == "release"]]; then
+if [[ "${TYPE}" == "release" ]]; then
   validate_env_vars
 fi
 

--- a/src/electron/custom_install_steps.nsh
+++ b/src/electron/custom_install_steps.nsh
@@ -112,7 +112,7 @@ ${StrRep}
   ;    string that Sentry will like *and* can fit on one line, e.g.
   ;    "device not found\ncommand failed"; fortunately, StrFunc.nsh's StrNSISToIO does precisely
   ;    this.
-  ;  - RELEASE and SENTRY_DSN are defined in env.nsh which is generated at build time by
+  ;  - RELEASE and SENTRY_URL are defined in env.nsh which is generated at build time by
   ;    {package,release}_action.sh.
 
   ; TODO: Remove this once we figure out why/if breadcrumbs are being truncated.
@@ -139,7 +139,7 @@ ${StrRep}
     "breadcrumbs":[\
       {"timestamp":1, "message":"$FAILURE_MESSAGE"}\
     ]\
-  }' /TOSTACK ${SENTRY_DSN} /END
+  }' /TOSTACK ${SENTRY_URL} /END
 
   Quit
 

--- a/src/electron/package_windows_action.sh
+++ b/src/electron/package_windows_action.sh
@@ -16,11 +16,10 @@
 
 yarn do src/electron/package_common
 
-# TODO: Share code with environment_json.sh (this is the dev/debug Sentry DSN).
 # TODO: Move env.sh to build/electron/.
 cat > build/env.nsh << EOF
 !define RELEASE "$(scripts/semantic_version.sh -p dev)"
-!define SENTRY_DSN "https://sentry.io/api/159503/store/?sentry_version=7&sentry_key=319145c481df41458bb6e84c1a99c9ff"
+!define SENTRY_DSN "${SENTRY_DSN:-}"
 EOF
 
 electron-builder \

--- a/src/electron/package_windows_action.sh
+++ b/src/electron/package_windows_action.sh
@@ -17,7 +17,8 @@
 yarn do src/electron/package_common
 
 if [[ -n ${SENTRY_DSN:-} ]]; then
-  # Build the Sentry URL for the installer by parsing the API key and project ID from $SENTRY_DSN.
+  # Build the Sentry URL for the installer by parsing the API key and project ID from $SENTRY_DSN,
+  # which has the following format: https://[API_KEY]@sentry.io/[PROJECT_ID].
   readonly SENTRY_URL="https://sentry.io/api/$(echo $SENTRY_DSN | awk -F/ '{print $4}')/store/?sentry_version=7&sentry_key=$(echo $SENTRY_DSN | awk -F/ '{print substr($3, 0, 32)}')"
 fi
 

--- a/src/electron/package_windows_action.sh
+++ b/src/electron/package_windows_action.sh
@@ -18,8 +18,10 @@ yarn do src/electron/package_common
 
 if [[ -n ${SENTRY_DSN:-} ]]; then
   # Build the Sentry URL for the installer by parsing the API key and project ID from $SENTRY_DSN,
-  # which has the following format: https://[API_KEY]@sentry.io/[PROJECT_ID].
-  readonly SENTRY_URL="https://sentry.io/api/$(echo $SENTRY_DSN | awk -F/ '{print $4}')/store/?sentry_version=7&sentry_key=$(echo $SENTRY_DSN | awk -F/ '{print substr($3, 0, 32)}')"
+  # which has the following format: https://[32_CHAR_API_KEY]@sentry.io/[PROJECT_ID].
+  readonly API_KEY=$(echo $SENTRY_DSN | awk -F/ '{print substr($3, 0, 32)}')
+  readonly PROJECT_ID=$(echo $SENTRY_DSN | awk -F/ '{print $4}')
+  readonly SENTRY_URL="https://sentry.io/api/$PROJECT_ID/store/?sentry_version=7&sentry_key=$API_KEY"
 fi
 
 # TODO: Move env.sh to build/electron/.

--- a/src/electron/package_windows_action.sh
+++ b/src/electron/package_windows_action.sh
@@ -16,10 +16,15 @@
 
 yarn do src/electron/package_common
 
+if [[ -n ${SENTRY_DSN:-} ]]; then
+  # Build the Sentry URL for the installer by parsing the API key and project ID from $SENTRY_DSN.
+  readonly SENTRY_URL="https://sentry.io/api/$(echo $SENTRY_DSN | awk -F/ '{print $4}')/store/?sentry_version=7&sentry_key=$(echo $SENTRY_DSN | awk -F/ '{print substr($3, 0, 32)}')"
+fi
+
 # TODO: Move env.sh to build/electron/.
 cat > build/env.nsh << EOF
 !define RELEASE "$(scripts/semantic_version.sh -p dev)"
-!define SENTRY_DSN "${SENTRY_DSN:-}"
+!define SENTRY_URL "${SENTRY_URL:-}"
 EOF
 
 electron-builder \

--- a/src/electron/release_windows_action.sh
+++ b/src/electron/release_windows_action.sh
@@ -23,7 +23,8 @@ yarn do src/electron/package_common
 
 scripts/environment_json.sh -r -p windows > www/environment.json
 
-# Build the Sentry URL for the installer by parsing the API key and project ID from $SENTRY_DSN.
+# Build the Sentry URL for the installer by parsing the API key and project ID from $SENTRY_DSN,
+# which has the following format: https://[API_KEY]@sentry.io/[PROJECT_ID].
 readonly SENTRY_URL="https://sentry.io/api/$(echo $SENTRY_DSN | awk -F/ '{print $4}')/store/?sentry_version=7&sentry_key=$(echo $SENTRY_DSN | awk -F/ '{print substr($3, 0, 32)}')"
 
 # TODO: Move env.sh to build/electron/.

--- a/src/electron/release_windows_action.sh
+++ b/src/electron/release_windows_action.sh
@@ -24,8 +24,10 @@ yarn do src/electron/package_common
 scripts/environment_json.sh -r -p windows > www/environment.json
 
 # Build the Sentry URL for the installer by parsing the API key and project ID from $SENTRY_DSN,
-# which has the following format: https://[API_KEY]@sentry.io/[PROJECT_ID].
-readonly SENTRY_URL="https://sentry.io/api/$(echo $SENTRY_DSN | awk -F/ '{print $4}')/store/?sentry_version=7&sentry_key=$(echo $SENTRY_DSN | awk -F/ '{print substr($3, 0, 32)}')"
+# which has the following format: https://[32_CHAR_API_KEY]@sentry.io/[PROJECT_ID].
+readonly API_KEY=$(echo $SENTRY_DSN | awk -F/ '{print substr($3, 0, 32)}')
+readonly PROJECT_ID=$(echo $SENTRY_DSN | awk -F/ '{print $4}')
+readonly SENTRY_URL="https://sentry.io/api/$PROJECT_ID/store/?sentry_version=7&sentry_key=$API_KEY"
 
 # TODO: Move env.sh to build/electron/.
 cat > build/env.nsh << EOF

--- a/src/electron/release_windows_action.sh
+++ b/src/electron/release_windows_action.sh
@@ -23,11 +23,10 @@ yarn do src/electron/package_common
 
 scripts/environment_json.sh -r -p windows > www/environment.json
 
-# TODO: Share code with environment_json.sh (this is the dev/debug Sentry DSN).
 # TODO: Move env.sh to build/electron/.
 cat > build/env.nsh << EOF
 !define RELEASE "$(scripts/semantic_version.sh -p windows)"
-!define SENTRY_DSN "https://sentry.io/api/159502/store/?sentry_version=7&sentry_key=6a1e6e7371a64db59f5ba6c34a77d78c"
+!define SENTRY_DSN "${SENTRY_DSN}"
 EOF
 
 # Publishing is disabled, updates are pulled from AWS. We use the generic provider instead of the S3

--- a/src/electron/release_windows_action.sh
+++ b/src/electron/release_windows_action.sh
@@ -23,10 +23,13 @@ yarn do src/electron/package_common
 
 scripts/environment_json.sh -r -p windows > www/environment.json
 
+# Build the Sentry URL for the installer by parsing the API key and project ID from $SENTRY_DSN.
+readonly SENTRY_URL="https://sentry.io/api/$(echo $SENTRY_DSN | awk -F/ '{print $4}')/store/?sentry_version=7&sentry_key=$(echo $SENTRY_DSN | awk -F/ '{print substr($3, 0, 32)}')"
+
 # TODO: Move env.sh to build/electron/.
 cat > build/env.nsh << EOF
 !define RELEASE "$(scripts/semantic_version.sh -p windows)"
-!define SENTRY_DSN "${SENTRY_DSN}"
+!define SENTRY_URL "${SENTRY_URL}"
 EOF
 
 # Publishing is disabled, updates are pulled from AWS. We use the generic provider instead of the S3

--- a/src/www/app/cordova_main.ts
+++ b/src/www/app/cordova_main.ts
@@ -45,9 +45,9 @@ class CordovaClipboard extends AbstractClipboard {
 
 // Adds reports from the (native) Cordova plugin.
 export class CordovaErrorReporter extends SentryErrorReporter {
-  constructor(appVersion: string, appBuildNumber: string, dsn: string, nativeDsn: string) {
+  constructor(appVersion: string, appBuildNumber: string, dsn: string) {
     super(appVersion, dsn, {'build.number': appBuildNumber});
-    cordova.plugins.outline.log.initialize(nativeDsn).catch(console.error);
+    cordova.plugins.outline.log.initialize(dsn).catch(console.error);
   }
 
   report(userFeedback: string, feedbackCategory: string, userEmail?: string): Promise<void> {
@@ -94,9 +94,8 @@ class CordovaPlatform implements OutlinePlatform {
 
   getErrorReporter(env: EnvironmentVariables) {
     return this.hasDeviceSupport() ?
-        new CordovaErrorReporter(
-            env.APP_VERSION, env.APP_BUILD_NUMBER, env.SENTRY_DSN, env.SENTRY_NATIVE_DSN) :
-        new SentryErrorReporter(env.APP_VERSION, env.SENTRY_DSN, {});
+        new CordovaErrorReporter(env.APP_VERSION, env.APP_BUILD_NUMBER, env.SENTRY_DSN || '') :
+        new SentryErrorReporter(env.APP_VERSION, env.SENTRY_DSN || '', {});
   }
 
   getUpdater() {

--- a/src/www/app/electron_main.ts
+++ b/src/www/app/electron_main.ts
@@ -29,7 +29,6 @@ import {OutlinePlatform} from './platform';
 import {AbstractUpdater, UpdateListener, Updater} from './updater';
 import {UrlInterceptor} from './url_interceptor';
 
-// Currently, proxying is only supported on Windows.
 const isWindows = os.platform() === 'win32';
 const isLinux = os.platform() === 'linux';
 const isOsSupported = isWindows || isLinux;

--- a/src/www/app/electron_main.ts
+++ b/src/www/app/electron_main.ts
@@ -106,7 +106,7 @@ main({
   getErrorReporter: (env: EnvironmentVariables) => {
     // Initialise error reporting in the main process.
     ipcRenderer.send('environment-info', {'appVersion': env.APP_VERSION, 'dsn': env.SENTRY_DSN});
-    return new ElectronErrorReporter(env.APP_VERSION, env.SENTRY_DSN);
+    return new ElectronErrorReporter(env.APP_VERSION, env.SENTRY_DSN || '');
   },
   getUpdater: () => {
     return new ElectronUpdater();

--- a/src/www/app/environment.ts
+++ b/src/www/app/environment.ts
@@ -16,15 +16,13 @@ export interface EnvironmentVariables {
   APP_VERSION: string;
   APP_BUILD_NUMBER: string;
   SENTRY_DSN: string;
-  SENTRY_NATIVE_DSN: string;
 }
 
 // Keep these in sync with the EnvironmentVariables interface above.
 const ENV_KEYS = {
   APP_VERSION: 'APP_VERSION',
   APP_BUILD_NUMBER: 'APP_BUILD_NUMBER',
-  SENTRY_DSN: 'SENTRY_DSN',
-  SENTRY_NATIVE_DSN: 'SENTRY_NATIVE_DSN'
+  SENTRY_DSN: 'SENTRY_DSN'
 };
 
 function validateEnvVars(json: {}) {

--- a/src/www/app/environment.ts
+++ b/src/www/app/environment.ts
@@ -18,21 +18,6 @@ export interface EnvironmentVariables {
   SENTRY_DSN: string;
 }
 
-// Keep these in sync with the EnvironmentVariables interface above.
-const ENV_KEYS = {
-  APP_VERSION: 'APP_VERSION',
-  APP_BUILD_NUMBER: 'APP_BUILD_NUMBER',
-  SENTRY_DSN: 'SENTRY_DSN'
-};
-
-function validateEnvVars(json: {}) {
-  for (const key in ENV_KEYS) {
-    if (!json.hasOwnProperty(key)) {
-      throw new Error(`Missing environment variable: ${key}`);
-    }
-  }
-}
-
 // According to http://caniuse.com/#feat=fetch fetch didn't hit iOS Safari
 // until v10.3 released 3/26/17, so use XMLHttpRequest instead.
 export const onceEnvVars: Promise<EnvironmentVariables> = new Promise((resolve, reject) => {
@@ -40,7 +25,6 @@ export const onceEnvVars: Promise<EnvironmentVariables> = new Promise((resolve, 
   xhr.onload = () => {
     try {
       const json = JSON.parse(xhr.responseText);
-      validateEnvVars(json);
       console.debug('Resolving with envVars:', json);
       resolve(json as EnvironmentVariables);
     } catch (err) {

--- a/src/www/app/environment.ts
+++ b/src/www/app/environment.ts
@@ -15,7 +15,7 @@
 export interface EnvironmentVariables {
   APP_VERSION: string;
   APP_BUILD_NUMBER: string;
-  SENTRY_DSN: string;
+  SENTRY_DSN: string|undefined;
 }
 
 // According to http://caniuse.com/#feat=fetch fetch didn't hit iOS Safari


### PR DESCRIPTION
- Removes development and production Sentry API keys from the repository.
- Removes the now deprecated native Sentry DSN.
- Enables error reporting through a `SENTRY_DSN` environment variable.
- Added a new production Sentry API key to Travis in order to start deprecating the old keys.