### PR TITLE
👷 build(windows): introduce Windows release pipeline

### DIFF
--- a/.github/workflows/build_release_candidates.yml
+++ b/.github/workflows/build_release_candidates.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   windows:
     uses: ./.github/workflows/build_windows_release_candidate.yml
+    secrets:
+      SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
   linux:
     name: Build Linux Release Candidate
     runs-on: ubuntu-20.04

--- a/.github/workflows/build_windows_release_candidate.yml
+++ b/.github/workflows/build_windows_release_candidate.yml
@@ -1,10 +1,15 @@
-name: Build Windows Release Candidate
+name: Build Windows Unsigned Release Candidate
 
-on: [workflow_dispatch, workflow_call]
+on:
+  workflow_dispatch:
+  workflow_call:
+    secrets:
+      SENTRY_DSN:
+        required: true
 
 jobs:
   windows_release_build:
-    name: Build and Pack Windows Release Binaries
+    name: Build and Pack Windows Unsigned Release Installer
     runs-on: windows-latest
     timeout-minutes: 10
     env:
@@ -21,12 +26,12 @@ jobs:
       - name: Install NPM Dependencies
         run: npm ci
 
-      - name: Build Windows Release Binaries
+      - name: Build Windows Installer
         run: npm run action src/electron/build windows -- --buildMode=release
 
-      - name: Upload Windows Release Binaries
+      - name: Upload Windows Installer
         uses: actions/upload-artifact@v2
         with:
-          name: client_windows_release_${{ github.sha }}
+          name: client_installer_unsigned_windows_release_${{ github.sha }}
           path: build/dist
           if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -94,23 +94,21 @@ To learn more about developing for Apple, see [docs/apple-development](docs/appl
 
 Unlike the Android and Apple clients, the Windows and Linux clients use the Electron framework, rather than Cordova.
 
-### Windows
-
 Additional requirements for building on Windows:
 
 * [Cygwin](https://cygwin.com/install.html). It provides the "missing Unix pieces" required by build system such as rsync (and many others). Besides the default selected Unix tools such as `bash` and `rsync`, please also make sure to install `git` during Cygwin installation as well. You will need to clone this repository using `git` in Cygwin instead of the native Windows version of git, in order to ensure Unix line endings.
 
-To build the Electron clients, run:
+To build the Electron clients, run (it will also package an installer executable into `build/dist`):
 
-    npm run action src/electron/build windows
+```sh
+npm run action src/electron/build [windows|linux]
+```
 
 To run the Electron clients, run:
 
-    npm run action src/electron/start windows
-
-To package the Electron clients into an installer executable, run:
-
-    npm run action src/electron/package_[linux|windows]
+```sh
+npm run action src/electron/start [windows|linux]
+```
 
 
 ## Error reporting


### PR DESCRIPTION
In this PR, I introduced the Windows release pipeline (to build _unsigned_ release candidate binaries). The pipeline can be:

* Either triggered manually
* Or automatically triggered by the overall Release Candidate mega-pipeline

Following is the manual triggered workflow image:

<img width="1279" alt="image" src="https://user-images.githubusercontent.com/93548144/153064609-09791aff-b067-4878-87e8-d0bca7be509e.png">
