### PR TITLE
feat(actions): action cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.action_cache.json
 .idea
 .vscode
 *.DS_Store

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "action": "node ./scripts/run_action.mjs",
     "action:help": "npm run action list",
     "action:list": "npm run action list",
-    "clean": "rm -rf build node_modules www platforms plugins",
+    "clean": "rm -rf build node_modules www platforms plugins .action_cache.json",
     "format": "pretty-quick --staged --pattern \"**/*.{cjs,mjs,html,js,json,md,ts}\"",
     "format:all": "prettier --write \"**/*.{cjs,mjs,html,js,json,md,ts}\"",
     "lint": "npm run lint:ts",

--- a/scripts/run_action.mjs
+++ b/scripts/run_action.mjs
@@ -43,11 +43,80 @@ const resolveActionPath = async actionPath => {
 };
 
 /**
+ * The "Action Cache" is a simple JSON file we use to track previous action runs and determine
+ * if they can be skipped on subsequent attempts.
+ *
+ * Cache methods:
+ *   readActionCache - loads the latest time the action was run along with the parameters it was run with
+ *   writeActionCache - updates the time an action was run and the parameters it was run with
+ *
+ * TODO(daniellacosse): convert the cache to a folder so each actions can run in parallel without risking
+ * corruption of the cache
+ */
+const ACTION_CACHE_FILE = "./.action_cache.json";
+
+const readActionCache = async (actionPathKey, parameters) => {
+  const cachePath = path.resolve(process.env.ROOT_DIR, ACTION_CACHE_FILE);
+
+  if (!existsSync(cachePath)) {
+    return {};
+  }
+
+  const cache = JSON.parse(await fs.readFile(cachePath));
+
+  if (JSON.stringify(cache[actionPathKey]?.parameters) !== JSON.stringify(parameters)) {
+    return {};
+  }
+
+  return cache[actionPathKey];
+};
+
+const writeActionCache = async (actionPathKey, actionCacheObject) => {
+  const cachePath = path.resolve(process.env.ROOT_DIR, ACTION_CACHE_FILE);
+
+  let cache = {};
+
+  if (existsSync(cachePath)) {
+    cache = JSON.parse(await fs.readFile(cachePath));
+  }
+
+  cache[actionPathKey] = actionCacheObject;
+
+  await fs.writeFile(cachePath, JSON.stringify(cache));
+};
+
+/**
+ * @description BFSes a list of file system targets, returning the timestamp of the most
+ * recently modified one.
+ *
+ * @param {Array<Directory | File>} foldersAndFiles List of folders and files to scan.
+ * @returns {number} Timestamp in milliseconds of the most recently modified file.
+ */
+const mostRecentModification = async (foldersAndFiles = []) => {
+  let result = 0;
+
+  while (foldersAndFiles.length) {
+    const currentFolderOrFile = foldersAndFiles.pop();
+    const fileInformation = await fs.stat(currentFolderOrFile);
+
+    result = Math.max(result, fileInformation.mtimeMs);
+
+    if (fileInformation.isDirectory()) {
+      const contents = await fs.readdir(currentFolderOrFile);
+
+      foldersAndFiles = [...foldersAndFiles, ...contents.map(child => `${currentFolderOrFile}/${child}`)];
+    }
+  }
+
+  return result;
+};
+
+/**
  * @description promisifies the child process (for supporting legacy bash actions!)
  */
 const spawnStream = (command, parameters) =>
   new Promise((resolve, reject) => {
-    const childProcess = spawn(command, parameters);
+    const childProcess = spawn(command, parameters, {shell: true});
 
     childProcess.stdout.on("data", data => console.info(data.toString()));
     childProcess.stderr.on("data", error => console.error(chalk.red(error.toString())));
@@ -84,10 +153,11 @@ export async function runAction(actionPath, ...parameters) {
   const startTime = performance.now();
 
   try {
-    if (resolvedPath.endsWith("mjs")) {
+    if (resolvedPath.endsWith(".mjs")) {
       const action = os.platform().startsWith("win")
         ? await import(`file://${resolvedPath}`)
         : await import(resolvedPath);
+      const actionCache = await readActionCache(resolvedPath, parameters);
 
       if (action.requirements?.length) {
         for (const requiredAction of action.requirements) {
@@ -95,7 +165,24 @@ export async function runAction(actionPath, ...parameters) {
         }
       }
 
-      await action.main(...parameters);
+      if (
+        action.dependencies?.length &&
+        actionCache.lastRan > (await mostRecentModification([...action.dependencies]))
+      ) {
+        console.info(
+          chalk.bold(`Skipping:`),
+          "No source file from this action's dependencies",
+          chalk.blue(`"${action.dependencies.join(", ")}"`),
+          "are newer than the previous successful run of this action."
+        );
+      } else {
+        await action.main(...parameters);
+
+        await writeActionCache(resolvedPath, {
+          parameters,
+          lastRan: Date.now(),
+        });
+      }
     } else {
       await spawnStream("bash", [resolvedPath, ...parameters]);
     }

--- a/src/cordova/build.action.mjs
+++ b/src/cordova/build.action.mjs
@@ -17,6 +17,7 @@ const {cordova} = cordovaLib;
 
 import {getBuildParameters} from "../../scripts/get_build_parameters.mjs";
 
+export const dependencies = ["src/www"];
 export const requirements = ["cordova/setup"];
 
 /**

--- a/src/cordova/setup.action.mjs
+++ b/src/cordova/setup.action.mjs
@@ -25,6 +25,7 @@ import {getBuildParameters} from "../../scripts/get_build_parameters.mjs";
 const CORDOVA_PLATFORMS = ["ios", "osx", "android"];
 const WORKING_CORDOVA_OSX_COMMIT = "07e62a53aa6a8a828fd988bc9e884c38c3495a67";
 
+export const dependencies = ["www", "resources", "src/cordova", "cordova-plugin-outline"];
 export const requirements = ["www/build"];
 
 /**


### PR DESCRIPTION
Blocked by https://github.com/Jigsaw-Code/outline-client/pull/1264

This PR enhances actions so they can export `dependencies` to help the runner know when it can skip a run.

Admittedly, I didn't _really_ need to recreate `make` in javascript. But I'm a bit proud of it:

![Screen Shot 2022-04-19 at 10 44 51](https://user-images.githubusercontent.com/3759828/164030922-0f35bbfb-4fdd-4770-a928-547e16076597.png)