### PR TITLE
Fix null pointer exception in VPN connectivity broadcast

### DIFF
--- a/cordova-plugin-outline/android/java/org/outline/vpn/VpnTunnelService.java
+++ b/cordova-plugin-outline/android/java/org/outline/vpn/VpnTunnelService.java
@@ -382,6 +382,10 @@ public class VpnTunnelService extends VpnService {
 
   /* Broadcast change in the VPN connectivity. */
   private void broadcastVpnConnectivityChange(OutlinePlugin.TunnelStatus status) {
+    if (tunnelConfig == null) {
+      LOG.warning("Tunnel disconnected, not sending VPN connectivity broadcast");
+      return;
+    }
     Intent statusChange = new Intent(OutlinePlugin.Action.ON_STATUS_CHANGE.value);
     statusChange.addCategory(getPackageName());
     statusChange.putExtra(OutlinePlugin.MessageData.PAYLOAD.value, status.value);


### PR DESCRIPTION
Cherry-picks #992 on the `go-tun2socks` branch in order to release `android-v1.5.1` without the persistence layer changes in `master`.