### PR TITLE
Increase Android version code

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="org.outline.android.client" version="1.4.0" android-versionCode="32" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="org.outline.android.client" version="1.4.0" android-versionCode="33" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Outline</name>
     <description>
         Internet without borders (powered by Shadowsocks)


### PR DESCRIPTION
- Android v1.4.0 has not been relased, but v1.4.0 (32) was uploaded to the Play Store.
- Increases the Android version code to 33 in order to upload and release v1.4.0 (master), including the app version display fix in #836.