### PR TITLE
Fix @sentry/electron init on main process

### DIFF
--- a/src/electron/electron_main.webpack.js
+++ b/src/electron/electron_main.webpack.js
@@ -17,30 +17,34 @@ const webpack = require('webpack');
 
 module.exports = (env) => {
   return {
-    entry: './src/electron/index.ts', target: 'electron-main',
-        node: {__dirname: false, __filename: false}, mode: 'production',
-        devtool: 'inline-source-map', module: {
-          rules:
-              [
-                {
-                  test: /\.tsx?$/,
-                  use: 'ts-loader',
-                  exclude: /node_modules/,
-                },
-              ],
+    entry: './src/electron/index.ts',
+    target: 'electron-main',
+    node: {
+      __dirname: false,
+      __filename: false
+    },
+    mode: 'production',
+    devtool: 'inline-source-map',
+    module: {
+      rules: [
+        {
+          test: /\.tsx?$/,
+          use: 'ts-loader',
+          exclude: /node_modules/,
         },
-        resolve: {
-          extensions: ['.tsx', '.ts', '.js'],
-        },
-        plugins:
-            [
-              new webpack.DefinePlugin({
-                NETWORK_STACK: JSON.stringify(env.NETWORK_STACK),
-              }),
-            ],
-        output: {
-          filename: 'index.js',
-          path: path.resolve(__dirname, '../../build/electron/electron'),
-        },
+      ],
+    },
+    resolve: {
+      extensions: [ '.tsx', '.ts', '.js' ],
+    },
+    plugins: [
+      new webpack.DefinePlugin({
+        NETWORK_STACK: JSON.stringify(env.NETWORK_STACK),
+      }),
+    ],
+    output: {
+      filename: 'index.js',
+      path: path.resolve(__dirname, '../../build/electron/electron'),
+    },
   }
 };

--- a/src/electron/index.ts
+++ b/src/electron/index.ts
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as sentry from '@sentry/electron';
+// Directly import @sentry/electron main process code.
+// See: https://docs.sentry.io/platforms/javascript/guides/electron/#webpack-configuration
+import * as sentry from '@sentry/electron/dist/main';
 import {app, BrowserWindow, ipcMain, Menu, MenuItemConstructorOptions, nativeImage, shell, Tray} from 'electron';
 import * as promiseIpc from 'electron-promise-ipc';
 import {autoUpdater} from 'electron-updater';


### PR DESCRIPTION
- Since migrating the electron main process build to webpack, we are bundling @sentry/electron code for the main and renderer process. We get a runtime error on the main process because it attempts to import @senty/electron renderer process code when initializing the library.
- Fixes sentry initialization by directly importing @sentry/electron main process code.
- See [sentry-electron/#142](https://github.com/getsentry/sentry-electron/issues/142) and [related documentation](https://docs.sentry.io/platforms/javascript/guides/electron/#webpack-configuration). Note that we don't have to define the process type and import sentry conditionally, since we have separate webpack configurations for the main and renderer processes.
