### PR TITLE
Android: sample VPN process error reports

### DIFF
--- a/cordova-plugin-outline/android/java/org/outline/vpn/VpnTunnelService.java
+++ b/cordova-plugin-outline/android/java/org/outline/vpn/VpnTunnelService.java
@@ -442,7 +442,7 @@ public class VpnTunnelService extends VpnService {
 
   private void initErrorReporting(final String apiKey) {
     try {
-      SentryErrorReporter.init(getApplicationContext(), apiKey);
+      SentryErrorReporter.init(this, apiKey);
     } catch (Exception e) {
       LOG.log(Level.SEVERE, "Failed to initialize Sentry", e);
     }


### PR DESCRIPTION
- Now that the VPN service runs in a separate process and is automatically restarted on crashes, we are seeing an increase of native (JNI/Go) Sentry error reports.
- Sets a sample rate for the VPN service process error reports in order to reduce the volume of automatic crash reports.
- Does not affect user feedback reports, or error reports in the main app process.
