### PR TITLE
CI build for Linux, Windows, MacOS and Android

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -75,27 +75,29 @@ jobs:
       - name: Build OSX Client
         run: npx gulp build --platform=osx
 
-  ios:
-    name: iOS
-    runs-on: macos-11
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2.3.4
+  # TODO: setup fastlane for iOS
+  
+  # ios:
+  #   name: iOS
+  #   runs-on: macos-11
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2.3.4
 
-      - name: Install Node
-        uses: actions/setup-node@v2.2.0
-        with:
-          node-version: 16
-          cache: npm
+  #     - name: Install Node
+  #       uses: actions/setup-node@v2.2.0
+  #       with:
+  #         node-version: 16
+  #         cache: npm
 
-      - name: Install NPM Dependencies
-        run: npm ci
+  #     - name: Install NPM Dependencies
+  #       run: npm ci
 
-      - name: Set XCode Version
-        run: sudo xcode-select -switch /Applications/Xcode_12.5.app
+  #     - name: Set XCode Version
+  #       run: sudo xcode-select -switch /Applications/Xcode_12.5.app
 
-      - name: Build iOS Client
-        run: npx gulp build --platform=ios
+  #     - name: Build iOS Client
+  #       run: npm run action apple/scripts/ios_package_remote
 
   android:
     name: Android

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -70,7 +70,7 @@ jobs:
         run: npm ci
 
       - name: Set XCode Settings
-        run: sudo xcode-select -switch /Applications/Xcode_13.2.app
+        run: sudo xcode-select -switch /Applications/Xcode_12.4.app
 
       - name: Print Build Settings
         run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -102,6 +102,9 @@ jobs:
   android:
     name: Android
     runs-on: ubuntu-20.04
+    env:
+      ANDROID_BUILD_TOOLS_VERSION: 30.0.2
+      NDK_VERSION: 21.0.6113669
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
@@ -123,12 +126,8 @@ jobs:
       - name: Setup Android
         uses: android-actions/setup-android@v2
 
-      # - name: Set Android SDK Version
-      #   run: |
-      #     sdkmanager "build-tools;30.0.2" "platforms;android-29"
+      - name: Set Android SDK Version
+        run: sdkmanager "build-tools;30.0.2"
 
       - name: Build Android Client
         run: npx gulp build --platform=android
-        env:
-          ANDROID_BUILD_TOOLS_VERSION: 30.0.2
-          NDK_VERSION: 21.0.6113669

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -117,7 +117,7 @@ jobs:
         uses: android-actions/setup-android@v2
 
       - name: Set Android SDK Version
-        run: sdkmanager "platform;android-29"
+        run: sdkmanager "platforms;android-29"
 
       - name: Build Android Client
         run: npx gulp build --platform=android

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Build OSX Client
         run: npx gulp build --platform=osx
 
-  mac:
+  ios:
     name: iOS
     runs-on: macos-11
     steps:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -132,10 +132,6 @@ jobs:
             && unzip -q android-commandline-tools.zip -d ${ANDROID_SDK_ROOT}/cmdline-tools \
             && rm android-commandline-tools.zip
           PATH="${PATH}:${ANDROID_SDK_ROOT}/platform-tools:${ANDROID_SDK_ROOT}/cmdline-tools/tools/bin"
-
-      - name: Set Android SDK Version
-        env:
-        run: |
           yes | sdkmanager \
             "build-tools;${ANDROID_BUILD_TOOLS_VERSION}" \
             "ndk;${NDK_VERSION}"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -123,10 +123,12 @@ jobs:
       - name: Setup Android
         uses: android-actions/setup-android@v2
 
-      - name: Set Android SDK Version
-        run: |
-          sdkmanager "build-tools;30.0.2" "platforms;android-29"
-          export ANDROID_BUILD_TOOLS_VERSION=30.0.2
+      # - name: Set Android SDK Version
+      #   run: |
+      #     sdkmanager "build-tools;30.0.2" "platforms;android-29"
 
       - name: Build Android Client
         run: npx gulp build --platform=android
+        env:
+          ANDROID_BUILD_TOOLS_VERSION: 30.0.2
+          NDK_VERSION: 21.0.6113669

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -8,28 +8,110 @@ on:
   pull_request:
 
 jobs:
-  build-and-test:
-    name: Build and Test Web and Electron Apps
-    runs-on: ubuntu-latest
+  linux:
+    name: Linux
+    runs-on: ubuntu-20.04
 
     steps:
-      - name: Checkout repo
+      - name: Checkout
         uses: actions/checkout@v2.3.4
 
-      - name: Install Node.js
+      - name: Install Node
         uses: actions/setup-node@v2.2.0
         with:
           node-version: 16
           cache: npm
       
-      - name: Install dependencies
+      - name: Install Dependencies
         run: npm ci
 
-      - name: Build web app
+      - name: Build Web App
         run: npx gulp build --platform=browser
-      
-      - name: Test web app
+
+      - name: Test Web App
         run: npm run action scripts/test
 
-      - name: Build Electron app
-        run: npm run action src/electron/build
+      - name: Build Electron App
+        run: npm run action src/electron/package_linux
+
+  windows:
+    name: Windows (Wine)
+    # When updating Ubuntu versions, you will need to update the Wine APT commands.  See below.
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+
+      - name: Install Node
+        uses: actions/setup-node@v2.2.0
+        with:
+          node-version: 16
+          cache: npm
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Install Wine
+        run: |
+          sudo dpkg --add-architecture i386
+          wget -nc https://dl.winehq.org/wine-builds/winehq.key
+          sudo apt-key add winehq.key
+          # This APT repo is specific to ubuntu 20.04. See https://wiki.winehq.org/Ubuntu when updating Ubuntu versions
+          sudo add-apt-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ focal main'
+          sudo apt update && sudo apt install --install-recommends winehq-stable\
+      - name: Build Windows Client
+        run: npm run action src/electron/package_windows
+
+  mac:
+    name: Apple
+    runs-on: macos-10.15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+
+      - name: Install Node
+        uses: actions/setup-node@v2.2.0
+        with:
+          node-version: 16
+          cache: npm
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Set XCode Settings
+        run: sudo xcode-select -switch /Applications/Xcode_11.7.app
+
+      - name: Print Build Settings
+        run: |
+          cd apple/xcode/osx
+          xcodebuild -project Outline.xcodeproj -showBuildSettings
+      
+      - name: Build OSX Client
+        run: npx gulp build --platform=osx
+
+      - name: Build iOS Client
+        run: npm run action apple/scripts/ios_package_remote
+
+  android:
+    name: Android
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+
+      - name: Install Java
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: 1.8
+
+      - name: Install Node
+        uses: actions/setup-node@v2.2.0
+        with:
+          node-version: 16
+          cache: npm
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build Android Client
+        run: npx gulp build --platform=android

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -54,7 +54,7 @@ jobs:
         run: npm run action src/electron/package_windows
 
   mac:
-    name: Apple
+    name: MacOS
     runs-on: macos-11
     steps:
       - name: Checkout
@@ -74,6 +74,25 @@ jobs:
 
       - name: Build OSX Client
         run: npx gulp build --platform=osx
+
+  mac:
+    name: iOS
+    runs-on: macos-11
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+
+      - name: Install Node
+        uses: actions/setup-node@v2.2.0
+        with:
+          node-version: 16
+          cache: npm
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Set XCode Version
+        run: sudo xcode-select -switch /Applications/Xcode_12.5.app
 
       - name: Build iOS Client
         run: npm run action apple/scripts/ios_package_remote

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -70,7 +70,7 @@ jobs:
         run: npm ci
 
       - name: Set XCode Settings
-        run: sudo xcode-select -switch /Applications/Xcode_11.7.app
+        run: sudo xcode-select -switch /Applications/Xcode_13.2.app
 
       - name: Print Build Settings
         run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -122,7 +122,9 @@ jobs:
         uses: android-actions/setup-android@v2
 
       - name: Set Android SDK Version
-        run: sdkmanager "build-tools;30.0.0" "platforms;android-29"
+        run: |
+          sdkmanager "platforms;android-29"
+          mklink %ANDROID_HOME%\build-tools\31.0.0\dx.bat %ANDROID_HOME%\build-tools\31.0.0\d8.bat && mklink %ANDROID_HOME%\build-tools\31.0.0\lib\dx.jar %ANDROID_HOME%\build-tools\31.0.0\lib\d8.jar
 
       - name: Build Android Client
         run: npx gulp build --platform=android

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -99,8 +99,8 @@ jobs:
         with:
           java-version: 1.8
 
-      - name: Install Android SDK
-        run: sudo apt install android-sdk
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
 
       - name: Build Android Client
         run: npx gulp build --platform=android

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,8 +36,7 @@ jobs:
 
   windows:
     name: Windows
-    # When updating Ubuntu versions, you will need to update the Wine APT commands.  See below.
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
@@ -51,14 +50,6 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-      # - name: Install Wine
-      #   run: |
-      #     sudo dpkg --add-architecture i386
-      #     wget -nc https://dl.winehq.org/wine-builds/winehq.key
-      #     sudo apt-key add winehq.key
-      #     # This APT repo is specific to ubuntu 20.04. See https://wiki.winehq.org/Ubuntu when updating Ubuntu versions
-      #     sudo add-apt-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ focal main'
-      #     sudo apt update && sudo apt install --install-recommends winehq-stable\
       - name: Build Windows Client
         run: npm run action src/electron/package_windows
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -122,7 +122,7 @@ jobs:
         uses: android-actions/setup-android@v2
 
       - name: Set Android SDK Version
-        run: sdkmanager "platforms;android-29"
+        run: sdkmanager "build-tools;30.0.0" "platforms;android-29"
 
       - name: Build Android Client
         run: npx gulp build --platform=android

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -113,6 +113,9 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
+      - name: Setup Android
+        run: android-actions/setup-android@v2
+
       - name: Set Android SDK Version
         run: sdkmanager "platform;android-29"
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -55,7 +55,7 @@ jobs:
 
   mac:
     name: Apple
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -91,6 +91,9 @@ jobs:
           node-version: 16
           cache: npm
 
+      - name: Install Dependencies
+        run: npm ci
+
       - name: Install Java
         uses: actions/setup-java@v1.4.3
         with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -105,6 +105,7 @@ jobs:
     env:
       ANDROID_BUILD_TOOLS_VERSION: 30.0.2
       NDK_VERSION: 21.0.6113669
+      ANDROID_SDK_ROOT: /opt/android-sdk
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
@@ -124,10 +125,20 @@ jobs:
           java-version: 1.8
 
       - name: Setup Android
-        uses: android-actions/setup-android@v2
+        run: |
+          cd /opt \
+            && wget -q https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip -O android-commandline-tools.zip \
+            && mkdir -p ${ANDROID_SDK_ROOT}/cmdline-tools \
+            && unzip -q android-commandline-tools.zip -d ${ANDROID_SDK_ROOT}/cmdline-tools \
+            && rm android-commandline-tools.zip
 
       - name: Set Android SDK Version
-        run: sdkmanager "build-tools;30.0.2"
+        env:
+          PATH: ${PATH}:${ANDROID_SDK_ROOT}/platform-tools:${ANDROID_SDK_ROOT}/cmdline-tools/tools/bin
+        run: |
+          yes | sdkmanager \
+            "build-tools;${ANDROID_BUILD_TOOLS_VERSION}" \
+            "ndk;${NDK_VERSION}"
 
       - name: Build Android Client
         run: npx gulp build --platform=android

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -124,9 +124,7 @@ jobs:
         uses: android-actions/setup-android@v2
 
       - name: Set Android SDK Version
-        run: |
-          sdkmanager "platforms;android-29"
-          sdkmanager --uninstall "build-tools;31.0.0"
+        run: sdkmanager "build-tools;30.0.2" "platforms;android-29"
 
       - name: Build Android Client
         run: npx gulp build --platform=android

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-      - name: Set XCode Settings
+      - name: Set XCode Version
         run: sudo xcode-select -switch /Applications/Xcode_12.5.app
 
       - name: Build OSX Client
@@ -94,13 +94,8 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-      - name: Install Java
-        uses: actions/setup-java@v1.4.3
-        with:
-          java-version: 1.8
-
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v2
+      - name: Set Android SDK Version
+        run: sdkmanager "platform;android-29"
 
       - name: Build Android Client
         run: npx gulp build --platform=android

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -124,7 +124,9 @@ jobs:
       - name: Set Android SDK Version
         run: |
           sdkmanager "platforms;android-29"
-          mklink %ANDROID_HOME%\build-tools\31.0.0\dx.bat %ANDROID_HOME%\build-tools\31.0.0\d8.bat && mklink %ANDROID_HOME%\build-tools\31.0.0\lib\dx.jar %ANDROID_HOME%\build-tools\31.0.0\lib\d8.jar
+          cd $ANDROID_HOME/build-tools/31.0.0
+          ln -s d8 dx
+          ln -s lib/d8.jar lib/dx.jar
 
       - name: Build Android Client
         run: npx gulp build --platform=android

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -131,10 +131,10 @@ jobs:
             && mkdir -p ${ANDROID_SDK_ROOT}/cmdline-tools \
             && unzip -q android-commandline-tools.zip -d ${ANDROID_SDK_ROOT}/cmdline-tools \
             && rm android-commandline-tools.zip
+          PATH="${PATH}:${ANDROID_SDK_ROOT}/platform-tools:${ANDROID_SDK_ROOT}/cmdline-tools/tools/bin"
 
       - name: Set Android SDK Version
         env:
-          PATH: ${PATH}:${ANDROID_SDK_ROOT}/platform-tools:${ANDROID_SDK_ROOT}/cmdline-tools/tools/bin
         run: |
           yes | sdkmanager \
             "build-tools;${ANDROID_BUILD_TOOLS_VERSION}" \

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -114,7 +114,7 @@ jobs:
         run: npm ci
 
       - name: Setup Android
-        run: android-actions/setup-android@v2
+        uses: android-actions/setup-android@v2
 
       - name: Set Android SDK Version
         run: sdkmanager "platform;android-29"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -97,7 +97,7 @@ jobs:
           java-version: 1.8
 
       - name: Install Android SDK
-        uses: android-actions/setup-android@v2
+        run: sudo apt install android-sdk
 
       - name: Build Android Client
         run: npx gulp build --platform=android

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: 16
           cache: npm
       
-      - name: Install Dependencies
+      - name: Install NPM Dependencies
         run: npm ci
 
       - name: Build Web App
@@ -47,7 +47,7 @@ jobs:
           node-version: 16
           cache: npm
 
-      - name: Install Dependencies
+      - name: Install NPM Dependencies
         run: npm ci
 
       - name: Build Windows Client
@@ -66,7 +66,7 @@ jobs:
           node-version: 16
           cache: npm
 
-      - name: Install Dependencies
+      - name: Install NPM Dependencies
         run: npm ci
 
       - name: Set XCode Version
@@ -88,7 +88,7 @@ jobs:
           node-version: 16
           cache: npm
 
-      - name: Install Dependencies
+      - name: Install NPM Dependencies
         run: npm ci
 
       - name: Set XCode Version
@@ -110,8 +110,13 @@ jobs:
           node-version: 16
           cache: npm
 
-      - name: Install Dependencies
+      - name: Install NPM Dependencies
         run: npm ci
+
+      - name: Install Java
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: 1.8
 
       - name: Setup Android
         uses: android-actions/setup-android@v2

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -124,9 +124,7 @@ jobs:
       - name: Set Android SDK Version
         run: |
           sdkmanager "platforms;android-29"
-          cd $ANDROID_HOME/build-tools/31.0.0
-          ln -s d8 dx
-          ln -s lib/d8.jar lib/dx.jar
+          sdkmanager --uninstall "build-tools;31.0.0"
 
       - name: Build Android Client
         run: npx gulp build --platform=android

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -124,7 +124,9 @@ jobs:
         uses: android-actions/setup-android@v2
 
       - name: Set Android SDK Version
-        run: sdkmanager "build-tools;30.0.2" "platforms;android-29"
+        run: |
+          sdkmanager "build-tools;30.0.2" "platforms;android-29"
+          export ANDROID_BUILD_TOOLS_VERSION=30.0.2
 
       - name: Build Android Client
         run: npx gulp build --platform=android

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -72,11 +72,6 @@ jobs:
       - name: Set XCode Settings
         run: sudo xcode-select -switch /Applications/Xcode_12.5.app
 
-      - name: Print Build Settings
-        run: |
-          cd apple/xcode/osx
-          xcodebuild -project Outline.xcodeproj -showBuildSettings
-      
       - name: Build OSX Client
         run: npx gulp build --platform=osx
 
@@ -90,16 +85,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.3.4
 
-      - name: Install Java
-        uses: actions/setup-java@v1.4.3
-        with:
-          java-version: 1.8
-
       - name: Install Node
         uses: actions/setup-node@v2.2.0
         with:
           node-version: 16
           cache: npm
 
+      - name: Install Java
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: 1.8
+
+      - name: Install Android SDK
+        uses: android-actions/setup-android@v2
+
       - name: Build Android Client
-        run: ./tools/build/build.sh npm ci && npx gulp build --platform=android
+        run: npx gulp build --platform=android

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -102,7 +102,7 @@ jobs:
           cache: npm
 
       - name: Install Dependencies
-        run: npm ci
+        run: ./tools/build/build.sh npm ci
 
       - name: Build Android Client
-        run: npx gulp build --platform=android
+        run: ./tools/build/build.sh npx gulp build --platform=android

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -70,7 +70,7 @@ jobs:
         run: npm ci
 
       - name: Set XCode Settings
-        run: sudo xcode-select -switch /Applications/Xcode_12.4.app
+        run: sudo xcode-select -switch /Applications/Xcode_12.5.app
 
       - name: Print Build Settings
         run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -101,8 +101,5 @@ jobs:
           node-version: 16
           cache: npm
 
-      - name: Install Dependencies
-        run: ./tools/build/build.sh npm ci
-
       - name: Build Android Client
-        run: ./tools/build/build.sh npx gulp build --platform=android
+        run: ./tools/build/build.sh npm ci && npx gulp build --platform=android

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -95,7 +95,7 @@ jobs:
         run: sudo xcode-select -switch /Applications/Xcode_12.5.app
 
       - name: Build iOS Client
-        run: npm run action apple/scripts/ios_package_remote
+        run: npx gulp build --platform=ios
 
   android:
     name: Android

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -35,9 +35,9 @@ jobs:
         run: npm run action src/electron/package_linux
 
   windows:
-    name: Windows (Wine)
+    name: Windows
     # When updating Ubuntu versions, you will need to update the Wine APT commands.  See below.
-    runs-on: ubuntu-20.04
+    runs-on: windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
@@ -51,14 +51,14 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-      - name: Install Wine
-        run: |
-          sudo dpkg --add-architecture i386
-          wget -nc https://dl.winehq.org/wine-builds/winehq.key
-          sudo apt-key add winehq.key
-          # This APT repo is specific to ubuntu 20.04. See https://wiki.winehq.org/Ubuntu when updating Ubuntu versions
-          sudo add-apt-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ focal main'
-          sudo apt update && sudo apt install --install-recommends winehq-stable\
+      # - name: Install Wine
+      #   run: |
+      #     sudo dpkg --add-architecture i386
+      #     wget -nc https://dl.winehq.org/wine-builds/winehq.key
+      #     sudo apt-key add winehq.key
+      #     # This APT repo is specific to ubuntu 20.04. See https://wiki.winehq.org/Ubuntu when updating Ubuntu versions
+      #     sudo add-apt-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ focal main'
+      #     sudo apt update && sudo apt install --install-recommends winehq-stable\
       - name: Build Windows Client
         run: npm run action src/electron/package_windows
 

--- a/tools/build/build.sh
+++ b/tools/build/build.sh
@@ -51,9 +51,9 @@ if (( $# > 0 )); then
   readonly GIT_ROOT=$(git rev-parse --show-toplevel)
   # Rather than a working directory of something like "/worker", mirror
   # the path on the host so that symlink tricks work as expected.
-  docker run --rm -i -v "$GIT_ROOT":"$GIT_ROOT" -w "$GIT_ROOT" -e SENTRY_DSN=${SENTRY_DSN:-} $IMAGE_NAME "$@"
+  docker run --rm -ti -v "$GIT_ROOT":"$GIT_ROOT" -w "$GIT_ROOT" -e SENTRY_DSN=${SENTRY_DSN:-} $IMAGE_NAME "$@"
   # GNU stat uses -c for format, which BSD stat does not accept; it uses -f instead
   stat -c 2>&1 | grep -q illegal && STATFLAG="f" || STATFLAG="c"
   # TODO: Don't spin up a second container just to chown.
-  docker run --rm -i -v "$GIT_ROOT":/worker -w /worker $IMAGE_NAME chown -R $(stat -$STATFLAG "%u:%g" .git) /worker
+  docker run --rm -ti -v "$GIT_ROOT":/worker -w /worker $IMAGE_NAME chown -R $(stat -$STATFLAG "%u:%g" .git) /worker
 fi

--- a/tools/build/build.sh
+++ b/tools/build/build.sh
@@ -51,9 +51,9 @@ if (( $# > 0 )); then
   readonly GIT_ROOT=$(git rev-parse --show-toplevel)
   # Rather than a working directory of something like "/worker", mirror
   # the path on the host so that symlink tricks work as expected.
-  docker run --rm -ti -v "$GIT_ROOT":"$GIT_ROOT" -w "$GIT_ROOT" -e SENTRY_DSN=${SENTRY_DSN:-} $IMAGE_NAME "$@"
+  docker run --rm -i -v "$GIT_ROOT":"$GIT_ROOT" -w "$GIT_ROOT" -e SENTRY_DSN=${SENTRY_DSN:-} $IMAGE_NAME "$@"
   # GNU stat uses -c for format, which BSD stat does not accept; it uses -f instead
   stat -c 2>&1 | grep -q illegal && STATFLAG="f" || STATFLAG="c"
   # TODO: Don't spin up a second container just to chown.
-  docker run --rm -ti -v "$GIT_ROOT":/worker -w /worker $IMAGE_NAME chown -R $(stat -$STATFLAG "%u:%g" .git) /worker
+  docker run --rm -i -v "$GIT_ROOT":/worker -w /worker $IMAGE_NAME chown -R $(stat -$STATFLAG "%u:%g" .git) /worker
 fi


### PR DESCRIPTION
This is a continuation of @JonathanDCohen's previous work. It individually builds clients for Linux, Windows, MacOS and Android in the CI. We need to set up fastlane w/ GH actions to support iOS.

<details>
<summary>TODOs:</summary>

- [x] install android SDK 29 manually
- [x] install xcode 12.5 manually
- [x] android sdk is in incorrect place? :/
- [x] fastlane issue
</details>