### PR TITLE
Electron: send app name regardless of debug mode

### DIFF
--- a/src/electron/index.ts
+++ b/src/electron/index.ts
@@ -107,8 +107,8 @@ function setupWindow(): void {
   const queryParams = new url.URLSearchParams();
   if (debugMode) {
     queryParams.set('debug', 'true');
-    queryParams.set('appName', app.getName());
   }
+  queryParams.set('appName', app.getName());
   webAppUrl.search = queryParams.toString();
 
   const webAppUrlAsString = webAppUrl.toString();

--- a/src/www/app/electron_main.ts
+++ b/src/www/app/electron_main.ts
@@ -110,7 +110,8 @@ main({
   getErrorReporter: (env: EnvironmentVariables) => {
     // Initialise error reporting in the main process.
     ipcRenderer.send('environment-info', {'appVersion': env.APP_VERSION, 'dsn': env.SENTRY_DSN});
-    return new ElectronErrorReporter(env.APP_VERSION, env.SENTRY_DSN || '', new URL(document.URL).searchParams.get('appName'));
+    return new ElectronErrorReporter(
+        env.APP_VERSION, env.SENTRY_DSN || '', new URL(document.URL).searchParams.get('appName') || 'Outline Client');
   },
   getUpdater: () => {
     return new ElectronUpdater();


### PR DESCRIPTION
- Fixes a runtime error initializing sentry on the Electron renderer process when debug mode is not set.
- Sends the app name to the renderer process unconditionally.
- Provides a fallback app name in the renderer process.