### PR TITLE
add quotes to $ROOT_DIR in case of bad chars

### DIFF
--- a/scripts/do_action.sh
+++ b/scripts/do_action.sh
@@ -16,14 +16,14 @@
 
 set -eux
 
-export ROOT_DIR=${ROOT_DIR:-$(git rev-parse --show-toplevel)}
-export BUILD_DIR=${BUILD_DIR:-$ROOT_DIR/build}
+export ROOT_DIR="${ROOT_DIR:-$(git rev-parse --show-toplevel)}"
+export BUILD_DIR="${BUILD_DIR:-$ROOT_DIR/build}"
 
 function do_action() {
   local action=$1
   echo "[Running $action]"
   shift
-  $ROOT_DIR/${action}_action.sh "$@"
+  "$ROOT_DIR/${action}_action.sh" "$@"
   echo "[Done $action]"
 }
 export -f do_action

--- a/scripts/l10n/import_native_android_strings_action.sh
+++ b/scripts/l10n/import_native_android_strings_action.sh
@@ -32,13 +32,13 @@ function get_native_android_locale() {
 }
 
 TRANSLATIONS_DIR="$ROOT_DIR/www/messages"
-for TRANSLATION_FILE in $TRANSLATIONS_DIR/*; do
+for TRANSLATION_FILE in "$TRANSLATIONS_DIR/*"; do
   LANG=`basename $TRANSLATION_FILE .json`
   echo "Importing ${LANG}"
   LANG=$(get_native_android_locale $LANG)
 
   NATIVE_DIR="cordova-plugin-outline/android/resources/strings/values-$LANG"
   OUTPUT_FILE="$NATIVE_DIR/strings.xml"
-  python $ROOT_DIR/scripts/l10n/import_native_android_strings.py $TRANSLATION_FILE $OUTPUT_FILE
+  python "$ROOT_DIR/scripts/l10n/import_native_android_strings.py" $TRANSLATION_FILE $OUTPUT_FILE
 done
 

--- a/scripts/test_action.sh
+++ b/scripts/test_action.sh
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 readonly TEST_DIR="${ROOT_DIR}/build/test"
-rm -rf $TEST_DIR
+rm -rf "$TEST_DIR"
 
 yarn install --check-files
-tsc -p $ROOT_DIR/src/www --outDir $TEST_DIR
-jasmine --config=$ROOT_DIR/jasmine.json
+tsc -p "$ROOT_DIR/src/www" --outDir "$TEST_DIR"
+jasmine "--config=$ROOT_DIR/jasmine.json"

--- a/third_party/shadowsocks-libev/linux_action.sh
+++ b/third_party/shadowsocks-libev/linux_action.sh
@@ -14,12 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-THIRD_PARTY_DIR=$ROOT_DIR/third_party
-LIBEV_DIR=$THIRD_PARTY_DIR/libev/linux
-MBEDTLS_DIR=$THIRD_PARTY_DIR/mbedtls/linux
-PCRE_DIR=$THIRD_PARTY_DIR/pcre/linux
-LIBSODIUM_DIR=$THIRD_PARTY_DIR/sodium/linux
-CARES_DIR=$THIRD_PARTY_DIR/c-ares/linux
+THIRD_PARTY_DIR="$ROOT_DIR/third_party"
+LIBEV_DIR="$THIRD_PARTY_DIR/libev/linux"
+MBEDTLS_DIR="$THIRD_PARTY_DIR/mbedtls/linux"
+PCRE_DIR="$THIRD_PARTY_DIR/pcre/linux"
+LIBSODIUM_DIR="$THIRD_PARTY_DIR/sodium/linux"
+CARES_DIR="$THIRD_PARTY_DIR/c-ares/linux"
 INSTALL_DIR=$(mktemp -d /tmp/temp.XXXX)
 
 echo "Building shadowsocks-libev (ss-local) for Linux..."
@@ -27,13 +27,13 @@ pushd $(dirname $0) > /dev/null
 
 # Build in-place due to lack of support to build out of tree in libcork.
 ./autogen.sh
-./configure --with-mbedtls=$MBEDTLS_DIR --with-pcre=$PCRE_DIR \
-	--with-sodium=$LIBSODIUM_DIR --with-cares=$CARES_DIR --with-ev=$LIBEV_DIR \
-	--prefix=$INSTALL_DIR --disable-documentation
+./configure "--with-mbedtls=$MBEDTLS_DIR" "--with-pcre=$PCRE_DIR" \
+	"--with-sodium=$LIBSODIUM_DIR" "--with-cares=$CARES_DIR" "--with-ev=$LIBEV_DIR" \
+	"--prefix=$INSTALL_DIR" --disable-documentation
 make install -j
 
 # Copy binary
-cp $INSTALL_DIR/bin/ss-local linux/
+cp "$INSTALL_DIR/bin/ss-local" linux/
 
 # Clean up
 make clean

--- a/tools/find_tap_name/build_action.sh
+++ b/tools/find_tap_name/build_action.sh
@@ -14,6 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-pushd $ROOT_DIR/tools/find_tap_name/ > /dev/null
+pushd "$ROOT_DIR/tools/find_tap_name/" > /dev/null
 GOOS=windows; GOARCH=386; go build -o bin/386/
 GOOS=windows; GOARCH=amd64; go build -o bin/amd64/


### PR DESCRIPTION
I have a bit of a wacky file system setup where my folders contain strange characters - spaces and parentheses, etc. In order to support building the client on my machine, I had to wrap all instances of `$ROOT_DIR` and vars derived from `$ROOT_DIR` in double quotes to escape these characters. Doing so I am now able to run `do_action.sh` successfully.