### PR TITLE
Use async/await

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "pretty-quick": "^2.0.1",
     "simple-plist": "^1.1.0",
     "tslint": "^5.12.0",
-    "typescript": "^3.6.4",
+    "typescript": "^3.9.7",
     "underscore": "^1.10.2",
     "vinyl-source-stream": "^2.0.0",
     "xml2js": "^0.4.17"

--- a/src/types/ambient/outlinePlugin.d.ts
+++ b/src/types/ambient/outlinePlugin.d.ts
@@ -45,7 +45,7 @@ declare namespace cordova.plugins.outline {
     name?: string;
   }
 
-  // Represents a VPN tunnel to a remote server.
+  // Represents a VPN tunnel to a proxy server.
   class Tunnel {
     // Creates a new instance with |serverConfig|.
     // A sequential ID will be generated if |id| is absent.

--- a/src/www/app/app.ts
+++ b/src/www/app/app.ts
@@ -499,7 +499,6 @@ export class App {
 
   private syncConnectivityStateToServerCards() {
     for (const server of this.serverRepo.getAll()) {
-      // TODO(alalama): should we wait? thread safety?
       this.syncServerConnectivityState(server);
     }
   }

--- a/src/www/app/app.ts
+++ b/src/www/app/app.ts
@@ -190,14 +190,13 @@ export class App {
     }
   }
 
-  private pullClipboardText() {
-    this.clipboard.getContents().then(
-        (text: string) => {
-          this.handleClipboardText(text);
-        },
-        (e) => {
-          console.warn('cannot read clipboard, system may lack clipboard support');
-        });
+  private async pullClipboardText() {
+    try {
+      const text = await this.clipboard.getContents();
+      this.handleClipboardText(text);
+    } catch (e) {
+      console.warn('cannot read clipboard, system may lack clipboard support');
+    }
   }
 
   private showServerConnected(event: events.ServerConnected): void {
@@ -347,19 +346,21 @@ export class App {
     }
   }
 
-  private forgetServer(event: CustomEvent) {
+  private async forgetServer(event: CustomEvent) {
     const serverId = event.detail.serverId;
     const server = this.serverRepo.getById(serverId);
     if (!server) {
       console.error(`No server with id ${serverId}`);
       return this.showLocalizedError();
     }
-    const onceNotRunning = server.checkRunning().then((isRunning) => {
-      return isRunning ? this.disconnectServer(event) : Promise.resolve();
-    });
-    onceNotRunning.then(() => {
-      this.serverRepo.forget(serverId);
-    });
+    try {
+      if (await server.checkRunning()) {
+        await this.disconnectServer(event);
+      }
+    } catch (e) {
+      console.warn(`failed to disconnect from server to forget: ${e}`);
+    }
+    this.serverRepo.forget(serverId);
   }
 
   private renameServer(event: CustomEvent) {
@@ -368,7 +369,7 @@ export class App {
     this.serverRepo.rename(serverId, newName);
   }
 
-  private connectServer(event: CustomEvent): void {
+  private async connectServer(event: CustomEvent) {
     const serverId = event.detail.serverId;
     if (!serverId) {
       throw new Error(`connectServer event had no server ID`);
@@ -380,21 +381,20 @@ export class App {
     console.log(`connecting to server ${serverId}`);
 
     card.state = 'CONNECTING';
-    server.connect().then(
-        () => {
-          card.state = 'CONNECTED';
-          console.log(`connected to server ${serverId}`);
-          this.rootEl.showToast(this.localize('server-connected', 'serverName', server.name));
-          this.maybeShowAutoConnectDialog();
-        },
-        (e) => {
-          card.state = 'DISCONNECTED';
-          this.showLocalizedError(e);
-          console.error(`could not connect to server ${serverId}: ${e.name}`);
-          if (!(e instanceof errors.RegularNativeError)) {
-            this.errorReporter.report(`connection failure: ${e.name}`, 'connection-failure');
-          }
-        });
+    try {
+      await server.connect();
+      card.state = 'CONNECTED';
+      console.log(`connected to server ${serverId}`);
+      this.rootEl.showToast(this.localize('server-connected', 'serverName', server.name));
+      this.maybeShowAutoConnectDialog();
+    } catch (e) {
+      card.state = 'DISCONNECTED';
+      this.showLocalizedError(e);
+      console.error(`could not connect to server ${serverId}: ${e.name}`);
+      if (!(e instanceof errors.RegularNativeError)) {
+        this.errorReporter.report(`connection failure: ${e.name}`, 'connection-failure');
+      }
+    }
   }
 
   private maybeShowAutoConnectDialog() {
@@ -413,7 +413,7 @@ export class App {
     this.settings.set(SettingsKey.AUTO_CONNECT_DIALOG_DISMISSED, 'true');
   }
 
-  private disconnectServer(event: CustomEvent): void {
+  private async disconnectServer(event: CustomEvent) {
     const serverId = event.detail.serverId;
     if (!serverId) {
       throw new Error(`disconnectServer event had no server ID`);
@@ -425,38 +425,35 @@ export class App {
     console.log(`disconnecting from server ${serverId}`);
 
     card.state = 'DISCONNECTING';
-    server.disconnect().then(
-        () => {
-          card.state = 'DISCONNECTED';
-          console.log(`disconnected from server ${serverId}`);
-          this.rootEl.showToast(this.localize('server-disconnected', 'serverName', server.name));
-        },
-        (e) => {
-          card.state = 'CONNECTED';
-          this.showLocalizedError(e);
-          console.warn(`could not disconnect from server ${serverId}: ${e.name}`);
-        });
+    try {
+      await server.disconnect();
+      card.state = 'DISCONNECTED';
+      console.log(`disconnected from server ${serverId}`);
+      this.rootEl.showToast(this.localize('server-disconnected', 'serverName', server.name));
+    } catch (e) {
+      card.state = 'CONNECTED';
+      this.showLocalizedError(e);
+      console.warn(`could not disconnect from server ${serverId}: ${e.name}`);
+    }
   }
 
-  private submitFeedback(event: CustomEvent) {
+  private async submitFeedback(event: CustomEvent) {
     const formData = this.feedbackViewEl.getValidatedFormData();
     if (!formData) {
       return;
     }
     const {feedback, category, email} = formData;
     this.rootEl.$.feedbackView.submitting = true;
-    this.errorReporter.report(feedback, category, email)
-        .then(
-            () => {
-              this.rootEl.$.feedbackView.submitting = false;
-              this.rootEl.$.feedbackView.resetForm();
-              this.changeToDefaultPage();
-              this.rootEl.showToast(this.rootEl.localize('feedback-thanks'));
-            },
-            (err: {}) => {
-              this.rootEl.$.feedbackView.submitting = false;
-              this.showLocalizedError(new errors.FeedbackSubmissionError());
-            });
+    try {
+      await this.errorReporter.report(feedback, category, email);
+      this.rootEl.$.feedbackView.submitting = false;
+      this.rootEl.$.feedbackView.resetForm();
+      this.changeToDefaultPage();
+      this.rootEl.showToast(this.rootEl.localize('feedback-thanks'));
+    } catch (e) {
+      this.rootEl.$.feedbackView.submitting = false;
+      this.showLocalizedError(new errors.FeedbackSubmissionError());
+    }
   }
 
   // EventQueue event handlers:
@@ -502,30 +499,29 @@ export class App {
 
   private syncConnectivityStateToServerCards() {
     for (const server of this.serverRepo.getAll()) {
+      // TODO(alalama): should we wait? thread safety?
       this.syncServerConnectivityState(server);
     }
   }
 
-  private syncServerConnectivityState(server: Server) {
-    server.checkRunning()
-        .then((isRunning) => {
-          const card = this.serverListEl.getServerCard(server.id);
-          if (!isRunning) {
-            card.state = 'DISCONNECTED';
-            return;
-          }
-          server.checkReachable().then((isReachable) => {
-            if (isReachable) {
-              card.state = 'CONNECTED';
-            } else {
-              console.log(`Server ${server.id} reconnecting`);
-              card.state = 'RECONNECTING';
-            }
-          });
-        })
-        .catch((e) => {
-          console.error('Failed to sync server connectivity state', e);
-        });
+  private async syncServerConnectivityState(server: Server) {
+    try {
+      const isRunning = await server.checkRunning();
+      const card = this.serverListEl.getServerCard(server.id);
+      if (!isRunning) {
+        card.state = 'DISCONNECTED';
+        return;
+      }
+      const isReachable = await server.checkReachable();
+      if (isReachable) {
+        card.state = 'CONNECTED';
+      } else {
+        console.log(`Server ${server.id} reconnecting`);
+        card.state = 'RECONNECTING';
+      }
+    } catch (e) {
+      console.error('Failed to sync server connectivity state', e);
+    }
   }
 
   private registerUrlInterceptionListener(urlInterceptor: UrlInterceptor) {

--- a/src/www/app/cordova_main.ts
+++ b/src/www/app/cordova_main.ts
@@ -51,16 +51,8 @@ export class CordovaErrorReporter extends SentryErrorReporter {
   }
 
   async report(userFeedback: string, feedbackCategory: string, userEmail?: string) {
-    try {
-      await super.report(userFeedback, feedbackCategory, userEmail);
-    } catch (e) {
-      console.error(`failed to submit webview error report: ${e}`);
-    }
-    try {
-      await cordova.plugins.outline.log.send(sentry.lastEventId() || '');
-    } catch (e) {
-      console.error(`failed to submit native error report: ${e}`);
-    }
+    await super.report(userFeedback, feedbackCategory, userEmail);
+    await cordova.plugins.outline.log.send(sentry.lastEventId() || '');
   }
 }
 

--- a/src/www/app/cordova_main.ts
+++ b/src/www/app/cordova_main.ts
@@ -50,10 +50,17 @@ export class CordovaErrorReporter extends SentryErrorReporter {
     cordova.plugins.outline.log.initialize(dsn).catch(console.error);
   }
 
-  report(userFeedback: string, feedbackCategory: string, userEmail?: string): Promise<void> {
-    return super.report(userFeedback, feedbackCategory, userEmail).then(() => {
-      return cordova.plugins.outline.log.send(sentry.lastEventId() || '');
-    });
+  async report(userFeedback: string, feedbackCategory: string, userEmail?: string) {
+    try {
+      await super.report(userFeedback, feedbackCategory, userEmail);
+    } catch (e) {
+      console.error(`failed to submit webview error report: ${e}`);
+    }
+    try {
+      await cordova.plugins.outline.log.send(sentry.lastEventId() || '');
+    } catch (e) {
+      console.error(`failed to submit native error report: ${e}`);
+    }
   }
 }
 

--- a/src/www/app/cordova_main.ts
+++ b/src/www/app/cordova_main.ts
@@ -22,7 +22,7 @@ import {EventQueue} from '../model/events';
 import {AbstractClipboard, Clipboard, ClipboardListener} from './clipboard';
 import {EnvironmentVariables} from './environment';
 import {SentryErrorReporter} from './error_reporter';
-import {FakeOutlineTunnel} from './fake_connection';
+import {FakeOutlineTunnel} from './fake_tunnel';
 import {main} from './main';
 import {OutlineServer} from './outline_server';
 import {OutlinePlatform} from './platform';

--- a/src/www/app/electron_main.ts
+++ b/src/www/app/electron_main.ts
@@ -22,7 +22,7 @@ import {AbstractClipboard, Clipboard, ClipboardListener} from './clipboard';
 import {ElectronOutlineTunnel} from './electron_outline_tunnel';
 import {EnvironmentVariables} from './environment';
 import {OutlineErrorReporter} from './error_reporter';
-import {FakeOutlineTunnel} from './fake_connection';
+import {FakeOutlineTunnel} from './fake_tunnel';
 import {getLocalizationFunction, main} from './main';
 import {OutlineServer} from './outline_server';
 import {OutlinePlatform} from './platform';

--- a/src/www/app/electron_outline_tunnel.ts
+++ b/src/www/app/electron_outline_tunnel.ts
@@ -35,7 +35,7 @@ export class ElectronOutlineTunnel implements cordova.plugins.outline.Tunnel {
     });
   }
 
-  start(): Promise<void> {
+  async start() {
     if (this.running) {
       return Promise.resolve();
     }
@@ -44,31 +44,33 @@ export class ElectronOutlineTunnel implements cordova.plugins.outline.Tunnel {
       this.handleStatusChange(TunnelStatus.DISCONNECTED);
     });
 
-    return promiseIpc.send('start-proxying', {config: this.config, id: this.id})
-        .then(() => {
-          this.running = true;
-        })
-        .catch((e: errors.ErrorCode|Error) => {
-          if (typeof e === 'number') {
-            throw new errors.OutlinePluginError(e);
-          } else {
-            throw e;
-          }
-        });
+    try {
+      await promiseIpc.send('start-proxying', {config: this.config, id: this.id});
+      this.running = true;
+    } catch (e) {
+      if (typeof e === 'number') {
+        throw new errors.OutlinePluginError(e);
+      } else {
+        throw e;
+      }
+    }
   }
 
-  stop(): Promise<void> {
+  async stop() {
     if (!this.running) {
-      return Promise.resolve();
+      return;
     }
 
-    return promiseIpc.send('stop-proxying').then(() => {
+    try {
+      await promiseIpc.send('stop-proxying');
       this.running = false;
-    });
+    } catch (e) {
+      console.error(`Failed to stop tunnelL ${e}`);
+    }
   }
 
-  isRunning(): Promise<boolean> {
-    return Promise.resolve(this.running);
+  async isRunning(): Promise<boolean> {
+    return this.running;
   }
 
   isReachable(): Promise<boolean> {

--- a/src/www/app/electron_outline_tunnel.ts
+++ b/src/www/app/electron_outline_tunnel.ts
@@ -65,7 +65,7 @@ export class ElectronOutlineTunnel implements cordova.plugins.outline.Tunnel {
       await promiseIpc.send('stop-proxying');
       this.running = false;
     } catch (e) {
-      console.error(`Failed to stop tunnelL ${e}`);
+      console.error(`Failed to stop tunnel ${e}`);
     }
   }
 

--- a/src/www/app/fake_tunnel.ts
+++ b/src/www/app/fake_tunnel.ts
@@ -24,11 +24,11 @@ export class FakeOutlineTunnel implements cordova.plugins.outline.Tunnel {
   constructor(public config: cordova.plugins.outline.ServerConfig, public id: string) {}
 
   private playBroken() {
-    return this.config.name && this.config.name.toLowerCase().includes('broken');
+    return this.config.name?.toLowerCase().includes('broken');
   }
 
   private playUnreachable() {
-    return this.config.name && this.config.name.toLowerCase().includes('unreachable');
+    return this.config.name?.toLowerCase().includes('unreachable');
   }
 
   async start(): Promise<void> {

--- a/src/www/app/fake_tunnel.ts
+++ b/src/www/app/fake_tunnel.ts
@@ -28,40 +28,36 @@ export class FakeOutlineTunnel implements cordova.plugins.outline.Tunnel {
   }
 
   private playUnreachable() {
-    return !(this.config.name && this.config.name.toLowerCase().includes('unreachable'));
+    return this.config.name && this.config.name.toLowerCase().includes('unreachable');
   }
 
-  start(): Promise<void> {
+  async start(): Promise<void> {
     if (this.running) {
-      return Promise.resolve();
+      return;
     }
 
-    if (!this.playUnreachable()) {
-      return Promise.reject(new errors.OutlinePluginError(errors.ErrorCode.SERVER_UNREACHABLE));
+    if (this.playUnreachable()) {
+      throw new errors.OutlinePluginError(errors.ErrorCode.SERVER_UNREACHABLE);
     } else if (this.playBroken()) {
-      return Promise.reject(
-          new errors.OutlinePluginError(errors.ErrorCode.SHADOWSOCKS_START_FAILURE));
-    } else {
-      this.running = true;
-      return Promise.resolve();
+      throw new errors.OutlinePluginError(errors.ErrorCode.SHADOWSOCKS_START_FAILURE);
     }
+
+    this.running = true;
   }
 
-  stop(): Promise<void> {
+  async stop(): Promise<void> {
     if (!this.running) {
-      return Promise.resolve();
+      return;
     }
-
     this.running = false;
-    return Promise.resolve();
   }
 
-  isRunning(): Promise<boolean> {
-    return Promise.resolve(this.running);
+  async isRunning(): Promise<boolean> {
+    return this.running;
   }
 
-  isReachable(): Promise<boolean> {
-    return Promise.resolve(!this.playUnreachable());
+  async isReachable(): Promise<boolean> {
+    return !this.playUnreachable();
   }
 
   onStatusChange(listener: (status: TunnelStatus) => void): void {

--- a/src/www/app/main.ts
+++ b/src/www/app/main.ts
@@ -96,7 +96,6 @@ export function main(platform: OutlinePlatform) {
           },
           (e) => {
             onUnexpectedError(e);
-            throw e;
           });
 }
 

--- a/src/www/app/outline_server.ts
+++ b/src/www/app/outline_server.ts
@@ -61,22 +61,26 @@ export class OutlineServer implements PersistentServer {
     return this.config.host;
   }
 
-  connect(): Promise<void> {
-    return this.tunnel.start().catch((e) => {
+  async connect() {
+    try {
+      await this.tunnel.start();
+    } catch (e) {
       // e originates in "native" code: either Cordova or Electron's main process.
       // Because of this, we cannot assume "instanceof OutlinePluginError" will work.
       if (e.errorCode) {
         throw errors.fromErrorCode(e.errorCode);
       }
       throw e;
-    });
+    }
   }
 
-  disconnect(): Promise<void> {
-    return this.tunnel.stop().catch((e) => {
-      // TODO: None of the plugins currently return an ErrorCode on disconnection.
+  async disconnect() {
+    try {
+      await this.tunnel.stop();
+    } catch (e) {
+      // All the plugins treat disconnection errors as ErrorCode.UNEXPECTED.
       throw new errors.RegularNativeError();
-    });
+    }
   }
 
   checkRunning(): Promise<boolean> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9979,10 +9979,10 @@ typedarray@^0.0.6, typedarray@~0.0.5:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.6.4:
-  version "3.6.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
-  integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
+typescript@^3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 typical@^2.6.0, typical@^2.6.1:
   version "2.6.1"


### PR DESCRIPTION
- Replaces promise chains with async/await syntax.
- Catches previously uncaught promise rejections and stops throwing in `main`.