### PR TITLE
fix(electron): add contextRegExp to webpack.IgnorePlugin

### DIFF
--- a/src/www/electron.webpack.js
+++ b/src/www/electron.webpack.js
@@ -54,7 +54,7 @@ module.exports = makeConfig({
     // @sentry/electron depends on electron code, even though it's never activated
     // in the browser. Webpack still tries to build it, but fails with missing APIs.
     // The IgnorePlugin prevents the compilation of the electron dependency.
-    new webpack.IgnorePlugin({resourceRegExp: /^electron$/}),
+    new webpack.IgnorePlugin({resourceRegExp: /^electron$/, contextRegExp: /^electron$/}),
     new HtmlWebpackPlugin({
       filename: 'electron_index.html',
       template: path.resolve(__dirname, './electron_index.html'),

--- a/src/www/electron.webpack.js
+++ b/src/www/electron.webpack.js
@@ -54,7 +54,8 @@ module.exports = makeConfig({
     // @sentry/electron depends on electron code, even though it's never activated
     // in the browser. Webpack still tries to build it, but fails with missing APIs.
     // The IgnorePlugin prevents the compilation of the electron dependency.
-    new webpack.IgnorePlugin({resourceRegExp: /^electron$/, contextRegExp: /^electron$/}),
+    new webpack.IgnorePlugin(
+        {resourceRegExp: /^electron$/, contextRegExp: /@sentry\/electron/}),
     new HtmlWebpackPlugin({
       filename: 'electron_index.html',
       template: path.resolve(__dirname, './electron_index.html'),


### PR DESCRIPTION
According to the [webpack v4 docs](https://v4.webpack.js.org/plugins/ignore-plugin/), `webpack.IgnorePlugin(/Regex/);` is equivalent to `new webpack.IgnorePlugin({resourceRegExp: /Regex/});`. This is, however, not the case. It seems we must now specify the context regexp as well.

![Screen Shot 2021-12-02 at 11 34 39 AM](https://user-images.githubusercontent.com/3759828/144464284-d9e9a2a6-5d47-4713-8086-a9787dcf21cd.png)


