### PR TITLE
Android: enable all orientations

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -30,7 +30,6 @@
 
     <!-- Android -->
     <platform name="android">
-        <preference name="orientation" value="portrait" />
         <preference name="SplashMaintainAspectRatio" value="true" />
 
         <icon density="ldpi" src="resources/icons/android/icon_mdpi.png" />


### PR DESCRIPTION
* Enables landscape and portrait orientations, which is the Cordova default for Android.
* Follow up to #778.

