### PR TITLE
Cleanup and fix auto launch

### DIFF
--- a/src/electron/tunnel_store.ts
+++ b/src/electron/tunnel_store.ts
@@ -21,7 +21,6 @@ import {ShadowsocksConfig} from '../www/model/shadowsocks';
 export interface SerializableTunnel {
   id: string;
   config: ShadowsocksConfig;
-  isUdpSupported?: boolean;
 }
 
 // Persistence layer for a single SerializableTunnel.


### PR DESCRIPTION
With this change we only setup the auto launcher when needed (while the VPN is running).
This way we prevent leaving residue behind and unnecessary auto launches that may upset the user.

This also fixes the auto VPN start on Linux, which currently doesn't work because we only auto-start if `--autostart` is set, which doesn't happen on Linux. The app will auto-launch, but the VPN doesn't start!
Now we will auto start whenever there's tunnel information saved, fixing Linux.

I have no idea how to test this, since I wasn't able to get the networking working on my dev environment.