### PR TITLE
Use verbose logging in ss-local and tun2socks when in Debug mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "outline-client",
   "productName": "Outline",
-  "version": "0.1.0-TODOBEFOREPUSHREMOVE",
   "scripts": {
     "clean": "rm -rf build www node_modules platforms/* plugins/*",
     "do": "bash ./scripts/do_action.sh"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "outline-client",
   "productName": "Outline",
+  "version": "0.1.0-TODOBEFOREPUSHREMOVE",
   "scripts": {
     "clean": "rm -rf build www node_modules platforms/* plugins/*",
     "do": "bash ./scripts/do_action.sh"

--- a/src/electron/index.ts
+++ b/src/electron/index.ts
@@ -300,7 +300,7 @@ async function startVpn(config: ShadowsocksConfig, id: string, isAutoConnect = f
   }
 
   currentTunnel = new TunnelManager(config, isAutoConnect);
-  currentTunnel.setDebug(debugMode);
+  currentTunnel.enableDebugMode();
 
   currentTunnel.onceStopped.then(() => {
     console.log(`disconnected from ${id}`);

--- a/src/electron/index.ts
+++ b/src/electron/index.ts
@@ -300,6 +300,7 @@ async function startVpn(config: ShadowsocksConfig, id: string, isAutoConnect = f
   }
 
   currentTunnel = new TunnelManager(config, isAutoConnect);
+  currentTunnel.setDebug(debugMode);
 
   currentTunnel.onceStopped.then(() => {
     console.log(`disconnected from ${id}`);

--- a/src/electron/process_manager.ts
+++ b/src/electron/process_manager.ts
@@ -15,6 +15,7 @@
 import {ChildProcess, execSync, spawn} from 'child_process';
 import {powerMonitor} from 'electron';
 import {platform} from 'os';
+import {env} from 'process';
 
 import {TunnelStatus} from '../www/app/tunnel';
 import * as errors from '../www/model/errors';
@@ -336,6 +337,9 @@ class SsLocal extends ChildProcessHelper {
     args.push('-k', config.password || '');
     args.push('-m', config.method || '');
     args.push('-u');
+    if (env.OUTLINE_DEBUG === 'true') {
+      args.push('-v');
+    }
 
     this.launch(args);
   }
@@ -362,7 +366,7 @@ class Tun2socks extends ChildProcessHelper {
     args.push('--netif-ipaddr', TUN2SOCKS_VIRTUAL_ROUTER_IP);
     args.push('--netif-netmask', TUN2SOCKS_VIRTUAL_ROUTER_NETMASK);
     args.push('--socks-server-addr', `${this.proxyAddress}:${this.proxyPort}`);
-    args.push('--loglevel', 'error');
+    args.push('--loglevel', env.OUTLINE_DEBUG === 'true' ? 'debug' : 'error');
     args.push('--transparent-dns');
     if (isUdpEnabled) {
       args.push('--socks5-udp');

--- a/src/electron/process_manager.ts
+++ b/src/electron/process_manager.ts
@@ -14,9 +14,9 @@
 
 import {ChildProcess, execSync, spawn} from 'child_process';
 import {powerMonitor} from 'electron';
-import {basename} from 'path';
 import {platform} from 'os';
-import {env} from 'process';
+import * as path from 'path';
+import * as process from 'process';
 
 import {TunnelStatus} from '../www/app/tunnel';
 import * as errors from '../www/model/errors';
@@ -301,9 +301,11 @@ class ChildProcessHelper {
       }
     };
 
-    if (env.OUTLINE_DEBUG === 'true') {
-      this.process.stdout.on('data', (data) => console.log(`[STDOUT - ${basename(this.path)}]: ${data}`));
-      this.process.stderr.on('data', (data) => console.log(`[STDERR - ${basename(this.path)}]: ${data}`));
+    if (process.env.OUTLINE_DEBUG === 'true') {
+      this.process.stdout.on(
+          'data', (data) => console.log(`[STDOUT - ${path.basename(this.path)}]: ${data}`));
+      this.process.stderr.on(
+          'data', (data) => console.log(`[STDERR - ${path.basename(this.path)}]: ${data}`));
     }
 
     // We have to listen for both events: error means the process could not be launched and in that
@@ -343,7 +345,7 @@ class SsLocal extends ChildProcessHelper {
     args.push('-k', config.password || '');
     args.push('-m', config.method || '');
     args.push('-u');
-    if (env.OUTLINE_DEBUG === 'true') {
+    if (process.env.OUTLINE_DEBUG === 'true') {
       args.push('-v');
     }
 
@@ -372,7 +374,7 @@ class Tun2socks extends ChildProcessHelper {
     args.push('--netif-ipaddr', TUN2SOCKS_VIRTUAL_ROUTER_IP);
     args.push('--netif-netmask', TUN2SOCKS_VIRTUAL_ROUTER_NETMASK);
     args.push('--socks-server-addr', `${this.proxyAddress}:${this.proxyPort}`);
-    args.push('--loglevel', env.OUTLINE_DEBUG === 'true' ? 'debug' : 'error');
+    args.push('--loglevel', process.env.OUTLINE_DEBUG === 'true' ? 'debug' : 'error');
     args.push('--transparent-dns');
     if (isUdpEnabled) {
       args.push('--socks5-udp');

--- a/src/electron/process_manager.ts
+++ b/src/electron/process_manager.ts
@@ -151,9 +151,12 @@ export class TunnelManager {
     }
   }
 
-  public setDebug(debug: boolean) {
-    this.ssLocal.setDebug(debug);
-    this.tun2socks.setDebug(debug);
+  /**
+   * Turns on verbose logging for the managed processes.  Must be called before launching the processes
+   */
+  public enableDebugMode() {
+    this.ssLocal.enableDebugMode();
+    this.tun2socks.enableDebugMode();
   }
 
   // Fulfills once all three helpers have started successfully.
@@ -295,6 +298,10 @@ class ChildProcessHelper {
 
   protected constructor(private path: string) {}
 
+  /**
+   * Starts the process with the given args. If enableDebug() has been called, then the process is started in verbose mode if supported.
+   * @param args The args for the process
+   */
   protected launch(args: string[]) {
     this.process = spawn(this.path, args);
     const processName = path.basename(this.path);
@@ -347,8 +354,11 @@ class ChildProcessHelper {
     this.exitListener = newListener;
   }
 
-  public setDebug(debug: boolean) {
-    this.isInDebugMode = debug;
+  /**
+   * Enables verbose logging for the process.  Must be called before launch().
+   */
+  public enableDebugMode() {
+    this.isInDebugMode = true;
   }
 }
 

--- a/src/electron/process_manager.ts
+++ b/src/electron/process_manager.ts
@@ -14,6 +14,7 @@
 
 import {ChildProcess, execSync, spawn} from 'child_process';
 import {powerMonitor} from 'electron';
+import {basename} from 'path';
 import {platform} from 'os';
 import {env} from 'process';
 
@@ -299,6 +300,11 @@ class ChildProcessHelper {
         this.exitListener();
       }
     };
+
+    if (env.OUTLINE_DEBUG === 'true') {
+      this.process.stdout.on('data', (data) => console.log(`[STDOUT - ${basename(this.path)}]: ${data}`));
+      this.process.stderr.on('data', (data) => console.log(`[STDERR - ${basename(this.path)}]: ${data}`));
+    }
 
     // We have to listen for both events: error means the process could not be launched and in that
     // case exit will not be invoked.

--- a/src/electron/process_manager.ts
+++ b/src/electron/process_manager.ts
@@ -320,8 +320,8 @@ class ChildProcessHelper {
 
     if (this.isInDebugMode) {
       // Expose logs to the node output.  This also makes the logs available in Sentry.
-      this.process.stdout!.pipe(process.stdout);
-      this.process.stderr!.pipe(process.stderr);
+      this.process.stdout.on('data', (data) => console.log(`[STDOUT - ${processName}]: ${data}`));	      // Expose logs to the node output.  This also makes the logs available in Sentry.
+      this.process.stderr.on('data', (data) => console.error(`[STDERR - ${processName}]: ${data}`));
     }
 
     // We have to listen for both events: error means the process could not be launched and in that

--- a/src/electron/process_manager.ts
+++ b/src/electron/process_manager.ts
@@ -313,8 +313,9 @@ class ChildProcessHelper {
     };
 
     if (this.isInDebugMode) {
-      this.process.stdout.on('data', (data) => console.log(`[STDOUT - ${processName}]: ${data}`));
-      this.process.stderr.on('data', (data) => console.log(`[STDERR - ${processName}]: ${data}`));
+      // Expose logs to the node output.  This also makes the logs available in Sentry.
+      this.process.stdout!.pipe(process.stdout);
+      this.process.stderr!.pipe(process.stderr);
     }
 
     // We have to listen for both events: error means the process could not be launched and in that

--- a/src/electron/process_manager.ts
+++ b/src/electron/process_manager.ts
@@ -327,7 +327,7 @@ class ChildProcessHelper {
 
     if (this.isInDebugMode) {
       // Expose logs to the node output.  This also makes the logs available in Sentry.
-      this.process.stdout.on('data', (data) => console.log(`[STDOUT - ${processName}]: ${data}`));	      // Expose logs to the node output.  This also makes the logs available in Sentry.
+      this.process.stdout.on('data', (data) => console.log(`[STDOUT - ${processName}]: ${data}`));
       this.process.stderr.on('data', (data) => console.error(`[STDERR - ${processName}]: ${data}`));
     }
 

--- a/src/electron/process_manager.ts
+++ b/src/electron/process_manager.ts
@@ -299,7 +299,7 @@ class ChildProcessHelper {
     this.process = spawn(this.path, args);
     const processName = path.basename(this.path);
 
-    const onExit = () => {
+    const onExit = (code: number, signal: string) => {
       if (this.process) {
         this.process.removeAllListeners();
       }
@@ -308,7 +308,13 @@ class ChildProcessHelper {
       }
 
       if (this.isInDebugMode) {
-        console.log(`[EXIT - ${processName}]: ${this.process.exitCode}`);
+        const prefix = `[EXIT - ${processName}]: `;
+        // Only ever one is non-null
+        if (code !== null) {
+          console.log(`${prefix}Exited with code ${code}`);
+        } else {
+          console.log(`${prefix}Killed by signal ${signal}`);
+        }
       }
     };
 


### PR DESCRIPTION
We have had [a number of disconnection issues](https://github.com/orgs/Jigsaw-Code/projects/1?card_filter_query=label%3Afailure%2Fconnect) on both Linux and Windows.  This PR is a first step towards debugging by setting `ss-local` and `tun2socks` to verbose logging mode and redirecting their output to the electron process's stdout and stderr.

This PR was jointly authored by myself and @mpmcroy 

- Add verbose logging to ss-local and Tun2Socks
- Adds subprocess stdout/stderr logging through `console` so the logs appear in Sentry

Example Sentry logs from connecting and disconnecting from the VPN: https://sentry.io/organizations/outlinevpn/issues/2211797476/
