### PR TITLE
👷 build(windows): pass the correct electron-builder argument for Windows

### DIFF
--- a/scripts/get_electron_build_flags.mjs
+++ b/scripts/get_electron_build_flags.mjs
@@ -24,7 +24,7 @@ export async function getElectronBuildFlags(platform, buildMode) {
 
   if (platform === "linux") {
     buildFlags = ["--linux", ...buildFlags];
-  } else if (platform === "win") {
+  } else if (platform === "windows") {
     buildFlags = ["--win", ...buildFlags];
   }
 
@@ -40,7 +40,7 @@ export async function getElectronBuildFlags(platform, buildMode) {
     ];
   }
 
-  if (buildMode === "release" && platform === "win") {
+  if (buildMode === "release" && platform === "windows") {
     buildFlags.push("--config.win.certificateSubjectName='Jigsaw Operations LLC'");
   }
 


### PR DESCRIPTION
This PR fixes an issue caused by mismatching argument when cross-building Windows electron app on macOS. The platform argument passed to `get_electron_build_flags.mjs` should be `windows` instead of `win`.