### PR TITLE
Add a CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,4 +10,7 @@
 /cordova-plugin-outline/  @Jigsaw-Code/outline-networking-owners
 /third_party/             @Jigsaw-Code/outline-networking-owners
 /tools/                   @Jigsaw-Code/outline-networking-owners
+
+# Ensure that if any JSON files are added to the model directory, they are
+# still subject to full owners approval.
 /src/www/model/           @Jigsaw-Code/outline-owners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,3 +10,4 @@
 /cordova-plugin-outline/  @Jigsaw-Code/outline-networking-owners
 /third_party/             @Jigsaw-Code/outline-networking-owners
 /tools/                   @Jigsaw-Code/outline-networking-owners
+/src/www/model/           @Jigsaw-Code/outline-owners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+/ @Jigsaw-Code/outline-owners
+
+/docs/       @Jigsaw-Code/outline-strings-owners
+/resources/  @Jigsaw-Code/outline-strings-owners
+*.json       @Jigsaw-Code/outline-strings-owners
+*.md         @Jigsaw-Code/outline-strings-owners
+*.png        @Jigsaw-Code/outline-strings-owners
+*.svg        @Jigsaw-Code/outline-strings-owners
+
+/cordova-plugin-outline/  @Jigsaw-Code/outline-networking-owners
+/third_party/             @Jigsaw-Code/outline-networking-owners
+/tools/                   @Jigsaw-Code/outline-networking-owners


### PR DESCRIPTION
This identifies the different roles responsible for managing the Outline
codebase.