### PR TITLE
iOS: downgrade go-tun2socks to v2.0.0

### DIFF
--- a/apple/xcode/ios/Outline/Outline-Info.plist
+++ b/apple/xcode/ios/Outline/Outline-Info.plist
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.0</string>
+	<string>1.5.0</string>
 	<key>CFBundleVersion</key>
-	<string>27</string>
+	<string>28</string>
   <key>CFBundleDevelopmentRegion</key>
   <string>English</string>
 	<key>CFBundleDisplayName</key>

--- a/apple/xcode/ios/Outline/VpnExtension-Info.plist
+++ b/apple/xcode/ios/Outline/VpnExtension-Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.0</string>
+	<string>1.5.0</string>
 	<key>CFBundleVersion</key>
-	<string>27</string>
+	<string>28</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/third_party/go-tun2socks/METADATA
+++ b/third_party/go-tun2socks/METADATA
@@ -11,8 +11,9 @@ third_party {
     value: "https://github.com/Jigsaw-Code/outline-go-tun2socks"
   }
   version: "2.1.2"
-  last_upgrade_date { year: 2020 month: 9 day: 14 }
+  last_upgrade_date { year: 2020 month: 9 day: 23 }
   local_modifications:
     "outline-go-tun2socks consumes go-tun2socks in order to build libraries "
     "and binaries for Outline platforms."
+    "The iOS framework has been downgraded to v2.0.0 due to memory consumption issues."
 }


### PR DESCRIPTION
- Downgrades the go-tun2socks iOS framework to v2.0.0 due to a significant increase in memory usage.
  - outline-go-tun2socks v2.1.* depends on Go 1.14, which seems to be the cause of the baseline memory increase: ~11MB vs ~9MB device idle on v2.0.0.
  - Does not roll back go-tun2socks for other platforms, since we haven't observed increased crash rates and iOS has a strict 15MB memory limit on the VPN process.
- Bumps the iOS minor version to account for the cordova-ios (WKWebview) update.

cc @fortuna