### PR TITLE
Windows: surface TAP install error codes to user and sentry

### DIFF
--- a/src/electron/custom_install_steps.nsh
+++ b/src/electron/custom_install_steps.nsh
@@ -93,7 +93,7 @@ ${StrRep}
   submitsentryreport:
   MessageBox MB_OK "Sorry, we could not configure your system to connect to Outline. Please try \
     running the installer again. If you still cannot install Outline, please get in \
-    touch with us and let us know that the TAP device could not be installed."
+    touch with us and let us know that the TAP device failed to install with error code $0."
 
   ; Submit a Sentry error event.
   ;


### PR DESCRIPTION
* Defines error codes for `add_tap_device.bat`.
* Surfaces error codes  to the user (in the existing dialog) and in Sentry error reports (as the title).
  * Users will be able to contact support with more detailed information about the failure.
  * Sentry error reports will be grouped by error code, easing the overhead of determining error rates.
