### PR TITLE
fix(ui): refresh new server name after renaming

### DIFF
--- a/src/www/ui_components/server_card.ts
+++ b/src/www/ui_components/server_card.ts
@@ -192,7 +192,7 @@ import {ServerConnectionState} from './server_connection_viz';
   // @polymer/decorators doesn't support Function constructors...
   @property({type: Object}) localize: (messageId: string) => string;
 
-  @computed('serverId', 'isOutlineServer', 'localize')
+  @computed('serverName', 'isOutlineServer', 'localize')
   get localizedServerName() {
     if (this.serverName.length) {
       return this.serverName;


### PR DESCRIPTION
We did not observe the correct property (we were using `serverId` instead of `serverName`), therefore when we rename a server card, the new name will not be applied immediately, it will only be applied after restart.

In this fix, I simply reference the correct `serverName` property so the new name will be refreshed as soon as we update a server name.

Fixes #1131 .