### PR TITLE
Update Android and Windows DNS resolvers

### DIFF
--- a/cordova-plugin-outline/android/java/org/outline/vpn/VpnTunnel.java
+++ b/cordova-plugin-outline/android/java/org/outline/vpn/VpnTunnel.java
@@ -38,11 +38,9 @@ public class VpnTunnel {
   private static final String VPN_INTERFACE_NETMASK = "255.255.255.0";
   private static final String VPN_IPV6_NULL = null;  // No IPv6 support.
   private static final int VPN_INTERFACE_MTU = 1500;
-  // OpenDNS and Dyn IP addresses.
+  // OpenDNS, Cloudflare, and Quad9 DNS resolvers' IP addresses.
   private static final String[] DNS_RESOLVER_IP_ADDRESSES = {
-    "216.146.35.35", "216.146.36.36",
-    "208.67.222.222", "208.67.220.220"
-  };
+      "208.67.222.222", "208.67.220.220", "1.1.1.1", "9.9.9.9"};
   private static final String PRIVATE_LAN_BYPASS_SUBNETS_ID = "reserved_bypass_subnets";
   private static final int DNS_RESOLVER_PORT = 53;
   private static final int TRANSPARENT_DNS_ENABLED = 1;

--- a/src/electron/add_tap_device.bat
+++ b/src/electron/add_tap_device.bat
@@ -112,15 +112,15 @@ if %errorlevel% neq 0 (
 :: "own" set of DNS servers. Windows seems to use the DNS server(s) of the
 :: network device associated with the default gateway. This is good for us
 :: as it means we do not have to modify the DNS settings of any other network
-:: device in the system. Configure with OpenDNS and Dyn resolvers.
+:: device in the system. Configure with Cloudflare and Quad9 resolvers
 echo Configuring primary DNS...
-netsh interface ip set dnsservers %DEVICE_NAME% static address=208.67.222.222
+netsh interface ip set dnsservers %DEVICE_NAME% static address=1.1.1.1
 if %errorlevel% neq 0 (
   echo Could not configure TAP device primary DNS. >&2
   exit /b %ERROR_TAP_CONFIGURE_DNS%
 )
 echo Configuring secondary DNS...
-netsh interface ip add dnsservers %DEVICE_NAME% 216.146.35.35 index=2
+netsh interface ip add dnsservers %DEVICE_NAME% 9.9.9.9 index=2
 if %errorlevel% neq 0 (
   echo Could not configure TAP device secondary DNS. >&2
   exit /b %ERROR_TAP_CONFIGURE_DNS%


### PR DESCRIPTION
- Adds Cloudflare and Quad9 DNS resolvers to the Windows and Android clients (Apple and Linux clients' resolvers have been updated).
- Removes DYN resolvers since we have observed issues with DNS/TCP.