### PR TITLE
👷 build(windows): introduce Windows release pipeline

### DIFF
--- a/.github/workflows/build_release_candidates.yml
+++ b/.github/workflows/build_release_candidates.yml
@@ -10,6 +10,8 @@ on:
       - master
 
 jobs:
+  windows:
+    uses: ./.github/workflows/build_windows_release_candidate.yml
   linux:
     name: Build Linux Release Candidate
     runs-on: ubuntu-20.04

--- a/.github/workflows/build_windows_release_candidate.yml
+++ b/.github/workflows/build_windows_release_candidate.yml
@@ -1,0 +1,32 @@
+name: Build Windows Release Candidate
+
+on: [workflow_dispatch, workflow_call]
+
+jobs:
+  windows_release_build:
+    name: Build and Pack Windows Release Binaries
+    runs-on: windows-latest
+    timeout-minutes: 10
+    env:
+      SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+
+      - name: Install Node
+        uses: actions/setup-node@v2.2.0
+        with:
+          node-version: 16
+
+      - name: Install NPM Dependencies
+        run: npm ci
+
+      - name: Build Windows Release Binaries
+        run: npm run action src/electron/build windows -- --buildMode=release
+
+      - name: Upload Windows Release Binaries
+        uses: actions/upload-artifact@v2
+        with:
+          name: client_windows_release_${{ github.sha }}
+          path: build/dist
+          if-no-files-found: error


### PR DESCRIPTION
In this PR, I introduced the Windows release pipeline (to build unsigned release candidate binaries). The pipeline can be:

* Either triggered manually
* Or automatically triggered by the overall Release Candidate mega-pipeline