### PR TITLE
Apple: don't collect device timezone and memory

### DIFF
--- a/cordova-plugin-outline/apple/src/OutlinePlugin.swift
+++ b/cordova-plugin-outline/apple/src/OutlinePlugin.swift
@@ -129,7 +129,7 @@ class OutlinePlugin: CDVPlugin {
     guard let port = command.argument(at: 1) as? UInt16 else {
       return sendError("Missing host port", callbackId: command.callbackId)
     }
-    OutlineVpn.shared.isServerReachable(host: host, port: port)) { errorCode in
+    OutlineVpn.shared.isServerReachable(host: host, port: port) { errorCode in
       self.sendSuccess(errorCode == OutlineVpn.ErrorCode.noError, callbackId: command.callbackId)
     }
   }
@@ -175,14 +175,23 @@ class OutlinePlugin: CDVPlugin {
     }
     event.message = "\(OutlinePlugin.kPlatform) report (\(uuid))"
 
-    // Remove device identifier. Note that we cannot use the beforeSerializeEvent callback,
-    // since contexts are only added after serialization when not present.
+    // Remove device identifier, timezone, and memory stats. Note that we cannot use the
+    // beforeSerializeEvent callback, since contexts are only added after serialization
+    // if not present.
     let serializedEvent = event.serialize()
-    var contexts = serializedEvent["contexts"] as? [String: [String: Any]]
-    contexts?["app"]?["device_app_hash"] = ""
+    let contexts = serializedEvent["contexts"] as? [String: [String: Any]]
+    var appContext = contexts?["app"]
+    appContext?["device_app_hash"] = ""
+    var deviceContext = contexts?["device"]
+    deviceContext?["timezone"] = ""
+    deviceContext?["memory_size"] = ""
+    deviceContext?["free_memory"] = ""
+    deviceContext?["usable_memory"] = ""
+    deviceContext?["storage_size"] = ""
     event.context = Context()
-    // Setting the sanitized app context will prevent it from being added on serialization.
-    event.context?.appContext = contexts?["app"]
+    // Setting the sanitized contexts will prevent them from being added on serialization.
+    event.context?.appContext = appContext
+    event.context?.deviceContext = deviceContext
 
     OutlineSentryLogger.sharedInstance.addVpnExtensionLogsToSentry()
     Client.shared?.send(event: event) { (error) in


### PR DESCRIPTION
- Stops collecting device timezone and memory stats.
- Fixes a build error due to a typo in #991.