### PR TITLE
Export SENTRY_DSN to Android build Docker image

### DIFF
--- a/tools/build/build.sh
+++ b/tools/build/build.sh
@@ -50,7 +50,7 @@ if (( $# > 0 )); then
   readonly GIT_ROOT=$(git rev-parse --show-toplevel)
   # Rather than a working directory of something like "/worker", mirror
   # the path on the host so that symlink tricks work as expected.
-  docker run --rm -ti -v "$GIT_ROOT":"$GIT_ROOT" -w "$GIT_ROOT" $IMAGE_NAME "$@"
+  docker run --rm -ti -v "$GIT_ROOT":"$GIT_ROOT" -w "$GIT_ROOT" -e SENTRY_DSN=${SENTRY_DSN:-} $IMAGE_NAME "$@"
   # GNU stat uses -c for format, which BSD stat does not accept; it uses -f instead
   stat -c 2>&1 | grep -q illegal && STATFLAG="f" || STATFLAG="c"
   # TODO: Don't spin up a second container just to chown.


### PR DESCRIPTION
- Fixes release builds on the Android Docker image by making `SENTRY_DSN` available to the image.