### PR TITLE
Electron: init sentry only when DSN is defined cont.

### DIFF
--- a/src/www/app/electron_main.ts
+++ b/src/www/app/electron_main.ts
@@ -73,7 +73,9 @@ class ElectronUpdater extends AbstractUpdater {
 
 class ElectronErrorReporter implements OutlineErrorReporter {
   constructor(appVersion: string, privateDsn: string) {
-    sentry.init({dsn: privateDsn, release: appVersion});
+    if (privateDsn) {
+      sentry.init({dsn: privateDsn, release: appVersion});
+    }
   }
 
   report(userFeedback: string, feedbackCategory: string, userEmail?: string): Promise<void> {

--- a/src/www/app/error_reporter.ts
+++ b/src/www/app/error_reporter.ts
@@ -20,7 +20,9 @@ export interface OutlineErrorReporter {
 
 export class SentryErrorReporter implements OutlineErrorReporter {
   constructor(appVersion: string, dsn: string, private tags: {[id: string]: string;}) {
-    sentry.init({dsn, release: appVersion});
+    if (dsn) {
+      sentry.init({dsn, release: appVersion});
+    }
     this.setUpUnhandledRejectionListener();
   }
 


### PR DESCRIPTION
Don't init sentry if we don't have a DSN for it.

Continuation of #794, to fix #781

----

I could have introduced a boolean `gotSentry` to each class, so they can skip calling `sentry.captureEvent()` or `sentry.captureMessage()` if sentry was not initialised.

However it seems in electron at least this isn't necessary. Calls to `captureEvent()` appear to do nothing when sentry was not initialised.

I hope the same is true for Cordova (which calls multiple sentry functions) but I didn't test it.

But should you want a `gotSentry: true/false` implementation, I do have that code stashed.