### PR TITLE
build(netstack): enable go network stack for Windows and Linux

### DIFF
--- a/src/electron/build.action.sh
+++ b/src/electron/build.action.sh
@@ -17,7 +17,7 @@
 npm run action src/www/build_electron
 
 webpack --config=src/electron/electron_main.webpack.js \
-    --env NETWORK_STACK="${NETWORK_STACK:-libevbadvpn}" \
+    --env NETWORK_STACK="${NETWORK_STACK:-go}" \
     ${BUILD_ENV:+--mode="${BUILD_ENV}"}
 
 # Environment variables.


### PR DESCRIPTION
In this change set, I replaced the [old `libev` network stack](https://github.com/Jigsaw-Code/outline-client/tree/master/third_party/badvpn) with the unified [`go` network stack](https://github.com/Jigsaw-Code/outline-go-tun2socks).

I have already tested the client on both Windows and Linux, they all work as expected. But we are still required to install the TAP device as well as the daemon service on both OSes.

Add @daniellacosse for awareness, we can have a dry run of the Linux CI pipeline to release this version.

Completes one step in #1128 .