### PR TITLE
🐛 fix(ui): ensure the error message is displayed when access key is invalid

### DIFF
--- a/src/www/app/app.ts
+++ b/src/www/app/app.ts
@@ -312,9 +312,9 @@ export class App {
       this.serverRepo.validateAccessKey(accessKey);
       addServerView.openAddServerConfirmationSheet(accessKey);
     } catch (e) {
-      addServerView.close();
       if (!fromClipboard && e instanceof errors.ServerAlreadyAdded) {
         // Display error message and don't propagate error if this is not a clipboard add.
+        addServerView.close();
         this.showLocalizedError(e);
         return;
       }

--- a/src/www/ui_components/add-server-view.js
+++ b/src/www/ui_components/add-server-view.js
@@ -148,7 +148,7 @@ Polymer({
       }
     </style>
 
-    <paper-dialog id="addServerSheet" with-backdrop="">
+    <paper-dialog id="addServerSheet" with-backdrop>
       <div class="vertical-margin">
         <div class="title">[[localize('server-add-access-key')]]</div>
         <div class="faded">[[localize('server-add-instructions')]]</div>
@@ -165,7 +165,7 @@ Polymer({
     <!-- no-cancel-on-outside-click prevents the dialog appearing for only
          an instant when the user clicks on some other part of the window.
          This is a real problem on desktop. -->
-    <paper-dialog id="serverDetectedSheet" with-backdrop="" no-cancel-on-outside-click="">
+    <paper-dialog id="serverDetectedSheet" with-backdrop no-cancel-on-outside-click>
       <div class="vertical-margin">
         <div class="title">[[localize('server-access-key-detected')]]</div>
         <div class="faded">


### PR DESCRIPTION
### Problem
When user pastes or types an invalid access key in the "Add server dialog", the dialog will be dismissed without any notifications; nothing changed on the main UI either. So our users are pretty confused and do not know what's going on.

### Solution

This is because we will **always** close the dialog to show the "server already added" notification. However this notification will only be popped up when the exception matches `errors.ServerAlreadyAdded`. For other types of exception, although we had an error message "invalid access key" in the dialog, the dialog itself is dismissed regardless of the exception type.

So the fix is pretty simple, only dismiss the dialog when exception is `errors.ServerAlreadyAdded`.

P.S., also fixed two related boolean attribute usage.

### Screenshots

<img width="938" alt="Screen Shot 2021-11-30 at 5 25 55 PM" src="https://user-images.githubusercontent.com/93548144/144155076-375a6442-95f4-43a7-a680-6d3df694a88c.png">


Fixes #1063 .