### PR TITLE
Increase Android version

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="org.outline.android.client" version="1.4.0-go" android-versionCode="34" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="org.outline.android.client" version="1.5.0-go" android-versionCode="35" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Outline</name>
     <description>
         Internet without borders (powered by Shadowsocks)


### PR DESCRIPTION
Bumps the Android (minor) version to v1.5.0-go (35) for Play Store (beta channel) release.