### PR TITLE
Fix app version not displaying

### DIFF
--- a/src/www/app/app.ts
+++ b/src/www/app/app.ts
@@ -70,7 +70,7 @@ export class App {
 
     this.syncServersToUI();
     this.syncConnectivityStateToServerCards();
-    rootEl.$.aboutView.version = environmentVars.APP_VERSION;
+    rootEl.appVersion = environmentVars.APP_VERSION;
 
     this.localize = this.rootEl.localize.bind(this.rootEl);
 

--- a/src/www/ui_components/app-root.html
+++ b/src/www/ui_components/app-root.html
@@ -269,7 +269,13 @@
           localize="[[localize]]"
         ></servers-view>
         <feedback-view name="feedback" id="feedbackView" localize="[[localize]]"></feedback-view>
-        <about-view name="about" id="aboutView" localize="[[localize]]" root-path="[[rootPath]]"></about-view>
+        <about-view
+          name="about"
+          id="aboutView"
+          localize="[[localize]]"
+          root-path="[[rootPath]]"
+          version="[[appVersion]]"
+        ></about-view>
         <language-view
           name="language"
           id="aboutView"
@@ -519,6 +525,10 @@
         useKeyIfMissing: {
           type: Boolean,
           value: true,
+        },
+        appVersion: {
+          type: String,
+          readonly: true,
         },
         page: {
           type: String,


### PR DESCRIPTION
- Previously, we set the app version directly on the about UI element. However, it seems like the property is not propagating to Polymer. As a result, the app version is not displayed in the about view.
- Fixes this issue by setting the app version on the root view and binding that property to the about view.