### PR TITLE
Electron: init sentry only when DSN is defined

### DIFF
--- a/src/electron/index.ts
+++ b/src/electron/index.ts
@@ -407,7 +407,9 @@ app.on('browser-window-focus', () => {
 // Error reporting.
 // This config makes console (log/info/warn/error - no debug!) output go to breadcrumbs.
 ipcMain.on('environment-info', (event: Event, info: {appVersion: string, dsn: string}) => {
-  sentry.init({dsn: info.dsn, release: info.appVersion, maxBreadcrumbs: 100});
+  if (info.dsn) {
+    sentry.init({dsn: info.dsn, release: info.appVersion, maxBreadcrumbs: 100});
+  }
   // To clearly identify app restarts in Sentry.
   console.info(`Outline is starting`);
 });


### PR DESCRIPTION
- Fixes #781 by only initializing sentry in the Electron main process when the DSN is defined.
- The failure happens when the environment variable `SENTRY_DSN` is undefined - affecting development.