### PR TITLE
fix(release): remove outdated windows flag

### DIFF
--- a/scripts/get_electron_build_flags.mjs
+++ b/scripts/get_electron_build_flags.mjs
@@ -41,7 +41,7 @@ export async function getElectronBuildFlags(platform, buildMode) {
   }
 
   if (buildMode === "release" && platform === "windows") {
-    buildFlags.push("--config.win.certificateSubjectName='Jigsaw Operations LLC'");
+    buildFlags.push('--config.win.certificateSubjectName="Jigsaw Operations LLC"');
   }
 
   return buildFlags;

--- a/scripts/get_electron_build_flags.mjs
+++ b/scripts/get_electron_build_flags.mjs
@@ -40,10 +40,6 @@ export async function getElectronBuildFlags(platform, buildMode) {
     ];
   }
 
-  if (buildMode === "release" && platform === "windows") {
-    buildFlags.push('--config.win.certificateSubjectName="Jigsaw Operations LLC"');
-  }
-
   return buildFlags;
 }
 


### PR DESCRIPTION
this flag didn't escape well in release - https://github.com/Jigsaw-Code/outline-client/runs/5591663786?check_suite_focus=true#step:5:166

but we actually don't need it anymore since we're not signing w/ electron, so i removed it.