### PR TITLE
Electron: merge Go network stack

### DIFF
--- a/src/electron/connectivity.ts
+++ b/src/electron/connectivity.ts
@@ -63,7 +63,7 @@ export function lookupIp(hostname: string): Promise<string> {
 export function isServerReachable(
     host: string, port: number, timeout = 0, maxAttempts = 1, retryIntervalMs = 0) {
   let attempt = 0;
-  return new Promise((fulfill, reject) => {
+  return new Promise<void>((fulfill, reject) => {
     const connect = () => {
       attempt++;
 

--- a/src/electron/electron-builder.json
+++ b/src/electron/electron-builder.json
@@ -19,6 +19,7 @@
     ],
     "files": [
       "third_party/badvpn/linux",
+      "third_party/outline-go-tun2socks/linux",
       "third_party/shadowsocks-libev/linux",
       "tools/outline_proxy_controller/dist"
     ],
@@ -34,6 +35,7 @@
     ],
     "files": [
       "third_party/badvpn/win32",
+      "third_party/outline-go-tun2socks/win32",
       "third_party/shadowsocks-libev/win32"
     ],
     "icon": "build/icons/win/icon.ico"

--- a/src/electron/process_manager.ts
+++ b/src/electron/process_manager.ts
@@ -242,7 +242,7 @@ export class TunnelManager {
     try {
       await this.shadowsocks.checkConnectivity();
       this.tun2socks.isUdpEnabled = true;
-    } catch(e) {
+    } catch (e) {
       if (!(e instanceof errors.RemoteUdpForwardingDisabled)) {
         throw e;
       }
@@ -418,8 +418,8 @@ class SsLocal extends ChildProcessHelper implements ShadowsocksProcess {
 
   private isSsLocalReachable() {
     return isServerReachable(
-      SSLOCAL_PROXY_ADDRESS, SSLOCAL_PROXY_PORT, SSLOCAL_CONNECTION_TIMEOUT, SSLOCAL_MAX_ATTEMPTS,
-      SSLOCAL_RETRY_INTERVAL_MS);
+        SSLOCAL_PROXY_ADDRESS, SSLOCAL_PROXY_PORT, SSLOCAL_CONNECTION_TIMEOUT, SSLOCAL_MAX_ATTEMPTS,
+        SSLOCAL_RETRY_INTERVAL_MS);
   }
 }
 
@@ -450,7 +450,7 @@ class GoShadowsocks implements ShadowsocksProcess {
 
   // Launches outline-go-tun2socks with the --checkConnectivity option.
   async checkConnectivity() {
-    return new Promise<void>((resolve, reject)=> {
+    return new Promise<void>((resolve, reject) => {
       this.tun2socks.onExit = (code: number) => {
         if (code !== errors.ErrorCode.NO_ERROR) {
           // Treat the absence of a code as an unexpected error.
@@ -539,7 +539,6 @@ class GoTun2socks extends ChildProcessHelper implements Tun2socksProcess {
     }
     this.launch(args);
   }
-
 }
 
 function logExit(processName: string, exitCode?: number, signal?: string) {

--- a/src/electron/process_manager.ts
+++ b/src/electron/process_manager.ts
@@ -407,10 +407,12 @@ class SsLocal extends ChildProcessHelper implements ShadowsocksProcess {
     // Possibly over-cautious, though we have seen occasional failures immediately after network
     // changes: ensure ss-local is reachable first.
     await this.isSsLocalReachable();
+    // TODO(alalama): parallelize.
     try {
       await checkUdpForwardingEnabled(SSLOCAL_PROXY_ADDRESS, SSLOCAL_PROXY_PORT);
-    } catch (e) {
+    } catch (udpErr) {
       await validateServerCredentials(SSLOCAL_PROXY_ADDRESS, SSLOCAL_PROXY_PORT);
+      throw udpErr;
     }
   }
 
@@ -421,9 +423,9 @@ class SsLocal extends ChildProcessHelper implements ShadowsocksProcess {
   }
 }
 
-// Stub process to run connectivity checks through GoTun2socks.
-// Note that outline-go-tun2socks implements the Shadowsocks protocol, so running
-// a separate Shadowsocks process is not necessary.
+// GoTun2socks implements the Shadowsocks protocol, so running a separate
+// Shadowsocks process is not necessary.
+// Stub process lifecycle to run connectivity checks through GoTun2socks.
 class GoShadowsocks implements ShadowsocksProcess {
   private tun2socks: GoTun2socks;
   private exitListener?: () => void;


### PR DESCRIPTION
- Merges the Go network stack for Windows and Linux clients from the [go-tun2socks branch](https://github.com/Jigsaw-Code/outline-client/tree/go-tun2socks), alongside the existing network stack. See #688.
- Defines common interfaces for Shadowsocks and Tun2socks implementations.
- TODO: switch the network stack based on a build flag; migrate Electron app build to webpack so we can use static compile-time constants.