### PR TITLE
macOS release updates

### DIFF
--- a/apple/xcode/osx/Outline.xcodeproj/project.pbxproj
+++ b/apple/xcode/osx/Outline.xcodeproj/project.pbxproj
@@ -301,9 +301,9 @@
 			children = (
 				FCB2DED41F3E3CAD000C6A44 /* VpnExtension.entitlements */,
 				FC5FF9121F3E1D1B0032A745 /* Outline.entitlements */,
+				70BD682D18FFB02D00A1EFCF /* Supporting Files */,
 				707060AE18FFC05700755D46 /* MainViewController.xib */,
 				70BD683E18FFB02D00A1EFCF /* Images.xcassets */,
-				70BD682D18FFB02D00A1EFCF /* Supporting Files */,
 			);
 			path = Outline;
 			sourceTree = "<group>";
@@ -688,6 +688,7 @@
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				EXCLUDED_ARCHS = arm64;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
@@ -747,6 +748,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				EXCLUDED_ARCHS = arm64;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_NO_COMMON_BLOCKS = YES;

--- a/apple/xcode/osx/Outline.xcodeproj/project.pbxproj
+++ b/apple/xcode/osx/Outline.xcodeproj/project.pbxproj
@@ -688,7 +688,7 @@
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				EXCLUDED_ARCHS = arm64;
+				EXCLUDED_ARCHS = arm64; /* Remove once framework dependencies support Apple Silicon */
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
@@ -748,7 +748,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				EXCLUDED_ARCHS = arm64;
+				EXCLUDED_ARCHS = arm64; /* Remove once framework dependencies support Apple Silicon */
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_NO_COMMON_BLOCKS = YES;

--- a/apple/xcode/osx/Outline/Outline-Info.plist
+++ b/apple/xcode/osx/Outline/Outline-Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.5.0</string>
 	<key>CFBundleVersion</key>
-	<string>25</string>
+	<string>26</string>
   <key>CFBundleDevelopmentRegion</key>
   <string>en</string>
   <key>CFBundleExecutable</key>

--- a/apple/xcode/osx/Outline/VpnExtension-Info.plist
+++ b/apple/xcode/osx/Outline/VpnExtension-Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.5.0</string>
 	<key>CFBundleVersion</key>
-	<string>25</string>
+	<string>26</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
 	<key>NSExtension</key>

--- a/src/www/ui_components/app-root.js
+++ b/src/www/ui_components/app-root.js
@@ -694,7 +694,7 @@ export class AppRoot extends mixinBehaviors
   }
 
   _computeShouldShowQuitButton(platform) {
-    return platform === 'Electron';
+    return platform === 'macOS' || platform === 'Electron';
   }
 
   _computeIsLastVisibleMenuItem(shouldShowQuitButton) {

--- a/src/www/ui_components/app-root.js
+++ b/src/www/ui_components/app-root.js
@@ -694,7 +694,7 @@ export class AppRoot extends mixinBehaviors
   }
 
   _computeShouldShowQuitButton(platform) {
-    return platform === 'Mac OS X' || platform === 'Electron';
+    return platform === 'Electron';
   }
 
   _computeIsLastVisibleMenuItem(shouldShowQuitButton) {


### PR DESCRIPTION
- Removes the quit button from the macOS client app.
- Builds the macos app only for x86_64 - Xcode 12.5 builds all architecures (including arm64) by default.
- Bumps the macos client bundle version.