### PR TITLE
bump ssconfig version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@polymer/paper-toast": "^3.0.1",
     "@sentry/electron": "1.2.1",
     "@webcomponents/webcomponentsjs": "^2.4.4",
-    "ShadowsocksConfig": "Jigsaw-Code/outline-shadowsocksconfig#^v0.1.0",
+    "ShadowsocksConfig": "Jigsaw-Code/outline-shadowsocksconfig#^v0.1.2",
     "auto-launch": "^5.0.5",
     "cordova-custom-config": "^5.1.0",
     "cordova-plugin-device": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1703,9 +1703,9 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-ShadowsocksConfig@Jigsaw-Code/outline-shadowsocksconfig#^v0.1.0:
-  version "0.0.9"
-  resolved "https://codeload.github.com/Jigsaw-Code/outline-shadowsocksconfig/tar.gz/acdbe0367e887776a7c8137b844d7b03f1bc5ad5"
+ShadowsocksConfig@Jigsaw-Code/outline-shadowsocksconfig#^v0.1.2:
+  version "0.1.2"
+  resolved "https://codeload.github.com/Jigsaw-Code/outline-shadowsocksconfig/tar.gz/e491bd06e98b1b9f3c4745e8eb66c503c490745d"
   dependencies:
     js-base64 "^3.5.2"
     punycode "^1.4.1"


### PR DESCRIPTION
To match newly cut version https://github.com/Jigsaw-Code/outline-shadowsocksconfig/releases/tag/v0.1.2

This is to fix #774