### PR TITLE
Update android build docker image

### DIFF
--- a/tools/build/Dockerfile
+++ b/tools/build/Dockerfile
@@ -38,21 +38,23 @@ ENV CI=true
 # trial and error, old pinball machine parts, and various
 # Dockerfiles lying around Github. Bitrise, in particular,
 # maintains images with many useful hints:
-#   https://github.com/bitrise-docker/android 
+#   https://github.com/bitrise-docker/android
 
-# Android SDK ("command line tools only"):
-#   https://developer.android.com/studio/index.html#downloads
-# This is version 26.1.1.
-RUN wget -O /tmp/android-tools.zip https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip && \
-    mkdir /opt/android-sdk && \
-    unzip /tmp/android-tools.zip -d /opt/android-sdk && \
-    rm /tmp/android-tools.zip
-ENV PATH ${PATH}:/opt/android-sdk/tools/bin
-ENV ANDROID_HOME /opt/android-sdk
+# Download Android Command Line Tools:
+#   https://developer.android.com/studio/command-line
+# This is version 2.1.
+ENV ANDROID_SDK_ROOT /opt/android-sdk
+RUN cd /opt \
+    && wget -q https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip -O android-commandline-tools.zip \
+    && mkdir -p ${ANDROID_SDK_ROOT}/cmdline-tools \
+    && unzip -q android-commandline-tools.zip -d ${ANDROID_SDK_ROOT}/cmdline-tools \
+    && rm android-commandline-tools.zip
+
+ENV PATH ${PATH}:${ANDROID_SDK_ROOT}/platform-tools:${ANDROID_SDK_ROOT}/cmdline-tools/tools/bin
 
 # Android SDK Build Tools:
 #   https://developer.android.com/studio/releases/build-tools.html
 # To find the latest version's label:
 #   sdkmanager --list|grep build-tools
-ENV ANDROID_BUILD_TOOLS_VERSION 28.0.3
+ENV ANDROID_BUILD_TOOLS_VERSION 30.0.2
 RUN yes | sdkmanager "build-tools;${ANDROID_BUILD_TOOLS_VERSION}"

--- a/tools/build/build.sh
+++ b/tools/build/build.sh
@@ -14,7 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-readonly IMAGE_NAME="quay.io/outline/build-android:2019-02-01@sha256:83e3e5fa46926f1c4f87a59c185f5e17b3c870887931cd6358d81a357330fff3"
+readonly IMAGE_NAME="quay.io/outline/build-android:2020-09-10@sha256:c4922e575a41c6c02e89be243087e419c7a284b49e361b58e69f15d304fedd1a"
+
 BUILD=false
 PUBLISH=false
 


### PR DESCRIPTION
- Updates the Docker image used for building the Android client.
- Replaces the deprecated SDK tools with command line tools.
- Updates the Android build tools to v30.0.2.
  - Sets `ANDROID_SDK_ROOT` env var instead of the deprecated `ANDROID_HOME` env var.
- The image `quay.io/outline/build-android:2020-09-10` has been uploaded to [quay.io](https://quay.io/repository/outline/build-android?tab=tags).
- Tested that the Android client builds and runs successfully via CI after this change.