### PR TITLE
Install NDK (side by side) in Android docker build image

### DIFF
--- a/tools/build/Dockerfile
+++ b/tools/build/Dockerfile
@@ -57,4 +57,8 @@ ENV PATH ${PATH}:${ANDROID_SDK_ROOT}/platform-tools:${ANDROID_SDK_ROOT}/cmdline-
 # To find the latest version's label:
 #   sdkmanager --list|grep build-tools
 ENV ANDROID_BUILD_TOOLS_VERSION 30.0.2
-RUN yes | sdkmanager "build-tools;${ANDROID_BUILD_TOOLS_VERSION}"
+# NDK (side by side) version must be kept in sync with the default build tools NDK version.
+ENV NDK_VERSION 21.0.6113669
+RUN yes | sdkmanager \
+  "build-tools;${ANDROID_BUILD_TOOLS_VERSION}" \
+  "ndk;${NDK_VERSION}"

--- a/tools/build/build.sh
+++ b/tools/build/build.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-readonly IMAGE_NAME="quay.io/outline/build-android:2020-09-10@sha256:c4922e575a41c6c02e89be243087e419c7a284b49e361b58e69f15d304fedd1a"
+readonly IMAGE_NAME="quay.io/outline/build-android:2020-09-14@sha256:432b3ad1d7bfb247e8bda82e2943cbe06f7d07b6585e3f3d22df5706fc6b9ba1"
 
 BUILD=false
 PUBLISH=false


### PR DESCRIPTION
- Installs NDK v21.0.6113669, side by side to Android build tools v30.0.2, on the Android build docker image.
- Updates the Android build docker image.