### PR TITLE
Fix race condition in RoutingDaemon.stop()

### DIFF
--- a/src/electron/go_vpn_tunnel.ts
+++ b/src/electron/go_vpn_tunnel.ts
@@ -186,15 +186,19 @@ export class GoVpnTunnel implements VpnTunnel {
     powerMonitor.removeListener('suspend', this.suspendListener.bind(this));
     powerMonitor.removeListener('resume', this.resumeListener.bind(this));
 
+    // A clean shutdown requires stopping tun2socks before the routing is
+    // reset.  However, this call to stop() is asynchronous, so shutdown
+    // may occur out of order.  This may print an error message to the logs
+    // but is otherwise harmless.
+    this.tun2socks.stop();
+
     try {
-      this.routing.stop();
+      await this.routing.stop();
     } catch (e) {
       // This can happen for several reasons, e.g. the daemon may have stopped while we were
       // connected.
       console.error(`could not stop routing: ${e.message}`);
     }
-
-    this.tun2socks.stop();
   }
 
   // Fulfills once all three helper processes have stopped.

--- a/src/electron/routing_service.ts
+++ b/src/electron/routing_service.ts
@@ -192,6 +192,8 @@ export class RoutingDaemon {
     });
   }
 
+  // stop() resolves when the stop command has been sent.
+  // Use #onceDisconnected to be notified when the connection terminates.
   async stop() {
     if (!this.socket) {
       // Never started.
@@ -204,8 +206,7 @@ export class RoutingDaemon {
     }
     this.stopping = true;
 
-    await this.writeReset();
-    await this.onceDisconnected;
+    return this.writeReset();
   }
 
   public get onceDisconnected() {

--- a/src/electron/sslibev_badvpn_tunnel.ts
+++ b/src/electron/sslibev_badvpn_tunnel.ts
@@ -268,16 +268,20 @@ export class ShadowsocksLibevBadvpnTunnel implements VpnTunnel {
     powerMonitor.removeListener('suspend', this.suspendListener.bind(this));
     powerMonitor.removeListener('resume', this.resumeListener.bind(this));
 
+    // This is the clean shutdown order, but to minimize delay, we don't
+    // wait for each shutdown step to complete.  They may therefore complete
+    // out of order.  This will cause tun2socks to print error messages in
+    // the console, but is otherwise harmless.
+    this.tun2socks.stop();
+    this.ssLocal.stop();
+
     try {
-      this.routing.stop();
+      await this.routing.stop();
     } catch (e) {
       // This can happen for several reasons, e.g. the daemon may have stopped while we were
       // connected.
       console.error(`could not stop routing: ${e.message}`);
     }
-
-    this.ssLocal.stop();
-    this.tun2socks.stop();
   }
 
   // Fulfills once all three helper processes have stopped.


### PR DESCRIPTION
Currently, a call to `Tunnel.disconnect()` shuts down all three helpers in
parallel, and the first one to close triggers another call to
`disconnect()` via `Promise.race(exits)`.  Both `disconnect()` calls try
to use `RoutingDaemon.socket.write()`.  If it has already closed, the second
call to `write()` will throw an exception that is surfaced to the user.