### PR TITLE
Migrate Android network stack to Go

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="org.outline.android.client" version="1.4.0" android-versionCode="33" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="org.outline.android.client" version="1.5.1" android-versionCode="36" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Outline</name>
     <description>
         Internet without borders (powered by Shadowsocks)

--- a/cordova-plugin-outline/README.md
+++ b/cordova-plugin-outline/README.md
@@ -1,47 +1,10 @@
 # cordova-plugin-outline
 
-This Cordova plugin provides the ability to start a system-wide VPN, connected to a local Shadowsocks client.
+Cordova plugin that implements a system-wide VPN to proxy device traffic over [Shadowsocks](https://shadowsocks.org/).
 
-We use [tun2socks](https://github.com/ambrop72/badvpn-googlecode-export/blob/master/tun2socks/badvpn-tun2socks.8) as an adapter; it receives all of the device’s traffic through the VPN network interface (TUN) and forwards it to a local Shadowsocks server.
+## Supported Platforms
 
-## shadowsocks-libev
-
-### Android update instructions
-
-The client code is https://github.com/shadowsocks/shadowsocks-libev, is compiled to a native shared library using the same process as https://github.com/shadowsocks/shadowsocks-android.
-
-`libss-local.so` is built with the help of https://github.com/shadowsocks/shadowsocks-android.
-
-It should be refreshed periodically; a script is included to do so, e.g.:
-```bash
-./update-shadowsocks-libev.sh 2.6.3
-```
-
-Upon successful completion, the script stages a commit including the new binary.
-
-### Apple update instructions
-
-We use a custom framework dependency, Shadowsocks, that implements shadowsocks-libev. To update it see `../third_party/shadowsocks-libev/apple/README.md`.
-
-## tun2socks
-
-### Android update instructions
-
-```
-ndk-build -C ../third_party/badvpn APP_BUILD_SCRIPT=Android.mk NDK_PROJECT_PATH=`pwd` NDK_APPLICATION_MK=`pwd`/../third_party/badvpn/Application.mk
-cp libs/armeabi-v7a/libtun2socks.so android/libs/armeabi-v7a/libtun2socks.so
-cp libs/x86/libtun2socks.so android/libs/x86/libtun2socks.so
-```
-
-For debug builds, which enable asserts and improved backtraces, append `NDK_DEBUG=1`.
-
-### Apple update instructions
-
-We use a custom framework dependency, PacketProcessor, that implements tun2socks. To update it see `../third_party/Potatso/README.md`
-
-## Target Platforms
-
-This plugin supports Android, iOS, and macOS.
+This plugin supports Android, iOS, and macOS. Browser is supported for UI development/demo mode.
 
 ### Android
 This plugin targets Android devices running Lollipop (API 22), or higher.
@@ -49,23 +12,20 @@ This plugin targets Android devices running Lollipop (API 22), or higher.
 ### Apple
 This plugin targets Apple devices running iOS 11.0+ and macOS/OS X 10.11.
 
+
+## tun2socks
+
+We rely on [outline-go-tun2socks](https://github.com/Jigsaw-Code/outline-go-tun2socks) to assemble IP traffic and implement the Shadowsocks protocol: it receives all of the device’s traffic through the VPN network interface (TUN) and forwards it to a [Shadowsocks proxy server](https://github.com/Jigsaw-Code/outline-ss-server).
+
+outline-go-tun2socks is consumed by native platforms as a library.
+
+
 ## JavaScript API
 
 ```ts
-
-// Represents a Shadowsocks server configuration.
-interface ServerConfig {
-  method?: string;
-  password?: string;
-  host?: string;
-  port?: number;
-  name?: string;
-}
-
 declare namespace cordova.plugins.outline {
 
-  export var Log: {
-
+  const log: {
     // Initializes the error reporting framework with the supplied credentials.
     initialize(apiKey: string): Promise<void>;
 
@@ -74,19 +34,22 @@ declare namespace cordova.plugins.outline {
     send(uuid: string): Promise<void>;
   }
 
+  const net: {
+    // Returns whether a server is reachable over TCP by attempting to establish
+    // a socket to |host:port|.
+    isReachable(host: string, port: number): Promise<boolean>;
+  }
+
   // Represents a VPN tunnel to a proxy through the plugin.
-  export class Tunnel {
+  class Tunnel {
+    // Creates a new instance with |id|.
+    constructor(public readonly id: string);
 
-    // Creates a new instance with |serverConfig|.
-    // A sequential ID will be generated if |id| is absent.
-    constructor(serverConfig: ShadowsocksServerConfig, id?: string);
-
-    // Starts the VPN service, and tunnels all the traffic to a local Shadowsocks
+    // Starts the VPN service, and tunnels all the traffic to a Shadowsocks proxy
     // server as dictated by its configuration. If there is another running
     // instance, broadcasts a disconnect event and stops the active tunnel.
     // In such case, the VPN is not torn down.
-    start(): Promise<void>;
-
+    start(config: ShadowsocksConfig): Promise<void>;
 
     // Stops the tunnel and VPN service.
     stop(): Promise<void>;
@@ -94,29 +57,15 @@ declare namespace cordova.plugins.outline {
     // Returns whether the tunnel instance is active.
     isRunning(): Promise<boolean>;
 
-    // Returns whether the proxy server is reachable by attempting to establish
-    // a socket to the IP and port specified in |config|.
-    isReachable(): Promise<boolean>;
-
     // Sets a listener, to be called when the VPN tunnel status changes.
     onStatusChange(listener: (status: TunnelStatus) => void): void;
   }
 }
-
 ```
-
-## Android Code Sources
-
-We have used as a starting point open source code from [Psiphon](https://psiphon.ca/uz@Latn/open-source.html), specifically their fork of badvpn.
-
-* `../third_party/badvpn`:
-  * built upon Psiphon's fork of [badvpn](https://github.com/ambrop72/badvpn).
-  * starting point: https://github.com/mei3am/ps/tree/master/Android/badvpn
-  * Outline-specific changes mostly confined to tun2socks/tun2socks.c and marked with `// ==== OUTLINE ====` (like Psiphon-specific changes)
 
 ## Additional Apple Dependencies
 
-We use the [Carthage dependency manager](https://github.com/Carthage/Carthage) to fetch Sentry Cocoa, CocoaLumberjack, and CocoaAsyncSocket.
+We use the [Carthage dependency manager](https://github.com/Carthage/Carthage) to install third party dependencies: sentry-cocoa and CocoaLumberjack.
 
 To upgrade the Carthage dependencies:
 * Install Carthage by running `brew install carthage`.

--- a/cordova-plugin-outline/README.md
+++ b/cordova-plugin-outline/README.md
@@ -1,23 +1,21 @@
 # cordova-plugin-outline
 
-Cordova plugin that implements a system-wide VPN to proxy device traffic over [Shadowsocks](https://shadowsocks.org/).
+Cordova plugin that implements a system-wide VPN to tunnel device traffic over [Shadowsocks](https://shadowsocks.org/).
 
 ## Supported Platforms
 
-This plugin supports Android, iOS, and macOS. Browser is supported for UI development/demo mode.
+This plugin supports Android, iOS, and macOS.
 
 ### Android
 This plugin targets Android devices running Lollipop (API 22), or higher.
 
 ### Apple
-This plugin targets Apple devices running iOS 11.0+ and macOS/OS X 10.11.
+This plugin targets Apple devices running iOS 11.0+ and macOS/OS X 10.11+.
 
 
 ## tun2socks
 
-We rely on [outline-go-tun2socks](https://github.com/Jigsaw-Code/outline-go-tun2socks) to assemble IP traffic and implement the Shadowsocks protocol: it receives all of the device’s traffic through the VPN network interface (TUN) and forwards it to a [Shadowsocks proxy server](https://github.com/Jigsaw-Code/outline-ss-server).
-
-outline-go-tun2socks is consumed by native platforms as a library.
+Native platforms consume [outline-go-tun2socks](https://github.com/Jigsaw-Code/outline-go-tun2socks) as a library to assemble IP traffic and implement the Shadowsocks protocol: it receives all of the device’s traffic through the VPN network interface (TUN) and forwards it to a [Shadowsocks proxy server](https://github.com/Jigsaw-Code/outline-ss-server).
 
 
 ## JavaScript API

--- a/cordova-plugin-outline/android/aidl/org/outline/IVpnTunnelService.aidl
+++ b/cordova-plugin-outline/android/aidl/org/outline/IVpnTunnelService.aidl
@@ -23,7 +23,7 @@ interface IVpnTunnelService {
   /**
    * Establishes a system-wide VPN connected to a remote Shadowsocks proxy server.
    * All device traffic is routed as follows:
-   * `VPN TUN` <-> `tun2socks` <-> `local Shadowsocks server` <-> `remote Shadowsocks server`.
+   *  |VPN TUN interface| <-> |outline-go-tun2socks| <-> |Shadowsocks server|.
    *
    * This method can be called multiple times with different configurations. The VPN will not be
    * torn down. Broadcasts an intent with action OutlinePlugin.Action.START and an error code
@@ -52,6 +52,14 @@ interface IVpnTunnelService {
    * @return boolean indicating whether the tunnel is active.
    */
   boolean isTunnelActive(String tunnelId);
+
+  /**
+   * Determines whether a server is reachable via TCP.
+   *
+   * @param host IP or hostname string.
+   * @return port TCP port number.
+   */
+  boolean isServerReachable(String host, int port);
 
   /**
    * Initializes the error reporting framework on the VPN service process.

--- a/cordova-plugin-outline/android/java/build-extras.gradle
+++ b/cordova-plugin-outline/android/java/build-extras.gradle
@@ -1,4 +1,11 @@
+repositories {
+  flatDir {
+    dirs 'src/main/libs'
+  }
+}
+
 dependencies {
+  implementation(name:'tun2socks', ext:'aar')
   implementation 'com.android.support:appcompat-v7:23.4.0'
   implementation 'io.sentry:sentry-android:2.0.2'
   implementation 'org.apache.commons:commons-collections4:4.4'

--- a/cordova-plugin-outline/android/java/org/outline/OutlinePlugin.java
+++ b/cordova-plugin-outline/android/java/org/outline/OutlinePlugin.java
@@ -38,7 +38,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.outline.log.OutlineLogger;
 import org.outline.log.SentryErrorReporter;
-import org.outline.shadowsocks.ShadowsocksConnectivity;
 import org.outline.vpn.VpnServiceStarter;
 import org.outline.vpn.VpnTunnelService;
 
@@ -252,7 +251,7 @@ public class OutlinePlugin extends CordovaPlugin {
           // Static actions
         } else if (Action.IS_REACHABLE.is(action)) {
           boolean isReachable =
-              ShadowsocksConnectivity.isServerReachable(args.getString(0), args.getInt(1));
+              this.vpnTunnelService.isServerReachable(args.getString(0), args.getInt(1));
           callback.sendPluginResult(new PluginResult(PluginResult.Status.OK, isReachable));
         } else if (Action.INIT_ERROR_REPORTING.is(action)) {
           errorReportingApiKey = args.getString(0);
@@ -318,14 +317,13 @@ public class OutlinePlugin extends CordovaPlugin {
 
   // Returns whether the VPN service is running a particular tunnel instance.
   private boolean isTunnelActive(final String tunnelId) {
-    boolean isActive = false;
     try {
-      isActive = vpnTunnelService.isTunnelActive(tunnelId);
+      return vpnTunnelService.isTunnelActive(tunnelId);
     } catch (Exception e) {
       LOG.log(Level.SEVERE,
           String.format(Locale.ROOT, "Failed to determine if tunnel is active: %s", tunnelId), e);
     }
-    return isActive;
+    return false;
   }
 
   // Broadcasts

--- a/cordova-plugin-outline/android/java/org/outline/vpn/VpnTunnel.java
+++ b/cordova-plugin-outline/android/java/org/outline/vpn/VpnTunnel.java
@@ -16,16 +16,17 @@ package org.outline.vpn;
 
 import android.net.ConnectivityManager;
 import android.net.Network;
+import android.net.VpnService;
 import android.os.Build;
 import android.os.ParcelFileDescriptor;
-import android.net.VpnService;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Locale;
+import java.util.Random;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.Random;
-import org.outline.tun2socks.Tun2SocksJni;
+import tun2socks.OutlineTunnel;
+import tun2socks.Tun2socks;
 
 /**
  * Manages the life-cycle of the system VPN, and of the tunnel that processes its traffic.
@@ -35,22 +36,16 @@ public class VpnTunnel {
 
   private static final String VPN_INTERFACE_PRIVATE_LAN = "10.111.222.%s";
   private static final int VPN_INTERFACE_PREFIX_LENGTH = 24;
-  private static final String VPN_INTERFACE_NETMASK = "255.255.255.0";
-  private static final String VPN_IPV6_NULL = null;  // No IPv6 support.
   private static final int VPN_INTERFACE_MTU = 1500;
   // OpenDNS, Cloudflare, and Quad9 DNS resolvers' IP addresses.
   private static final String[] DNS_RESOLVER_IP_ADDRESSES = {
       "208.67.222.222", "208.67.220.220", "1.1.1.1", "9.9.9.9"};
   private static final String PRIVATE_LAN_BYPASS_SUBNETS_ID = "reserved_bypass_subnets";
-  private static final int DNS_RESOLVER_PORT = 53;
-  private static final int TRANSPARENT_DNS_ENABLED = 1;
-  private static final int SOCKS5_UDP_ENABLED = 1;
-  private static final int SOCKS5_UDP_DISABLED = 0;
 
   private final VpnTunnelService vpnService;
   private String dnsResolverAddress;
   private ParcelFileDescriptor tunFd;
-  private Thread tun2socksThread = null;
+  private OutlineTunnel tunnel;
 
   /**
    * Constructor.
@@ -67,7 +62,7 @@ public class VpnTunnel {
 
   /**
    * Establishes a system-wide VPN that routes all device traffic to its TUN interface. Randomly
-   * selects between OpenDNS and Dyn resolvers to set the VPN's DNS resolvers.
+   * selects between OpenDNS, Cloudflare, and Quad9 resolvers to set the VPN's DNS resolvers.
    *
    * @return boolean indicating whether the VPN was successfully established.
    */
@@ -82,6 +77,7 @@ public class VpnTunnel {
               .addAddress(String.format(Locale.ROOT, VPN_INTERFACE_PRIVATE_LAN, "1"),
                   VPN_INTERFACE_PREFIX_LENGTH)
               .addDnsServer(dnsResolverAddress)
+              .setBlocking(true)
               .addDisallowedApplication(vpnService.getPackageName());
 
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
@@ -119,60 +115,59 @@ public class VpnTunnel {
   }
 
   /**
-   * Connects a tunnel between a SOCKS server and the VPN TUN interface, by using the tun2socks
-   * native library.
+   * Connects a tunnel between a Shadowsocks proxy server and the VPN TUN interface.
    *
-   * @param socksServerAddress IP address of the SOCKS server.
-   * @param remoteUdpForwardingEnabled whether the remote server supports UDP forwarding.
+   * @param host is  IP address of the SOCKS proxy server.
+   * @param port is the port of the SOCKS proxy server.
+   * @param password is the password of the Shadowsocks proxy.
+   * @param cipher is the encryption cipher used by the Shadowsocks proxy.
    * @throws IllegalArgumentException if |socksServerAddress| is null.
    * @throws IllegalStateException if the VPN has not been established, or the tunnel is already
    *     connected.
+   * @throws Exception when the tunnel fails to connect.
    */
-  public synchronized void connectTunnel(
-      final String socksServerAddress, boolean remoteUdpForwardingEnabled) {
+  public synchronized void connectTunnel(final String host, int port, final String password,
+      final String cipher, boolean isUdpEnabled) throws Exception {
     LOG.info("Connecting the tunnel.");
-    if (socksServerAddress == null) {
-      throw new IllegalArgumentException("Must provide an IP address to a SOCKS server.");
+    if (host == null || port <= 0 || port > 65535 || password == null || cipher == null) {
+      throw new IllegalArgumentException("Must provide valid Shadowsocks proxy parameters.");
     }
     if (tunFd == null) {
       throw new IllegalStateException("Must establish the VPN before connecting the tunnel.");
     }
-    if (tun2socksThread != null) {
+    if (isTunnelConnected()) {
       throw new IllegalStateException("Tunnel already connected");
     }
 
-    LOG.fine("Starting tun2socks thread");
-    tun2socksThread =
-        new Thread() {
-          public void run() {
-            Tun2SocksJni.start(tunFd.getFd(), VPN_INTERFACE_MTU,
-                String.format(Locale.ROOT, VPN_INTERFACE_PRIVATE_LAN, "2"), // Router IP address
-                VPN_INTERFACE_NETMASK, VPN_IPV6_NULL, socksServerAddress,
-                remoteUdpForwardingEnabled ? socksServerAddress : null, // UDP relay IP address
-                remoteUdpForwardingEnabled
-                    ? String.format(Locale.ROOT, "%s:%d", dnsResolverAddress, DNS_RESOLVER_PORT)
-                    : null,
-                TRANSPARENT_DNS_ENABLED,
-                remoteUdpForwardingEnabled ? SOCKS5_UDP_ENABLED : SOCKS5_UDP_DISABLED);
-          }
-        };
-    tun2socksThread.start();
+    LOG.fine("Starting tun2socks...");
+    tunnel = Tun2socks.connectShadowsocksTunnel(
+        tunFd.getFd(), host, port, password, cipher, isUdpEnabled);
   }
 
   /* Disconnects a tunnel created by a previous call to |connectTunnel|. */
   public synchronized void disconnectTunnel() {
     LOG.info("Disconnecting the tunnel.");
-    if (tun2socksThread == null) {
+    if (!isTunnelConnected()) {
       return;
     }
-    try {
-      Tun2SocksJni.stop();
-      tun2socksThread.join();
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-    } finally {
-      tun2socksThread = null;
+    tunnel.disconnect();
+    tunnel = null;
+  }
+
+  /**
+   * Instructs the tunnel to update whether UDP is supported after a network connectivity change.
+   *
+   * @return boolean indicating whether UDP is supported.
+   */
+  public synchronized boolean updateUDPSupport() {
+    if (!isTunnelConnected()) {
+      return false;
     }
+    return tunnel.updateUDPSupport();
+  }
+
+  private boolean isTunnelConnected() {
+    return tunnel != null && tunnel.isConnected();
   }
 
   /* Returns a random IP address from |DNS_RESOLVER_IP_ADDRESSES|. */

--- a/cordova-plugin-outline/android/scripts/copy_third_party.js
+++ b/cordova-plugin-outline/android/scripts/copy_third_party.js
@@ -18,9 +18,9 @@ const child_process = require('child_process');
 
 module.exports = function(context) {
   console.log('Copying Android third party libraries...');
-  ['arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64'].forEach((arch) => {
-    const destDir = `plugins/cordova-plugin-outline/android/libs/${arch}/`
-    child_process.execSync(`mkdir -p ${destDir}`);
-    child_process.execSync(`cp third_party/shadowsocks-libev/android/libs/${arch}/*.so ${destDir}`);
-  });
+  child_process.execSync('mkdir -p plugins/cordova-plugin-outline/android/libs');
+  child_process.execSync(
+      `cp third_party/outline-go-tun2socks/android/tun2socks.aar plugins/cordova-plugin-outline/android/libs/`);
+  child_process.execSync(
+      `cp -R third_party/outline-go-tun2socks/android/jni plugins/cordova-plugin-outline/android/libs/obj`);
 }

--- a/cordova-plugin-outline/plugin.xml
+++ b/cordova-plugin-outline/plugin.xml
@@ -63,39 +63,15 @@
       src="android/java/org/outline/vpn"
       target-dir="app/src/main/java/org/outline" />
     <source-file
-      src="android/java/org/outline/shadowsocks"
-      target-dir="app/src/main/java/org/outline" />
-    <source-file
-      src="android/java/org/outline/tun2socks"
-      target-dir="app/src/main/java/org/outline" />
-    <source-file
       src="android/java/org/outline/log"
       target-dir="app/src/main/java/org/outline" />
-
     <source-file
-      src="android/libs/arm64-v8a/libss-local.so"
-      target-dir="app/src/main/jniLibs/arm64-v8a" />
+      src="android/libs/tun2socks.aar"
+      target-dir="app/src/main/libs" />
+    <!-- These are JNI libraries with debug symbols required for crash reporting tools. -->
     <source-file
-      src="android/libs/arm64-v8a/libtun2socks.so"
-      target-dir="app/src/main/jniLibs/arm64-v8a" />
-    <source-file
-      src="android/libs/x86_64/libss-local.so"
-      target-dir="app/src/main/jniLibs/x86_64" />
-    <source-file
-      src="android/libs/x86_64/libtun2socks.so"
-      target-dir="app/src/main/jniLibs/x86_64" />
-    <source-file
-      src="android/libs/armeabi-v7a/libss-local.so"
-      target-dir="app/src/main/jniLibs/armeabi-v7a" />
-    <source-file
-      src="android/libs/armeabi-v7a/libtun2socks.so"
-      target-dir="app/src/main/jniLibs/armeabi-v7a" />
-    <source-file
-      src="android/libs/x86/libss-local.so"
-      target-dir="app/src/main/jniLibs/x86" />
-    <source-file
-      src="android/libs/x86/libtun2socks.so"
-      target-dir="app/src/main/jniLibs/x86" />
+      src="android/libs/obj"
+      target-dir="app/" />
 
     <resource-file src="android/resources/small_icon.png" target="res/drawable/small_icon.png" />
     <resource-file src="android/resources/bypass_subnets.xml" target="res/values/bypass_subnets.xml" />


### PR DESCRIPTION
- Merges the Android client Go network stack from the [go-tun2socks](https://github.com/Jigsaw-Code/outline-client/tree/go-tun2socks) feature branch at ca0f04b.
  - Deprecates shadowsocks-libev and badvpn-tun2socks for Android.
  - Connectivity checks are also migrated to Go (VPN service process).
- Starting from v1.5.0, the Android clients has been released from the go-tun2socks branch.
- All code in this PR has been reviewed before merging into the go-tun2socks branch (i.e. #664, #670).
- Updates the cordova-plugin-oultine documentation.