### PR TITLE
Increase Android version to 1.5.0 (35)

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="org.outline.android.client" version="1.4.0" android-versionCode="33" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="org.outline.android.client" version="1.5.0" android-versionCode="35" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Outline</name>
     <description>
         Internet without borders (powered by Shadowsocks)


### PR DESCRIPTION
- Bumps the Android client version to v1.5.0, build number 35 (to account for the latest beta release).
- Planning to release this (master) build to beta, in order to test running the VPN service on a separate process. When the release is promoted to production, we will update the Play Store assets to reflect the new branding.