### PR TITLE
🔖 release(version): bump up Windows to 1.7.1 for the electron cordova fix

### DIFF
--- a/scripts/get_version.mjs
+++ b/scripts/get_version.mjs
@@ -41,7 +41,7 @@ export async function getVersion(platform) {
       } = await parseFile(`src/cordova/apple/xcode/${platform}/Outline/Outline-Info.plist`);
       return plistValues[plistKeys.indexOf("CFBundleShortVersionString")];
     case "windows":
-      return "1.7.0";
+      return "1.7.1";
     case "linux":
       return "1.7.0";
     default:


### PR DESCRIPTION
We fixed [a critical issue related to electron and cordova](https://github.com/Jigsaw-Code/outline-client/pull/1238) several days ago. Although we did not observe any serious outcomes for Windows app, it is still possible that there might be some issues hidden below.

Therefore, here I will release a new version 1.7.1 for Windows.