### PR TITLE
Update cordova-osx

### DIFF
--- a/apple/xcode/osx/Outline/config.xml
+++ b/apple/xcode/osx/Outline/config.xml
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='utf-8'?>
+<widget android-versionCode="33" id="org.outline.android.client" version="1.4.0" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+    <feature name="LocalStorage">
+        <param name="osx-package" value="CDVLocalStorage" />
+    </feature>
+    <feature name="Device">
+        <param name="ios-package" value="CDVDevice" />
+    </feature>
+    <feature name="OutlinePlugin">
+        <param name="ios-package" value="OutlinePlugin" />
+        <param name="onload" value="true" />
+    </feature>
+    <feature name="Clipboard">
+        <param name="ios-package" value="CDVClipboard" />
+    </feature>
+    <name>Outline</name>
+    <description>
+        Internet without borders (powered by Shadowsocks)
+    </description>
+    <content src="cordova_index.html" />
+    <access origin="*" />
+    <allow-intent href="http://*/*" />
+    <allow-intent href="https://*/*" />
+    <icon height="16" src="resources/icons/osx/icon-16.png" width="16" />
+    <icon height="32" src="resources/icons/osx/icon-32.png" width="32" />
+    <icon height="64" src="resources/icons/osx/icon-64.png" width="64" />
+    <icon height="128" src="resources/icons/osx/icon-128.png" width="128" />
+    <icon height="256" src="resources/icons/osx/icon-256.png" width="256" />
+    <icon height="512" src="resources/icons/osx/icon-512.png" width="512" />
+    <icon height="1024" src="resources/icons/osx/icon-1024.png" width="1024" />
+    <preference name="AllowInlineMediaPlayback" value="true" />
+    <preference name="AllowWebViewNavigation" value="false" />
+    <preference name="BackupWebStorage" value="cloud" />
+    <preference name="DisallowOverscroll" value="false" />
+    <preference name="EnableViewportScale" value="false" />
+    <preference name="KeyboardDisplayRequiresUserAction" value="true" />
+    <preference name="MediaPlaybackRequiresUserAction" value="false" />
+    <preference name="android-minSdkVersion" value="22" />
+    <preference name="android-targetSdkVersion" value="29" />
+    <preference name="AndroidLaunchMode" value="singleInstance" />
+    <preference name="ShowSplashScreenSpinner" value="false" />
+    <preference name="deployment-target" value="10.11" />
+</widget>

--- a/apple/xcode/osx/osx.json
+++ b/apple/xcode/osx/osx.json
@@ -1,0 +1,79 @@
+{
+  "prepare_queue": {
+    "installed": [],
+    "uninstalled": []
+  },
+  "config_munge": {
+    "files": {
+      "config.xml": {
+        "parents": {
+          "/*": [
+            {
+              "xml": "<feature name=\"Device\"><param name=\"ios-package\" value=\"CDVDevice\" /></feature>",
+              "count": 1
+            },
+            {
+              "xml": "<feature name=\"OutlinePlugin\"><param name=\"ios-package\" value=\"OutlinePlugin\" /><param name=\"onload\" value=\"true\" /></feature>",
+              "count": 1
+            },
+            {
+              "xml": "<feature name=\"Clipboard\"><param name=\"ios-package\" value=\"CDVClipboard\" /></feature>",
+              "count": 1
+            }
+          ]
+        }
+      }
+    }
+  },
+  "installed_plugins": {
+    "cordova-custom-config": {},
+    "cordova-plugin-device": {},
+    "cordova-plugin-outline": {},
+    "cordova-plugin-whitelist": {},
+    "cordova-plugin-clipboard": {},
+    "cordova-webintent": {}
+  },
+  "dependent_plugins": {},
+  "modules": [
+    {
+      "id": "cordova-plugin-device.device",
+      "file": "plugins/cordova-plugin-device/www/device.js",
+      "pluginId": "cordova-plugin-device",
+      "clobbers": [
+        "device"
+      ]
+    },
+    {
+      "id": "cordova-plugin-outline.OutlinePlugin",
+      "file": "plugins/cordova-plugin-outline/outlinePlugin.js",
+      "pluginId": "cordova-plugin-outline",
+      "clobbers": [
+        "cordova.plugins.outline"
+      ]
+    },
+    {
+      "id": "cordova-plugin-clipboard.Clipboard",
+      "file": "plugins/cordova-plugin-clipboard/www/clipboard.js",
+      "pluginId": "cordova-plugin-clipboard",
+      "clobbers": [
+        "cordova.plugins.clipboard"
+      ]
+    },
+    {
+      "id": "cordova-webintent.WebIntent",
+      "file": "plugins/cordova-webintent/www/webintent.js",
+      "pluginId": "cordova-webintent",
+      "clobbers": [
+        "WebIntent"
+      ]
+    }
+  ],
+  "plugin_metadata": {
+    "cordova-custom-config": "5.1.0",
+    "cordova-plugin-device": "2.0.3",
+    "cordova-plugin-outline": "0.0.0",
+    "cordova-plugin-whitelist": "1.3.4",
+    "cordova-plugin-clipboard": "2.0.0",
+    "cordova-webintent": "2.0.0"
+  }
+}

--- a/apple/xcode/osx/www/cordova_plugins.js
+++ b/apple/xcode/osx/www/cordova_plugins.js
@@ -1,0 +1,44 @@
+cordova.define('cordova/plugin_list', function(require, exports, module) {
+  module.exports = [
+    {
+      "id": "cordova-plugin-device.device",
+      "file": "plugins/cordova-plugin-device/www/device.js",
+      "pluginId": "cordova-plugin-device",
+      "clobbers": [
+        "device"
+      ]
+    },
+    {
+      "id": "cordova-plugin-outline.OutlinePlugin",
+      "file": "plugins/cordova-plugin-outline/outlinePlugin.js",
+      "pluginId": "cordova-plugin-outline",
+      "clobbers": [
+        "cordova.plugins.outline"
+      ]
+    },
+    {
+      "id": "cordova-plugin-clipboard.Clipboard",
+      "file": "plugins/cordova-plugin-clipboard/www/clipboard.js",
+      "pluginId": "cordova-plugin-clipboard",
+      "clobbers": [
+        "cordova.plugins.clipboard"
+      ]
+    },
+    {
+      "id": "cordova-webintent.WebIntent",
+      "file": "plugins/cordova-webintent/www/webintent.js",
+      "pluginId": "cordova-webintent",
+      "clobbers": [
+        "WebIntent"
+      ]
+    }
+  ];
+  module.exports.metadata = {
+    "cordova-custom-config": "5.1.0",
+    "cordova-plugin-device": "2.0.3",
+    "cordova-plugin-outline": "0.0.0",
+    "cordova-plugin-whitelist": "1.3.4",
+    "cordova-plugin-clipboard": "2.0.0",
+    "cordova-webintent": "2.0.0"
+  };
+});

--- a/cordova-plugin-outline/apple/src/OutlineConnectivity.swift
+++ b/cordova-plugin-outline/apple/src/OutlineConnectivity.swift
@@ -59,7 +59,7 @@ class OutlineConnectivity: NSObject, GCDAsyncSocketDelegate {
         ai_addr: nil,
         ai_next: nil)
     var info: UnsafeMutablePointer<addrinfo>?
-    var err = getaddrinfo(ipv4Address, nil, &hints, &info)
+    let err = getaddrinfo(ipv4Address, nil, &hints, &info)
     if err != 0 {
       DDLogError("getaddrinfo failed \(String(describing: gai_strerror(err)))")
       return nil

--- a/cordova-plugin-outline/apple/src/OutlineSentryLogger.swift
+++ b/cordova-plugin-outline/apple/src/OutlineSentryLogger.swift
@@ -43,7 +43,16 @@ class OutlineSentryLogger: DDAbstractLogger {
     self.logsDirectory = containerUrl.appendingPathComponent("Logs").path
 
     DDLog.add(OutlineSentryLogger.sharedInstance)
-    DDLog.add(DDOSLogger.sharedInstance)
+    #if os(iOS)
+      DDLog.add(DDOSLogger.sharedInstance)
+    #else
+      if #available(OSX 10.12, *) {
+        DDLog.add(DDOSLogger.sharedInstance)
+      } else {
+        // Fallback on earlier versions
+        DDLog.add(DDASLLogger.sharedInstance)
+      }
+    #endif
     dynamicLogLevel = DDLogLevel.info
   }
 

--- a/cordova-plugin-outline/apple/vpn/PacketTunnelProvider.m
+++ b/cordova-plugin-outline/apple/vpn/PacketTunnelProvider.m
@@ -69,7 +69,15 @@ static NSDictionary *kVpnSubnetCandidates;  // Subnets to bind the VPN.
   id<DDLogFileManager> logFileManager = [[DDLogFileManagerDefault alloc]
                                          initWithLogsDirectory:logsDirectory];
   _fileLogger = [[DDFileLogger alloc] initWithLogFileManager:logFileManager];
+#if TARGET_OS_IPHONE
   [DDLog addLogger:[DDOSLogger sharedInstance]];
+#else
+  if (@available(macOS 10.12, *)) {
+    [DDLog addLogger:[DDOSLogger sharedInstance]];
+  } else {
+    [DDLog addLogger:[DDASLLogger sharedInstance]];
+  }
+#endif
   [DDLog addLogger:_fileLogger];
 
   _connectionStore = [[OutlineConnectionStore alloc] initWithAppGroup:appGroup];

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "cordova-android": "~8.0.0",
     "cordova-browser": "~6.0.0",
     "cordova-ios": "~6.1.0",
-    "cordova-osx": "~5.0.0",
+    "cordova-osx": "~6.0.0",
     "cordova-plugin-clipboard": "github:Jigsaw-Code/outline-cordova-plugin-clipboard#v2.0.0",
     "cordova-plugin-outline": "file:cordova-plugin-outline",
     "cordova-webintent": "github:cordova-misc/cordova-webintent#v2.0.0",
@@ -66,6 +66,7 @@
     "posthtml-postcss": "^0.2.6",
     "prettier": "^1.19.1",
     "pretty-quick": "^2.0.1",
+    "simple-plist": "^1.1.0",
     "tslint": "^5.12.0",
     "typescript": "^3.6.4",
     "underscore": "^1.10.2",
@@ -91,9 +92,9 @@
     },
     "platforms": [
       "browser",
-      "osx",
       "android",
-      "ios"
+      "ios",
+      "osx"
     ]
   },
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "do": "bash ./scripts/do_action.sh"
   },
   "comments": {
-    "sentry": "@sentry/electron depends on @sentry/browser; use @sentry/browser as a transitive dependency to avoid version mismatches that make the build fail. See: https://github.com/getsentry/sentry-javascript/issues/1853"
+    "sentry": "@sentry/electron depends on @sentry/browser; use @sentry/browser as a transitive dependency to avoid version mismatches that make the build fail. See: https://github.com/getsentry/sentry-javascript/issues/1853",
+    "codrova-osx@6.0.0": "Version-controlled platform config files at apple/xcode/osx/Outline/config.xml, apple/xcode/osx/osx.json, and apple/xcode/osx/www/cordova_plugins.js as a workaround for https://github.com/apache/cordova-osx/issues/106. Delete these files when the issue is fixed."
   },
   "dependencies": {
     "@sentry/electron": "1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3095,19 +3095,19 @@ cordova-lib@^10.0.0:
     stringify-package "^1.0.1"
     write-file-atomic "^3.0.3"
 
-cordova-osx@~5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/cordova-osx/-/cordova-osx-5.0.0.tgz#d0aec1537fe739e1d5bea784ec05714f327b325b"
-  integrity sha512-KuufKtncBwpO0VGBeGH6YXSpiEjE6f5aQtgJZONjOqJ9HFXGwuqbmukJK7Dv5a+/XQ9ZkQhh9CJDdn5HPDhU+g==
+cordova-osx@~6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/cordova-osx/-/cordova-osx-6.0.0.tgz#28aea6c9d3c86ec339a1dc1b4996aae4282cf0fc"
+  integrity sha512-WQTJSh0E2HymwIQF2mTGXYE8i8uG5RaRjE2CFJt/VXTn1xs/nnjcSsALsPLh7en2kv/N6YKe5bBesYYNULrWdQ==
   dependencies:
-    cordova-common "^3.1.0"
+    cordova-common "^4.0.0"
     nopt "^4.0.1"
     plist "^3.0.1"
     q "^1.4.1"
     shelljs "^0.5.3"
     underscore "^1.9.1"
     unorm "^1.4.1"
-    xcode "^2.0.0"
+    xcode "^3.0.1"
 
 "cordova-plugin-clipboard@github:Jigsaw-Code/outline-cordova-plugin-clipboard#v2.0.0":
   version "2.0.0"
@@ -9019,15 +9019,6 @@ simple-plist@^0.2.1:
     bplist-parser "0.1.1"
     plist "2.0.1"
 
-simple-plist@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/simple-plist/-/simple-plist-1.0.0.tgz#bed3085633b22f371e111f45d159a1ccf94b81eb"
-  integrity sha512-043L2rO80LVF7zfZ+fqhsEkoJFvW8o59rt/l4ctx1TJWoTx7/jkiS1R5TatD15Z1oYnuLJytzE7gcnnBuIPL2g==
-  dependencies:
-    bplist-creator "0.0.7"
-    bplist-parser "0.1.1"
-    plist "^3.0.1"
-
 simple-plist@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/simple-plist/-/simple-plist-1.1.0.tgz#8354ab63eb3922a054c78ce96c209c532e907a23"
@@ -10653,14 +10644,6 @@ xcode@^1.0.0:
   integrity sha512-hllHFtfsNu5WbVzj8KbGNdI3NgOYmTLZqyF4a9c9J1aGMhAdxmLLsXlpG0Bz8fEtKh6I3pyargRXN0ZlLpcF5w==
   dependencies:
     simple-plist "^0.2.1"
-    uuid "^3.3.2"
-
-xcode@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/xcode/-/xcode-2.0.0.tgz#134f1f94c26fbfe8a9aaa9724bfb2772419da1a2"
-  integrity sha512-5xF6RCjAdDEiEsbbZaS/gBRt3jZ/177otZcpoLCjGN/u1LrfgH7/Sgeeavpr/jELpyDqN2im3AKosl2G2W8hfw==
-  dependencies:
-    simple-plist "^1.0.0"
     uuid "^3.3.2"
 
 xcode@^3.0.1:


### PR DESCRIPTION
- Updates cordova-osx to v6.0.0.
  - Unlike cordova-ios, cordova-osx still uses WebView, so local storage migration is not necessary.
- Version-controls macOS plugin configuration files as a workround for a failure to restore plugins from `package.json`.
  - Reproduced this issue in a minimal macOS project; manually adding plugins results in the expected configuration.
  - I'm not yet sure if this is an issue with cordova-osx, cordova-cli or one of its dependencies, i.e. cordova-common, cordova-lib (note that all these had breaking updates). 
- Minor iOS compatibility fixes.
