### PR TITLE
Update Outline Proxy Controller docker build

### DIFF
--- a/tools/outline_proxy_controller/Dockerfile
+++ b/tools/outline_proxy_controller/Dockerfile
@@ -12,5 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:cosmic
-RUN apt update && apt dist-upgrade -y && apt install -y build-essential cmake libboost-all-dev
+FROM ubuntu:focal
+RUN apt update && apt dist-upgrade -y
+# Preempt interactive tzdata prompt
+RUN DEBIAN_FRONTEND="noninteractive" TZ="America/New_York" apt-get -y install tzdata
+RUN apt install -y build-essential cmake libboost-all-dev

--- a/tools/outline_proxy_controller/Dockerfile
+++ b/tools/outline_proxy_controller/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:focal
+FROM ubuntu:20.04
 RUN apt update && apt dist-upgrade -y
 # Preempt interactive tzdata prompt
 RUN DEBIAN_FRONTEND="noninteractive" TZ="America/New_York" apt-get -y install tzdata

--- a/tools/outline_proxy_controller/outline_controller_server.cpp
+++ b/tools/outline_proxy_controller/outline_controller_server.cpp
@@ -27,7 +27,7 @@ using boost::asio::local::stream_protocol;
 
 void session::start() {
   auto self(shared_from_this());
-  boost::asio::spawn(strand_, [this, self](boost::asio::yield_context yield) {
+  boost::asio::spawn(executor_, [this, self](boost::asio::yield_context yield) {
     try {
       std::ostringstream response;
       std::string clientCommand, buffer;
@@ -144,9 +144,8 @@ OutlineControllerServer::OutlineControllerServer(boost::asio::io_context& io_con
   ::unlink(unix_socket_name.c_str());
   boost::asio::spawn(io_context, [&](boost::asio::yield_context yield) {
     stream_protocol::acceptor acceptor(io_context, stream_protocol::endpoint(unix_socket_name));
-    auto result =
-        chmod(unix_socket_name.c_str(),
-              S_IRWXU | S_IROTH | S_IWOTH);  // enables all user to read from and write into socket
+    chmod(unix_socket_name.c_str(),
+          S_IRWXU | S_IROTH | S_IWOTH);  // enables all user to read from and write into socket
 
     for (;;) {
       boost::system::error_code ec;

--- a/tools/outline_proxy_controller/outline_controller_server.h
+++ b/tools/outline_proxy_controller/outline_controller_server.h
@@ -55,7 +55,7 @@ class session : public std::enable_shared_from_this<session> {
   session(stream_protocol::socket sock,
           std::shared_ptr<OutlineProxyController> outlineProxyController)
       : socket_(std::move(sock)),
-        strand_(socket_.get_io_context()),
+        executor_(socket_.get_executor()),
         outlineProxyController_(outlineProxyController) {}
   /**
    * callback from async_accept, starts a new session when
@@ -77,7 +77,7 @@ class session : public std::enable_shared_from_this<session> {
   std::tuple<int, std::string, std::string> runClientCommand(std::string clientCommand);
 
   stream_protocol::socket socket_;
-  boost::asio::io_context::strand strand_;
+  boost::asio::executor executor_;
   std::shared_ptr<OutlineProxyController> outlineProxyController_;
 };
 

--- a/tools/outline_proxy_controller/outline_proxy_controller.h
+++ b/tools/outline_proxy_controller/outline_proxy_controller.h
@@ -189,11 +189,12 @@ class OutlineProxyController {
   const std::string c_normal_traffic_priority_metric = "10";
   const std::string c_proxy_priority_metric = "5";
 
+  // TODO: Configure these values at runtime.
   std::string tunInterfaceName = "outline-tun0";
   std::string tunInterfaceIp = "10.0.85.1";
   std::string tunInterfaceRouterIp = "10.0.85.2";
   std::string outlineServerIP;
-  std::string outlineDNSServer = "216.146.35.35";
+  std::string outlineDNSServer = "9.9.9.9";
 
   std::string clientLocalIP;
   std::string routingGatewayIP;


### PR DESCRIPTION
This updates the build from Ubuntu Cosmic (which is no longer available)
to Ubuntu Focal (supported until 2025).  This required removing use of
deprecated Boost API calls.

This PR also changes the default DNS server to better match the behavior of
other Outline clients.