### PR TITLE
Reduce server card size when there are multiple servers

### DIFF
--- a/src/www/ui_components/server-card.html
+++ b/src/www/ui_components/server-card.html
@@ -30,14 +30,6 @@
     <style>
       :host {
         display: block;
-        background: #efefef;
-        /*
-          Ballpark figure chosen to be comfortably more than
-          the combined height of the toolbar, button, and status.
-          Really only relevant for testing since virtually no
-          real Android device will be this short.
-        */
-        min-height: 300px;
       }
 
       :focus {
@@ -49,6 +41,10 @@
 
       paper-card {
         width: 100%;
+      }
+
+      paper-menu-button {
+        color: #5f6368;
       }
 
       paper-item {
@@ -68,9 +64,13 @@
         padding: 10% 0;
       }
 
+      .card-header server-connection-viz {
+        padding: 16px 0 0 16px;
+      }
+
       #serverInfo {
         flex: 1;
-        padding: 16px 0 0 20px;
+        padding: 16px 0 0 16px;
         font-size: 20px;
         /* Make the IP address copyable */
         -webkit-user-select: text; /* Safari */
@@ -106,8 +106,13 @@
       .card-actions {
         display: flex;
         align-items: center;
-        background-color: var(--paper-grey-50);
         border-radius: 0 0 2px 2px;
+        border-top: none;
+      }
+
+      .expanded .card-actions {
+        background-color: var(--paper-grey-50);
+        border-top: 1px solid #e8e8e8;
       }
 
       #connectButton {
@@ -125,6 +130,15 @@
         margin-right: auto;
       }
 
+      @media (max-width: 360px) {
+        #serverInfo {
+          font-size: 18px;
+        }
+        #serverName {
+          line-height: 24px;
+        }
+      }
+
       @media (min-height: 600px) {
         .card-content {
           padding: 20% 0;
@@ -132,8 +146,13 @@
       }
     </style>
 
-    <paper-card>
+    <paper-card class$="[[_computeExpandedClassName(expanded)]]">
       <div class="card-header">
+        <server-connection-viz
+          state="[[state]]"
+          root-path="[[rootPath]]"
+          hidden$="[[expanded]]"
+        ></server-connection-viz>
         <div id="serverInfo">
           <div id="serverName">[[serverName]]</div>
           <div id="serverHost">[[serverHost]]:[[serverPort]]</div>
@@ -151,7 +170,7 @@
           </paper-listbox>
         </paper-menu-button>
       </div>
-      <div class="card-content">
+      <div class="card-content" hidden$="[[!expanded]]">
         <div>
           <paper-button
             id="server-visualization-button"
@@ -159,7 +178,7 @@
             disabled$="[[connectButtonDisabled]]"
             noink
           >
-            <server-connection-viz state="[[state]]" root-path="[[rootPath]]"></server-connection-viz>
+            <server-connection-viz state="[[state]]" root-path="[[rootPath]]" expanded></server-connection-viz>
           </paper-button>
         </div>
         <div class$="status-message [[state]]">[[statusMessage]]</div>
@@ -179,6 +198,7 @@
       properties: {
         // Need to declare localize function passed in from parent, or else
         // localize() calls within the template won't be updated.
+        expanded: {type: Boolean, value: false},
         errorMessage: String,
         disabled: Boolean,
         localize: Function,
@@ -237,6 +257,9 @@
       },
       _computeConnectButtonDisabled: function(state) {
         return this.disabled || state === "CONNECTING" || state === "DISCONNECTING";
+      },
+      _computeExpandedClassName: function(expanded) {
+        return expanded ? "expanded" : "";
       },
       _onMenuItemPressed: function(evt, detail) {
         if (detail.selected === "forget") {

--- a/src/www/ui_components/server-connection-viz.html
+++ b/src/www/ui_components/server-connection-viz.html
@@ -120,32 +120,53 @@
 
       #sm,
       #sm-grey {
-        top: 60px;
-        left: 60px;
-        height: 40px;
-        width: 40px;
+        top: 16px;
+        left: 16px;
+        height: 16px;
+        width: 16px;
         z-index: 300;
       }
-
       #md,
       #md-grey {
-        top: 30px;
-        left: 30px;
-        height: 100px;
-        width: 100px;
+        top: 8px;
+        left: 8px;
+        height: 32px;
+        width: 32px;
         transition-delay: 250ms;
         z-index: 200;
       }
-
       #lg,
       #lg-grey,
       #lg-zero {
         top: 0;
         left: 0;
-        height: 160px;
-        width: 160px;
+        height: 48px;
+        width: 48px;
         transition-delay: 500ms;
         z-index: 100;
+      }
+
+      .expanded #sm,
+      .expanded #sm-grey {
+        top: 60px;
+        left: 60px;
+        height: 40px;
+        width: 40px;
+      }
+      .expanded #md,
+      .expanded #md-grey {
+        top: 30px;
+        left: 30px;
+        height: 100px;
+        width: 100px;
+      }
+      .expanded #lg,
+      .expanded #lg-grey,
+      .expanded #lg-zero {
+        top: 0;
+        left: 0;
+        height: 160px;
+        width: 160px;
       }
 
       #lg {
@@ -167,26 +188,49 @@
         z-index: 400;
       }
 
-      @media (min-height: 600px) {
+      @media (max-width: 360px) {
         #sm,
         #sm-grey {
+          top: 12px;
+          left: 12px;
+          height: 8px;
+          width: 8px;
+        }
+        #md,
+        #md-grey {
+          top: 8px;
+          left: 8px;
+          height: 16px;
+          width: 16px;
+        }
+        #lg,
+        #lg-grey,
+        #lg-zero {
+          top: 0;
+          left: 0;
+          height: 32px;
+          width: 32px;
+        }
+      }
+
+      @media (min-height: 600px) {
+        .expanded #sm,
+        .expanded #sm-grey {
           top: 72px;
           left: 72px;
           height: 48px;
           width: 48px;
         }
-
-        #md,
-        #md-grey {
+        .expanded #md,
+        .expanded #md-grey {
           top: 36px;
           left: 36px;
           height: 120px;
           width: 120px;
         }
-
-        #lg,
-        #lg-grey,
-        #lg-zero {
+        .expanded #lg,
+        .expanded #lg-grey,
+        .expanded #lg-zero {
           top: 0;
           left: 0;
           height: 192px;
@@ -195,7 +239,7 @@
       }
       /* rtl:end:ignore */
     </style>
-    <div id="container">
+    <div id="container" class$="[[_computeExpandedClassName(expanded)]]">
       <paper-ripple id="ripple" noink="" center=""></paper-ripple>
       <img id="sm-grey" src$="[[rootPath]]assets/disc_grey.png" class$="grey {{animationState}}" />
       <img id="sm" src$="[[rootPath]]assets/disc_color.png" class$="green {{animationState}}" />
@@ -221,6 +265,10 @@
           type: String,
           notify: true,
           value: "ZERO_STATE",
+        },
+        expanded: {
+          type: Boolean,
+          value: false,
         },
       },
       _onStateChanged: function _onStateChanged(newState) {
@@ -267,6 +315,9 @@
       },
       _isAnimating: function(state) {
         return state === "CONNECTING" || state === "DISCONNECTING" || state === "RECONNECTING";
+      },
+      _computeExpandedClassName: function(expanded) {
+        return expanded ? "expanded" : "";
       },
     });
   </script>

--- a/src/www/ui_components/server-connection-viz.html
+++ b/src/www/ui_components/server-connection-viz.html
@@ -82,52 +82,52 @@
         opacity: 1;
       }
 
-      #sm.CONNECTING,
-      #sm-grey.CONNECTING,
-      #sm.RECONNECTING,
-      #sm-grey.RECONNECTING {
+      #small.CONNECTING,
+      #small-grey.CONNECTING,
+      #small.RECONNECTING,
+      #small-grey.RECONNECTING {
         animation: rotate-with-pause 1.75s ease-out infinite;
       }
 
-      #md.CONNECTING,
-      #md-grey.CONNECTING,
-      #md.RECONNECTING,
-      #md-grey.RECONNECTING {
+      #medium.CONNECTING,
+      #medium-grey.CONNECTING,
+      #medium.RECONNECTING,
+      #medium-grey.RECONNECTING {
         animation: rotate-with-pause 1.75s ease-out 250ms infinite;
       }
 
-      #lg.CONNECTING,
-      #lg-grey.CONNECTING,
-      #lg.RECONNECTING,
-      #lg-grey.RECONNECTING {
+      #large.CONNECTING,
+      #large-grey.CONNECTING,
+      #large.RECONNECTING,
+      #large-grey.RECONNECTING {
         animation: rotate-with-pause 1.75s ease-out 500ms infinite;
       }
 
-      #sm.DISCONNECTING,
-      #sm-grey.DISCONNECTING {
+      #small.DISCONNECTING,
+      #small-grey.DISCONNECTING {
         animation: rotate-backward-with-pause 1.75s ease-out infinite;
       }
 
-      #md.DISCONNECTING,
-      #md-grey.DISCONNECTING {
+      #medium.DISCONNECTING,
+      #medium-grey.DISCONNECTING {
         animation: rotate-backward-with-pause 1.75s ease-out 250ms infinite;
       }
 
-      #lg.DISCONNECTING,
-      #lg-grey.DISCONNECTING {
+      #large.DISCONNECTING,
+      #large-grey.DISCONNECTING {
         animation: rotate-backward-with-pause 1.75s ease-out 500ms infinite;
       }
 
-      #sm,
-      #sm-grey {
+      #small,
+      #small-grey {
         top: 16px;
         left: 16px;
         height: 16px;
         width: 16px;
         z-index: 300;
       }
-      #md,
-      #md-grey {
+      #medium,
+      #medium-grey {
         top: 8px;
         left: 8px;
         height: 32px;
@@ -135,9 +135,9 @@
         transition-delay: 250ms;
         z-index: 200;
       }
-      #lg,
-      #lg-grey,
-      #lg-zero {
+      #large,
+      #large-grey,
+      #large-zero {
         top: 0;
         left: 0;
         height: 48px;
@@ -146,38 +146,38 @@
         z-index: 100;
       }
 
-      .expanded #sm,
-      .expanded #sm-grey {
+      .expanded #small,
+      .expanded #small-grey {
         top: 60px;
         left: 60px;
         height: 40px;
         width: 40px;
       }
-      .expanded #md,
-      .expanded #md-grey {
+      .expanded #medium,
+      .expanded #medium-grey {
         top: 30px;
         left: 30px;
         height: 100px;
         width: 100px;
       }
-      .expanded #lg,
-      .expanded #lg-grey,
-      .expanded #lg-zero {
+      .expanded #large,
+      .expanded #large-grey,
+      .expanded #large-zero {
         top: 0;
         left: 0;
         height: 160px;
         width: 160px;
       }
 
-      #lg {
+      #large {
         position: relative;
       }
 
-      #lg-zero {
+      #large-zero {
         opacity: 0;
       }
 
-      #lg-zero.ZERO_STATE {
+      #large-zero.ZERO_STATE {
         opacity: 1;
       }
 
@@ -189,23 +189,23 @@
       }
 
       @media (max-width: 360px) {
-        #sm,
-        #sm-grey {
+        #small,
+        #small-grey {
           top: 12px;
           left: 12px;
           height: 8px;
           width: 8px;
         }
-        #md,
-        #md-grey {
+        #medium,
+        #medium-grey {
           top: 8px;
           left: 8px;
           height: 16px;
           width: 16px;
         }
-        #lg,
-        #lg-grey,
-        #lg-zero {
+        #large,
+        #large-grey,
+        #large-zero {
           top: 0;
           left: 0;
           height: 32px;
@@ -214,23 +214,23 @@
       }
 
       @media (min-height: 600px) {
-        .expanded #sm,
-        .expanded #sm-grey {
+        .expanded #small,
+        .expanded #small-grey {
           top: 72px;
           left: 72px;
           height: 48px;
           width: 48px;
         }
-        .expanded #md,
-        .expanded #md-grey {
+        .expanded #medium,
+        .expanded #medium-grey {
           top: 36px;
           left: 36px;
           height: 120px;
           width: 120px;
         }
-        .expanded #lg,
-        .expanded #lg-grey,
-        .expanded #lg-zero {
+        .expanded #large,
+        .expanded #large-grey,
+        .expanded #large-zero {
           top: 0;
           left: 0;
           height: 192px;
@@ -241,13 +241,13 @@
     </style>
     <div id="container" class$="[[_computeExpandedClassName(expanded)]]">
       <paper-ripple id="ripple" noink="" center=""></paper-ripple>
-      <img id="sm-grey" src$="[[rootPath]]assets/disc_grey.png" class$="grey {{animationState}}" />
-      <img id="sm" src$="[[rootPath]]assets/disc_color.png" class$="green {{animationState}}" />
-      <img id="md-grey" src$="[[rootPath]]assets/disc_grey.png" class$="grey {{animationState}}" />
-      <img id="md" src$="[[rootPath]]assets/disc_color.png" class$="green {{animationState}}" />
-      <img id="lg-grey" src$="[[rootPath]]assets/disc_grey.png" class$="grey {{animationState}}" />
-      <img id="lg-zero" src$="[[rootPath]]assets/disc_empty.png" class$="{{state}}" />
-      <img id="lg" src$="[[rootPath]]assets/disc_color.png" class$="green {{animationState}}" />
+      <img id="small-grey" src$="[[rootPath]]assets/disc_grey.png" class$="grey {{animationState}}" />
+      <img id="small" src$="[[rootPath]]assets/disc_color.png" class$="green {{animationState}}" />
+      <img id="medium-grey" src$="[[rootPath]]assets/disc_grey.png" class$="grey {{animationState}}" />
+      <img id="medium" src$="[[rootPath]]assets/disc_color.png" class$="green {{animationState}}" />
+      <img id="large-grey" src$="[[rootPath]]assets/disc_grey.png" class$="grey {{animationState}}" />
+      <img id="large-zero" src$="[[rootPath]]assets/disc_empty.png" class$="{{state}}" />
+      <img id="large" src$="[[rootPath]]assets/disc_color.png" class$="green {{animationState}}" />
     </div>
   </template>
   <script>

--- a/src/www/ui_components/server-list.html
+++ b/src/www/ui_components/server-list.html
@@ -53,6 +53,7 @@
         disabled="[[item.errorMessageId]]"
         localize="[[localize]]"
         root-path="[[rootPath]]"
+        expanded="[[!hasMultipleServers]]"
       ></server-card>
     </template>
   </template>
@@ -66,6 +67,10 @@
         localize: Function,
         rootPath: String,
         servers: Array,
+        hasMultipleServers: {
+          type: Boolean,
+          computed: "_computeHasMultipleServers(servers)",
+        },
       },
       getServerCard: function(serverId) {
         var cards = this.shadowRoot.querySelectorAll("server-card");
@@ -75,6 +80,9 @@
           }
         }
         throw new Error(`Card for server ${serverId} not found`);
+      },
+      _computeHasMultipleServers: function(servers) {
+        return !!servers && servers.length > 1;
       },
     });
   </script>

--- a/src/www/ui_components/server-list.html
+++ b/src/www/ui_components/server-list.html
@@ -53,7 +53,7 @@
         disabled="[[item.errorMessageId]]"
         localize="[[localize]]"
         root-path="[[rootPath]]"
-        expanded="[[!hasMultipleServers]]"
+        expanded="[[hasSingleServer]]"
       ></server-card>
     </template>
   </template>
@@ -67,9 +67,9 @@
         localize: Function,
         rootPath: String,
         servers: Array,
-        hasMultipleServers: {
+        hasSingleServer: {
           type: Boolean,
-          computed: "_computeHasMultipleServers(servers)",
+          computed: "_computeHasSingleServer(servers)",
         },
       },
       getServerCard: function(serverId) {
@@ -81,8 +81,8 @@
         }
         throw new Error(`Card for server ${serverId} not found`);
       },
-      _computeHasMultipleServers: function(servers) {
-        return !!servers && servers.length > 1;
+      _computeHasSingleServer: function(servers) {
+        return !!servers && servers.length === 1;
       },
     });
   </script>

--- a/src/www/ui_components/servers-view.html
+++ b/src/www/ui_components/servers-view.html
@@ -86,7 +86,7 @@
       <div class="flex-column-container" hidden$="[[!shouldShowZeroState]]">
         <div class="flex-column-container">
           <paper-button noink on-tap="_requestPromptAddServer">
-            <server-connection-viz state="ZERO_STATE" root-path="[[rootPath]]"></server-connection-viz>
+            <server-connection-viz state="ZERO_STATE" root-path="[[rootPath]]" expanded></server-connection-viz>
             <div class="header">[[localize('server-add')]]</div>
             <div class="subtle">[[localize('server-add-zero-state-instructions')]]</div>
           </paper-button>


### PR DESCRIPTION
* Condenses the server card UI when there are more than one server.
  * Implements a responsive server list, with a threshold of 360px screen width.
* The UI remains unchanged if there are no servers (intro screen) or one server (full size single server card).
* [Demo video](https://drive.google.com/file/d/1cWrxUGm1m9zWQZQHq9-VbpMl-ZDivnzM/view?usp=sharing).