### PR TITLE
Tell Sentry the app name from the renderer process

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "do": "bash ./scripts/do_action.sh"
   },
   "comments": {
+    "name": "This must stay in sync with the app name given to Sentry in the ElectronErrorReporter constructor",
     "sentry": "@sentry/electron depends on @sentry/browser; use @sentry/browser as a transitive dependency to avoid version mismatches that make the build fail. See: https://github.com/getsentry/sentry-javascript/issues/1853",
     "codrova-osx@6.0.0": "Version-controlled platform config files at apple/xcode/osx/Outline/config.xml, apple/xcode/osx/osx.json, and apple/xcode/osx/www/cordova_plugins.js as a workaround for https://github.com/apache/cordova-osx/issues/106. Delete these files when the issue is fixed."
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "do": "bash ./scripts/do_action.sh"
   },
   "comments": {
-    "name": "This must stay in sync with the app name given to Sentry in the ElectronErrorReporter constructor",
     "sentry": "@sentry/electron depends on @sentry/browser; use @sentry/browser as a transitive dependency to avoid version mismatches that make the build fail. See: https://github.com/getsentry/sentry-javascript/issues/1853",
     "codrova-osx@6.0.0": "Version-controlled platform config files at apple/xcode/osx/Outline/config.xml, apple/xcode/osx/osx.json, and apple/xcode/osx/www/cordova_plugins.js as a workaround for https://github.com/apache/cordova-osx/issues/106. Delete these files when the issue is fixed."
   },

--- a/src/electron/index.ts
+++ b/src/electron/index.ts
@@ -76,6 +76,7 @@ function createWindow(tunnelAtShutdown?: SerializableTunnel) {
   const queryParams = new url.URLSearchParams();
   if (debugMode) {
     queryParams.set('debug', 'true');
+    queryParams.set('appName', app.getName());
   }
   webAppUrl.search = queryParams.toString();
 

--- a/src/www/app/electron_main.ts
+++ b/src/www/app/electron_main.ts
@@ -78,6 +78,7 @@ class ElectronUpdater extends AbstractUpdater {
 class ElectronErrorReporter implements OutlineErrorReporter {
   constructor(appVersion: string, privateDsn: string) {
     if (privateDsn) {
+      // The app name here must stay in sync with the one in package.json
       sentry.init({dsn: privateDsn, release: appVersion, appName: 'outline-client'});
     }
   }

--- a/src/www/app/electron_main.ts
+++ b/src/www/app/electron_main.ts
@@ -22,15 +22,14 @@ import * as os from 'os';
 import {EventQueue} from '../model/events';
 import {ServerConfig} from '../model/server';
 
-import {AbstractClipboard, Clipboard, ClipboardListener} from './clipboard';
+import {AbstractClipboard} from './clipboard';
 import {ElectronOutlineTunnel} from './electron_outline_tunnel';
 import {EnvironmentVariables} from './environment';
 import {OutlineErrorReporter} from './error_reporter';
 import {FakeOutlineTunnel} from './fake_tunnel';
 import {getLocalizationFunction, main} from './main';
 import {OutlineServer} from './outline_server';
-import {OutlinePlatform} from './platform';
-import {AbstractUpdater, UpdateListener, Updater} from './updater';
+import {AbstractUpdater} from './updater';
 import {UrlInterceptor} from './url_interceptor';
 
 const isWindows = os.platform() === 'win32';
@@ -76,10 +75,9 @@ class ElectronUpdater extends AbstractUpdater {
 }
 
 class ElectronErrorReporter implements OutlineErrorReporter {
-  constructor(appVersion: string, privateDsn: string) {
+  constructor(appVersion: string, privateDsn: string, appName: string) {
     if (privateDsn) {
-      // The app name here must stay in sync with the one in package.json
-      sentry.init({dsn: privateDsn, release: appVersion, appName: 'outline-client'});
+      sentry.init({dsn: privateDsn, release: appVersion, appName});
     }
   }
 
@@ -112,7 +110,7 @@ main({
   getErrorReporter: (env: EnvironmentVariables) => {
     // Initialise error reporting in the main process.
     ipcRenderer.send('environment-info', {'appVersion': env.APP_VERSION, 'dsn': env.SENTRY_DSN});
-    return new ElectronErrorReporter(env.APP_VERSION, env.SENTRY_DSN || '');
+    return new ElectronErrorReporter(env.APP_VERSION, env.SENTRY_DSN || '', new URL(document.URL).searchParams.get('appName'));
   },
   getUpdater: () => {
     return new ElectronUpdater();

--- a/src/www/app/electron_main.ts
+++ b/src/www/app/electron_main.ts
@@ -78,7 +78,7 @@ class ElectronUpdater extends AbstractUpdater {
 class ElectronErrorReporter implements OutlineErrorReporter {
   constructor(appVersion: string, privateDsn: string) {
     if (privateDsn) {
-      sentry.init({dsn: privateDsn, release: appVersion});
+      sentry.init({dsn: privateDsn, release: appVersion, appName: 'outline-client'});
     }
   }
 

--- a/src/www/app/main.ts
+++ b/src/www/app/main.ts
@@ -83,8 +83,8 @@ export function main(platform: OutlinePlatform) {
           ([environmentVars]) => {
             console.debug('running main() function');
 
-            const queryParams = url.parse(document.URL, true).query;
-            const debugMode = queryParams.debug === 'true';
+            const queryParams = new URL(document.URL).searchParams;
+            const debugMode = queryParams.get('debug') === 'true';
 
             const eventQueue = new EventQueue();
             const serverRepo = createServerRepo(


### PR DESCRIPTION
Formerly it used the remote module to do this when `app.getName()` wasn't available (ie when not in the main process) but since Electron 10 the module has been removed by default in prep for its complete removal in Electron 14.

Tested: https://sentry.io/organizations/outlinevpn/issues/2211432007/?project=159503&query=is%3Aunresolved