### PR TITLE
Configure sentry to only collect console statements

### DIFF
--- a/src/www/app/electron_main.ts
+++ b/src/www/app/electron_main.ts
@@ -23,7 +23,7 @@ import * as os from 'os';
 import {AbstractClipboard} from './clipboard';
 import {ElectronOutlineTunnel} from './electron_outline_tunnel';
 import {EnvironmentVariables} from './environment';
-import {OutlineErrorReporter} from './error_reporter';
+import {getSentryBrowserIntegrations, OutlineErrorReporter} from './error_reporter';
 import {FakeNativeNetworking} from './fake_net';
 import {FakeOutlineTunnel} from './fake_tunnel';
 import {getLocalizationFunction, main} from './main';
@@ -76,7 +76,12 @@ class ElectronUpdater extends AbstractUpdater {
 class ElectronErrorReporter implements OutlineErrorReporter {
   constructor(appVersion: string, privateDsn: string, appName: string) {
     if (privateDsn) {
-      sentry.init({dsn: privateDsn, release: appVersion, appName});
+      sentry.init({
+        dsn: privateDsn,
+        release: appVersion,
+        appName,
+        integrations: getSentryBrowserIntegrations
+      });
     }
   }
 

--- a/src/www/app/outline_server.ts
+++ b/src/www/app/outline_server.ts
@@ -346,7 +346,7 @@ function accessKeysMatch(a: string, b: string): boolean {
     return l.host === r.host && l.port === r.port && l.password === r.password &&
         l.method === r.method;
   } catch (e) {
-    console.error(`failed to parse access key for comparison`);
+    console.debug(`failed to parse access key for comparison`);
   }
   return false;
 }


### PR DESCRIPTION
-  Configures `sentry/browser` to only collect console events.
- Keeps the [default Sentry integrations](https://docs.sentry.io/platforms/javascript/configuration/integrations/default/) with default options.