### PR TITLE
🎨 style(electron): prettier format all code in electron

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,16 @@
 {
   "singleQuote": true,
   "bracketSpacing": false,
-  "printWidth": 100
+  "trailingComma": "es5",
+  "arrowParens": "avoid",
+  "printWidth": 120,
+
+  "overrides": [
+    {
+      "files": "*.cjs",
+      "options": {
+        "parser": "babel"
+      }
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -137,10 +137,5 @@
       "ios",
       "osx"
     ]
-  },
-  "prettier": {
-    "bracketSpacing": false,
-    "trailingComma": "es5",
-    "printWidth": 120
   }
 }

--- a/src/electron/connectivity.ts
+++ b/src/electron/connectivity.ts
@@ -26,21 +26,28 @@ const DNS_LOOKUP_TIMEOUT_MS = 10000;
 // Effectively a no-op if hostname is already an IP.
 export function lookupIp(hostname: string): Promise<string> {
   return util.timeoutPromise(
-      new Promise<string>((fulfill, reject) => {
-        dns.lookup(hostname, 4, (e, address) => {
-          if (e) {
-            return reject(new errors.ServerUnreachable('could not resolve proxy server hostname'));
-          }
-          fulfill(address);
-        });
-      }),
-      DNS_LOOKUP_TIMEOUT_MS, 'DNS lookup');
+    new Promise<string>((fulfill, reject) => {
+      dns.lookup(hostname, 4, (e, address) => {
+        if (e) {
+          return reject(new errors.ServerUnreachable('could not resolve proxy server hostname'));
+        }
+        fulfill(address);
+      });
+    }),
+    DNS_LOOKUP_TIMEOUT_MS,
+    'DNS lookup'
+  );
 }
 
 // Resolves iff a (TCP) connection can be established with the specified destination within the
 // specified timeout (zero means "no timeout"), optionally retrying with a delay.
 export function isServerReachable(
-    host: string, port: number, timeout = 0, maxAttempts = 1, retryIntervalMs = 0): Promise<void> {
+  host: string,
+  port: number,
+  timeout = 0,
+  maxAttempts = 1,
+  retryIntervalMs = 0
+): Promise<void> {
   let attempt = 0;
   return new Promise((fulfill, reject) => {
     const connect = () => {

--- a/src/electron/go_vpn_tunnel.ts
+++ b/src/electron/go_vpn_tunnel.ts
@@ -70,7 +70,7 @@ export class GoVpnTunnel implements VpnTunnel {
     // lifecycle:
     //  - once any helper fails or exits, stop them all
     //  - once *all* helpers have stopped, we're done
-    this.onAllHelpersStopped = new Promise((resolve) => {
+    this.onAllHelpersStopped = new Promise(resolve => {
       this.resolveAllHelpersStopped = resolve;
     });
 
@@ -90,7 +90,7 @@ export class GoVpnTunnel implements VpnTunnel {
       // Windows: when the system suspends, tun2socks terminates due to the TAP device getting
       // closed.
       powerMonitor.on('suspend', this.suspendListener.bind(this));
-      powerMonitor.on('resume', this.resumeListener.bind((this)));
+      powerMonitor.on('resume', this.resumeListener.bind(this));
     }
 
     // Disconnect the tunnel if the routing service disconnects unexpectedly.
@@ -201,16 +201,15 @@ export class GoVpnTunnel implements VpnTunnel {
   }
 
   // Sets an optional callback for when the routing daemon is attempting to re-connect.
-  onReconnecting(newListener: () => void|undefined) {
+  onReconnecting(newListener: () => void | undefined) {
     this.reconnectingListener = newListener;
   }
 
   // Sets an optional callback for when the routing daemon successfully reconnects.
-  onReconnected(newListener: () => void|undefined) {
+  onReconnected(newListener: () => void | undefined) {
     this.reconnectedListener = newListener;
   }
 }
-
 
 // outline-go-tun2socks is a Go program that processes IP traffic from a TUN/TAP device
 // and relays it to a Shadowsocks proxy server.
@@ -218,8 +217,7 @@ class GoTun2socks {
   private process: ChildProcessHelper;
 
   constructor(private config: ShadowsocksConfig) {
-    this.process =
-        new ChildProcessHelper(pathToEmbeddedBinary('outline-go-tun2socks', 'tun2socks'));
+    this.process = new ChildProcessHelper(pathToEmbeddedBinary('outline-go-tun2socks', 'tun2socks'));
   }
 
   async start(isUdpEnabled: boolean) {
@@ -247,15 +245,14 @@ class GoTun2socks {
       this.process.onExit = (code?: number, signal?: string) => {
         reject(errors.fromErrorCode(code ?? errors.ErrorCode.UNEXPECTED));
       };
-      this.process.onStdErr = (data?: string|Buffer) => {
+      this.process.onStdErr = (data?: string | Buffer) => {
         if (!data?.toString().includes('tun2socks running')) {
           return;
         }
         console.debug('tun2socks started');
         this.process.onExit = async (code?: number, signal?: string) => {
-           // The process exited unexpectedly, restart it.
-          console.warn(
-            `tun2socks exited unexpectedly with signal: ${signal}, code: ${code}. Restarting...`);
+          // The process exited unexpectedly, restart it.
+          console.warn(`tun2socks exited unexpectedly with signal: ${signal}, code: ${code}. Restarting...`);
           await this.start(isUdpEnabled);
         };
         this.process.onStdErr = null;
@@ -266,7 +263,7 @@ class GoTun2socks {
   }
 
   async stop() {
-    return new Promise<void>((resolve) => {
+    return new Promise<void>(resolve => {
       this.process.onExit = (code?: number, signal?: string) => {
         console.log(`tun2socks stopped with signal: ${signal}, code: ${code}.`);
         resolve();

--- a/src/electron/index.ts
+++ b/src/electron/index.ts
@@ -14,30 +14,30 @@
 
 // Directly import @sentry/electron main process code.
 // See: https://docs.sentry.io/platforms/javascript/guides/electron/#webpack-configuration
-import * as sentry from "@sentry/electron";
-import {app, BrowserWindow, ipcMain, Menu, MenuItemConstructorOptions, nativeImage, shell, Tray} from "electron";
-import promiseIpc from "electron-promise-ipc";
-import {autoUpdater} from "electron-updater";
-import * as os from "os";
-import * as path from "path";
-import * as process from "process";
-import * as url from "url";
-import autoLaunch = require("auto-launch"); // tslint:disable-line
+import * as sentry from '@sentry/electron';
+import {app, BrowserWindow, ipcMain, Menu, MenuItemConstructorOptions, nativeImage, shell, Tray} from 'electron';
+import promiseIpc from 'electron-promise-ipc';
+import {autoUpdater} from 'electron-updater';
+import * as os from 'os';
+import * as path from 'path';
+import * as process from 'process';
+import * as url from 'url';
+import autoLaunch = require('auto-launch'); // tslint:disable-line
 
-import * as connectivity from "./connectivity";
-import * as errors from "../www/model/errors";
+import * as connectivity from './connectivity';
+import * as errors from '../www/model/errors';
 
-import {ShadowsocksConfig} from "../www/app/config";
-import {TunnelStatus} from "../www/app/tunnel";
-import {GoVpnTunnel} from "./go_vpn_tunnel";
-import {RoutingDaemon} from "./routing_service";
-import {ShadowsocksLibevBadvpnTunnel} from "./sslibev_badvpn_tunnel";
-import {TunnelStore, SerializableTunnel} from "./tunnel_store";
-import {VpnTunnel} from "./vpn_tunnel";
+import {ShadowsocksConfig} from '../www/app/config';
+import {TunnelStatus} from '../www/app/tunnel';
+import {GoVpnTunnel} from './go_vpn_tunnel';
+import {RoutingDaemon} from './routing_service';
+import {ShadowsocksLibevBadvpnTunnel} from './sslibev_badvpn_tunnel';
+import {TunnelStore, SerializableTunnel} from './tunnel_store';
+import {VpnTunnel} from './vpn_tunnel';
 
 // Used for the auto-connect feature. There will be a tunnel in store
 // if the user was connected at shutdown.
-const tunnelStore = new TunnelStore(app.getPath("userData"));
+const tunnelStore = new TunnelStore(app.getPath('userData'));
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
@@ -47,25 +47,25 @@ let tray: Tray;
 let isAppQuitting = false;
 // Default to English strings in case we fail to retrieve them from the renderer process.
 let localizedStrings: {[key: string]: string} = {
-  "tray-open-window": "Open",
-  "connected-server-state": "Connected",
-  "disconnected-server-state": "Disconnected",
-  quit: "Quit",
+  'tray-open-window': 'Open',
+  'connected-server-state': 'Connected',
+  'disconnected-server-state': 'Disconnected',
+  quit: 'Quit',
 };
 
-const debugMode = process.env.OUTLINE_DEBUG === "true";
+const debugMode = process.env.OUTLINE_DEBUG === 'true';
 
 // Build-time constant defined by webpack and set to the value of $NETWORK_STACK,
 // or 'libevbadvpn' by default.
 declare const NETWORK_STACK: string;
 
 const TRAY_ICON_IMAGES = {
-  connected: createTrayIconImage("connected.png"),
-  disconnected: createTrayIconImage("disconnected.png"),
+  connected: createTrayIconImage('connected.png'),
+  disconnected: createTrayIconImage('disconnected.png'),
 };
 
 const enum Options {
-  AUTOSTART = "--autostart",
+  AUTOSTART = '--autostart',
 }
 
 const REACHABILITY_TIMEOUT_MS = 10000;
@@ -77,8 +77,8 @@ function setupMenu(): void {
     Menu.setApplicationMenu(
       Menu.buildFromTemplate([
         {
-          label: "Developer",
-          submenu: Menu.buildFromTemplate([{role: "reload"}, {role: "forceReload"}, {role: "toggleDevTools"}]),
+          label: 'Developer',
+          submenu: Menu.buildFromTemplate([{role: 'reload'}, {role: 'forceReload'}, {role: 'toggleDevTools'}]),
         },
       ])
     );
@@ -91,10 +91,10 @@ function setupMenu(): void {
 function setupTray(): void {
   tray = new Tray(TRAY_ICON_IMAGES.disconnected);
   // On Linux, the click event is never fired: https://github.com/electron/electron/issues/14941
-  tray.on("click", () => {
+  tray.on('click', () => {
     mainWindow?.show();
   });
-  tray.setToolTip("Outline");
+  tray.setToolTip('Outline');
   updateTray(TunnelStatus.DISCONNECTED);
 }
 
@@ -109,15 +109,15 @@ function setupWindow(): void {
     },
   });
 
-  const pathToIndexHtml = path.join(app.getAppPath(), "www", "index_electron.html");
+  const pathToIndexHtml = path.join(app.getAppPath(), 'www', 'index_electron.html');
   const webAppUrl = new url.URL(`file://${pathToIndexHtml}`);
 
   // Debug mode, etc.
   const queryParams = new url.URLSearchParams();
   if (debugMode) {
-    queryParams.set("debug", "true");
+    queryParams.set('debug', 'true');
   }
-  queryParams.set("appName", app.getName());
+  queryParams.set('appName', app.getName());
   webAppUrl.search = queryParams.toString();
 
   const webAppUrlAsString = webAppUrl.toString();
@@ -125,7 +125,7 @@ function setupWindow(): void {
   console.info(`loading web app from ${webAppUrlAsString}`);
   mainWindow.loadURL(webAppUrlAsString);
 
-  mainWindow.on("close", (event: Event) => {
+  mainWindow.on('close', (event: Event) => {
     if (isAppQuitting) {
       // Actually close the window if we are quitting.
       return;
@@ -134,24 +134,24 @@ function setupWindow(): void {
     event.preventDefault();
     mainWindow.hide();
   });
-  if (os.platform() === "win32") {
+  if (os.platform() === 'win32') {
     // On Windows we hide the app from the taskbar.
-    mainWindow.on("minimize", (event: Event) => {
+    mainWindow.on('minimize', (event: Event) => {
       event.preventDefault();
       mainWindow.hide();
     });
   }
 
   // TODO: is this the most appropriate event?
-  mainWindow.webContents.on("did-finish-load", () => {
-    mainWindow.webContents.send("localizationRequest", Object.keys(localizedStrings));
+  mainWindow.webContents.on('did-finish-load', () => {
+    mainWindow.webContents.send('localizationRequest', Object.keys(localizedStrings));
     interceptShadowsocksLink(process.argv);
   });
 
   // The client is a single page app - loading any other page means the
   // user clicked on one of the Privacy, Terms, etc., links. These should
   // open in the user's browser.
-  mainWindow.webContents.on("will-navigate", (event: Event, url: string) => {
+  mainWindow.webContents.on('will-navigate', (event: Event, url: string) => {
     shell.openExternal(url);
     event.preventDefault();
   });
@@ -162,22 +162,22 @@ function updateTray(status: TunnelStatus) {
   tray.setImage(isConnected ? TRAY_ICON_IMAGES.connected : TRAY_ICON_IMAGES.disconnected);
   // Retrieve localized strings, falling back to the pre-populated English default.
   const statusString = isConnected
-    ? localizedStrings["connected-server-state"]
-    : localizedStrings["disconnected-server-state"];
+    ? localizedStrings['connected-server-state']
+    : localizedStrings['disconnected-server-state'];
   let menuTemplate = [
     {label: statusString, enabled: false},
-    {type: "separator"} as MenuItemConstructorOptions,
-    {label: localizedStrings["quit"], click: quitApp},
+    {type: 'separator'} as MenuItemConstructorOptions,
+    {label: localizedStrings['quit'], click: quitApp},
   ];
-  if (os.platform() === "linux") {
+  if (os.platform() === 'linux') {
     // Because the click event is never fired on Linux, we need an explicit open option.
-    menuTemplate = [{label: localizedStrings["tray-open-window"], click: () => mainWindow.show()}, ...menuTemplate];
+    menuTemplate = [{label: localizedStrings['tray-open-window'], click: () => mainWindow.show()}, ...menuTemplate];
   }
   tray.setContextMenu(Menu.buildFromTemplate(menuTemplate));
 }
 
 function createTrayIconImage(imageName: string) {
-  const image = nativeImage.createFromPath(path.join(app.getAppPath(), "resources", "tray", imageName));
+  const image = nativeImage.createFromPath(path.join(app.getAppPath(), 'resources', 'tray', imageName));
   if (image.isEmpty()) {
     throw new Error(`cannot find ${imageName} tray icon image`);
   }
@@ -194,16 +194,16 @@ async function quitApp() {
 
 function interceptShadowsocksLink(argv: string[]) {
   if (argv.length > 1) {
-    const protocol = "ss://";
+    const protocol = 'ss://';
     let url = argv[1];
     if (url.startsWith(protocol)) {
       if (mainWindow) {
         // The system adds a trailing slash to the intercepted URL (before the fragment).
         // Remove it before sending to the UI.
-        url = `${protocol}${url.substr(protocol.length).replace(/\//g, "")}`;
-        mainWindow.webContents.send("add-server", url);
+        url = `${protocol}${url.substr(protocol.length).replace(/\//g, '')}`;
+        mainWindow.webContents.send('add-server', url);
       } else {
-        console.error("called with URL but mainWindow not open");
+        console.error('called with URL but mainWindow not open');
       }
     }
   }
@@ -214,10 +214,10 @@ function interceptShadowsocksLink(argv: string[]) {
 async function setupAutoLaunch(args: SerializableTunnel): Promise<void> {
   try {
     await tunnelStore.save(args);
-    if (os.platform() === "linux") {
+    if (os.platform() === 'linux') {
       if (process.env.APPIMAGE) {
         const outlineAutoLauncher = new autoLaunch({
-          name: "OutlineClient",
+          name: 'OutlineClient',
           path: process.env.APPIMAGE,
         });
         outlineAutoLauncher.enable();
@@ -232,9 +232,9 @@ async function setupAutoLaunch(args: SerializableTunnel): Promise<void> {
 
 async function tearDownAutoLaunch() {
   try {
-    if (os.platform() === "linux") {
+    if (os.platform() === 'linux') {
       const outlineAutoLauncher = new autoLaunch({
-        name: "OutlineClient",
+        name: 'OutlineClient',
       });
       outlineAutoLauncher.disable();
     } else {
@@ -249,10 +249,10 @@ async function tearDownAutoLaunch() {
 // Factory function to create a VPNTunnel instance backed by a network statck
 // specified at build time.
 function createVpnTunnel(config: ShadowsocksConfig, isAutoConnect: boolean): VpnTunnel {
-  const routing = new RoutingDaemon(config.host || "", isAutoConnect);
+  const routing = new RoutingDaemon(config.host || '', isAutoConnect);
   let tunnel: VpnTunnel;
-  if (NETWORK_STACK === "go") {
-    console.log("Using Go network stack");
+  if (NETWORK_STACK === 'go') {
+    console.log('Using Go network stack');
     tunnel = new GoVpnTunnel(routing, config);
   } else {
     tunnel = new ShadowsocksLibevBadvpnTunnel(routing, config);
@@ -265,7 +265,7 @@ function createVpnTunnel(config: ShadowsocksConfig, isAutoConnect: boolean): Vpn
 // Invoked by both the start-proxying event handler and auto-connect.
 async function startVpn(config: ShadowsocksConfig, id: string, isAutoConnect = false) {
   if (currentTunnel) {
-    throw new Error("already connected");
+    throw new Error('already connected');
   }
 
   currentTunnel = createVpnTunnel(config, isAutoConnect);
@@ -310,13 +310,13 @@ function setUiTunnelStatus(status: TunnelStatus, tunnelId: string) {
   let statusString;
   switch (status) {
     case TunnelStatus.CONNECTED:
-      statusString = "connected";
+      statusString = 'connected';
       break;
     case TunnelStatus.DISCONNECTED:
-      statusString = "disconnected";
+      statusString = 'disconnected';
       break;
     case TunnelStatus.RECONNECTING:
-      statusString = "reconnecting";
+      statusString = 'reconnecting';
       break;
     default:
       console.error(`Cannot send unknown proxy status: ${status}`);
@@ -341,16 +341,16 @@ function checkForUpdates() {
 
 function main() {
   if (!app.requestSingleInstanceLock()) {
-    console.log("another instance is running - exiting");
+    console.log('another instance is running - exiting');
     app.quit();
   }
 
-  app.setAsDefaultProtocolClient("ss");
+  app.setAsDefaultProtocolClient('ss');
 
   // This method will be called when Electron has finished
   // initialization and is ready to create browser windows.
   // Some APIs can only be used after this event occurs.
-  app.on("ready", async () => {
+  app.on('ready', async () => {
     setupMenu();
     setupTray();
     // TODO(fortuna): Start the app with the window hidden on auto-start?
@@ -383,26 +383,26 @@ function main() {
     }
   });
 
-  app.on("second-instance", (event: Event, argv: string[]) => {
+  app.on('second-instance', (event: Event, argv: string[]) => {
     interceptShadowsocksLink(argv);
     // Someone tried to run a second instance, we should focus our window.
     mainWindow?.show();
   });
 
-  app.on("activate", () => {
+  app.on('activate', () => {
     // On OS X it's common to re-create a window in the app when the
     // dock icon is clicked and there are no other windows open.
     mainWindow?.show();
   });
 
   // This event fires whenever the app's window receives focus.
-  app.on("browser-window-focus", () => {
-    mainWindow?.webContents.send("push-clipboard");
+  app.on('browser-window-focus', () => {
+    mainWindow?.webContents.send('push-clipboard');
   });
 
-  promiseIpc.on("is-server-reachable", async (args: {hostname: string; port: number}) => {
+  promiseIpc.on('is-server-reachable', async (args: {hostname: string; port: number}) => {
     try {
-      await connectivity.isServerReachable(args.hostname || "", args.port || 0, REACHABILITY_TIMEOUT_MS);
+      await connectivity.isServerReachable(args.hostname || '', args.port || 0, REACHABILITY_TIMEOUT_MS);
       return true;
     } catch {
       return false;
@@ -410,12 +410,12 @@ function main() {
   });
 
   // Connects to the specified server, if that server is reachable and the credentials are valid.
-  promiseIpc.on("start-proxying", async (args: {config: ShadowsocksConfig; id: string}) => {
+  promiseIpc.on('start-proxying', async (args: {config: ShadowsocksConfig; id: string}) => {
     // TODO: Rather than first disconnecting, implement a more efficient switchover (as well as
     //       being faster, this would help prevent traffic leaks - the Cordova clients already do
     //       this).
     if (currentTunnel) {
-      console.log("disconnecting from current server...");
+      console.log('disconnecting from current server...');
       currentTunnel.disconnect();
       await currentTunnel.onceDisconnected;
     }
@@ -425,16 +425,16 @@ function main() {
     try {
       // Rather than repeadedly resolving a hostname in what may be a fingerprint-able way,
       // resolve it just once, upfront.
-      args.config.host = await connectivity.lookupIp(args.config.host || "");
+      args.config.host = await connectivity.lookupIp(args.config.host || '');
 
-      await connectivity.isServerReachable(args.config.host || "", args.config.port || 0, REACHABILITY_TIMEOUT_MS);
+      await connectivity.isServerReachable(args.config.host || '', args.config.port || 0, REACHABILITY_TIMEOUT_MS);
 
       await startVpn(args.config, args.id);
       console.log(`connected to ${args.id}`);
       await setupAutoLaunch(args);
       // Auto-connect requires IPs; the hostname in here has already been resolved (see above).
       tunnelStore.save(args).catch(e => {
-        console.error("Failed to store tunnel.");
+        console.error('Failed to store tunnel.');
       });
     } catch (e) {
       console.error(`could not connect: ${e.name} (${e.message})`);
@@ -443,11 +443,11 @@ function main() {
   });
 
   // Disconnects from the current server, if any.
-  promiseIpc.on("stop-proxying", stopVpn);
+  promiseIpc.on('stop-proxying', stopVpn);
 
   // Error reporting.
   // This config makes console (log/info/warn/error - no debug!) output go to breadcrumbs.
-  ipcMain.on("environment-info", (event: Event, info: {appVersion: string; dsn: string}) => {
+  ipcMain.on('environment-info', (event: Event, info: {appVersion: string; dsn: string}) => {
     if (info.dsn) {
       sentry.init({dsn: info.dsn, release: info.appVersion, maxBreadcrumbs: 100});
     }
@@ -455,9 +455,9 @@ function main() {
     console.info(`Outline is starting`);
   });
 
-  ipcMain.on("quit-app", quitApp);
+  ipcMain.on('quit-app', quitApp);
 
-  ipcMain.on("localizationResponse", (event: Event, localizationResult: {[key: string]: string}) => {
+  ipcMain.on('localizationResponse', (event: Event, localizationResult: {[key: string]: string}) => {
     if (!!localizationResult) {
       localizedStrings = localizationResult;
     }
@@ -465,8 +465,8 @@ function main() {
   });
 
   // Notify the UI of updates.
-  autoUpdater.on("update-downloaded", (ev, info) => {
-    mainWindow?.webContents.send("update-downloaded");
+  autoUpdater.on('update-downloaded', (ev, info) => {
+    mainWindow?.webContents.send('update-downloaded');
   });
 }
 

--- a/src/electron/process.ts
+++ b/src/electron/process.ts
@@ -26,7 +26,7 @@ export class ChildProcessHelper {
   protected isInDebugMode = false;
 
   private exitListener?: (code?: number, signal?: string) => void;
-  private stdErrListener?: (data?: string|Buffer) => void;
+  private stdErrListener?: (data?: string | Buffer) => void;
 
   constructor(private path: string) {}
 
@@ -49,7 +49,7 @@ export class ChildProcessHelper {
 
       logExit(processName, code, signal);
     };
-    const onStdErr = (data?: string|Buffer) => {
+    const onStdErr = (data?: string | Buffer) => {
       if (this.isInDebugMode) {
         console.error(`[STDERR - ${processName}]: ${data}`);
       }
@@ -58,7 +58,6 @@ export class ChildProcessHelper {
       }
     };
     this.process.stderr.on('data', onStdErr.bind(this));
-
 
     if (this.isInDebugMode) {
       // Redirect subprocess output while bypassing the Node console.  This makes sure we don't
@@ -69,8 +68,8 @@ export class ChildProcessHelper {
 
     // We have to listen for both events: error means the process could not be launched and in that
     // case exit will not be invoked.
-    this.process.on('error', onExit.bind((this)));
-    this.process.on('exit', onExit.bind((this)));
+    this.process.on('error', onExit.bind(this));
+    this.process.on('exit', onExit.bind(this));
   }
 
   // Use #onExit to be notified when the process exits.
@@ -86,11 +85,11 @@ export class ChildProcessHelper {
     this.process.kill();
   }
 
-  set onExit(newListener: ((code?: number, signal?: string) => void)|undefined) {
+  set onExit(newListener: ((code?: number, signal?: string) => void) | undefined) {
     this.exitListener = newListener;
   }
 
-  set onStdErr(listener: ((data?: string|Buffer) => void)|undefined) {
+  set onStdErr(listener: ((data?: string | Buffer) => void) | undefined) {
     this.stdErrListener = listener;
     if (!this.stdErrListener && !this.isDebugModeEnabled) {
       this.process.stderr.removeAllListeners();

--- a/src/electron/routing_service.ts
+++ b/src/electron/routing_service.ts
@@ -21,18 +21,17 @@ import * as errors from '../www/model/errors';
 import {TunnelStatus} from '../www/app/tunnel';
 import {getServiceStartCommand} from './util';
 
-const SERVICE_NAME =
-    platform() === 'win32' ? '\\\\.\\pipe\\OutlineServicePipe' : '/var/run/outline_controller';
+const SERVICE_NAME = platform() === 'win32' ? '\\\\.\\pipe\\OutlineServicePipe' : '/var/run/outline_controller';
 
 const isLinux = platform() === 'linux';
 
 interface RoutingServiceRequest {
   action: string;
-  parameters: {[parameter: string]: string|boolean};
+  parameters: {[parameter: string]: string | boolean};
 }
 
 interface RoutingServiceResponse {
-  action: RoutingServiceAction;  // Matches RoutingServiceRequest.action
+  action: RoutingServiceAction; // Matches RoutingServiceRequest.action
   statusCode: RoutingServiceStatusCode;
   errorMessage?: string;
   connectionStatus: TunnelStatus;
@@ -41,13 +40,13 @@ interface RoutingServiceResponse {
 enum RoutingServiceAction {
   CONFIGURE_ROUTING = 'configureRouting',
   RESET_ROUTING = 'resetRouting',
-  STATUS_CHANGED = 'statusChanged'
+  STATUS_CHANGED = 'statusChanged',
 }
 
 enum RoutingServiceStatusCode {
   SUCCESS = 0,
   GENERIC_FAILURE = 1,
-  UNSUPPORTED_ROUTING_TABLE = 2
+  UNSUPPORTED_ROUTING_TABLE = 2,
 }
 
 // Communicates with the Outline routing daemon via a Unix socket.
@@ -65,13 +64,13 @@ enum RoutingServiceStatusCode {
 //  - Linux: systemctl start|stop outline_proxy_controller.service
 //  - Windows: net start|stop OutlineService
 export class RoutingDaemon {
-  private socket: Socket|undefined;
+  private socket: Socket | undefined;
 
   private stopping = false;
 
   private fulfillDisconnect!: () => void;
 
-  private disconnected = new Promise<void>((F) => {
+  private disconnected = new Promise<void>(F => {
     this.fulfillDisconnect = F;
   });
 
@@ -83,7 +82,7 @@ export class RoutingDaemon {
   // configured the system's routing table.
   async start(retry = true) {
     return new Promise<void>((fulfill, reject) => {
-      const newSocket = this.socket = createConnection(SERVICE_NAME, () => {
+      const newSocket = (this.socket = createConnection(SERVICE_NAME, () => {
         newSocket.removeListener('error', initialErrorHandler);
         const cleanup = () => {
           newSocket.removeAllListeners();
@@ -92,10 +91,13 @@ export class RoutingDaemon {
         newSocket.once('close', cleanup);
         newSocket.once('error', cleanup);
 
-        newSocket.once('data', (data) => {
+        newSocket.once('data', data => {
           const message = this.parseRoutingServiceResponse(data);
-          if (!message || message.action !== RoutingServiceAction.CONFIGURE_ROUTING ||
-              message.statusCode !== RoutingServiceStatusCode.SUCCESS) {
+          if (
+            !message ||
+            message.action !== RoutingServiceAction.CONFIGURE_ROUTING ||
+            message.statusCode !== RoutingServiceStatusCode.SUCCESS
+          ) {
             // NOTE: This will rarely occur because the connectivity tests
             //       performed when the user clicks "CONNECT" should detect when
             //       the system is offline and that, currently, is pretty much
@@ -109,11 +111,13 @@ export class RoutingDaemon {
           fulfill();
         });
 
-        newSocket.write(JSON.stringify({
-          action: RoutingServiceAction.CONFIGURE_ROUTING,
-          parameters: {'proxyIp': this.proxyAddress, 'isAutoConnect': this.isAutoConnect}
-        } as RoutingServiceRequest));
-      });
+        newSocket.write(
+          JSON.stringify({
+            action: RoutingServiceAction.CONFIGURE_ROUTING,
+            parameters: {proxyIp: this.proxyAddress, isAutoConnect: this.isAutoConnect},
+          } as RoutingServiceRequest)
+        );
+      }));
 
       const initialErrorHandler = () => {
         if (!retry) {
@@ -122,7 +126,7 @@ export class RoutingDaemon {
         }
 
         console.info(`(re-)installing routing daemon`);
-        sudo.exec(getServiceStartCommand(), {name: 'Outline'}, (sudoError) => {
+        sudo.exec(getServiceStartCommand(), {name: 'Outline'}, sudoError => {
           if (sudoError) {
             // NOTE: The script could have terminated with an error - see the comment in
             //       sudo-prompt's typings definition.
@@ -161,12 +165,12 @@ export class RoutingDaemon {
 
   // Parses JSON `data` as a `RoutingServiceResponse`. Logs the error and returns undefined on
   // failure.
-  private parseRoutingServiceResponse(data: Buffer): RoutingServiceResponse|undefined {
+  private parseRoutingServiceResponse(data: Buffer): RoutingServiceResponse | undefined {
     if (!data) {
       console.error('received empty response from routing service');
       return undefined;
     }
-    let response: RoutingServiceResponse|undefined = undefined;
+    let response: RoutingServiceResponse | undefined = undefined;
     try {
       response = JSON.parse(data.toString());
     } catch (error) {
@@ -177,17 +181,18 @@ export class RoutingDaemon {
 
   private async writeReset() {
     return new Promise<void>((resolve, reject) => {
-      const written = this.socket.write(JSON.stringify(
-        {action: RoutingServiceAction.RESET_ROUTING, parameters: {}} as RoutingServiceRequest),
-        (err) => {
+      const written = this.socket.write(
+        JSON.stringify({action: RoutingServiceAction.RESET_ROUTING, parameters: {}} as RoutingServiceRequest),
+        err => {
           if (err) {
             reject(err);
           } else {
             resolve();
           }
-        });
+        }
+      );
       if (!written) {
-        reject(new Error("Write failed"));
+        reject(new Error('Write failed'));
       }
     });
   }
@@ -213,7 +218,7 @@ export class RoutingDaemon {
     return this.disconnected;
   }
 
-  public set onNetworkChange(newListener: ((status: TunnelStatus) => void)|undefined) {
+  public set onNetworkChange(newListener: ((status: TunnelStatus) => void) | undefined) {
     this.networkChangeListener = newListener;
   }
 }

--- a/src/electron/tsconfig.json
+++ b/src/electron/tsconfig.json
@@ -3,7 +3,5 @@
   "compilerOptions": {
     "outDir": "../../build/electron"
   },
-  "include": [
-    "**/*.ts"
-  ]
+  "include": ["**/*.ts"]
 }

--- a/src/electron/tunnel_store.ts
+++ b/src/electron/tunnel_store.ts
@@ -42,7 +42,7 @@ export class TunnelStore {
       return Promise.reject(new Error('Cannot save invalid tunnel'));
     }
     return new Promise((resolve, reject) => {
-      fs.writeFile(this.storagePath, JSON.stringify(tunnel), 'utf8', (error) => {
+      fs.writeFile(this.storagePath, JSON.stringify(tunnel), 'utf8', error => {
         if (error) {
           reject(error);
         } else {
@@ -76,7 +76,7 @@ export class TunnelStore {
       if (!fs.existsSync(this.storagePath)) {
         resolve();
       }
-      fs.unlink(this.storagePath, (error) => {
+      fs.unlink(this.storagePath, error => {
         if (error) {
           reject(error);
         } else {

--- a/src/electron/util.ts
+++ b/src/electron/util.ts
@@ -21,8 +21,7 @@ import * as path from 'path';
 const isWindows = os.platform() === 'win32';
 const isLinux = os.platform() === 'linux';
 
-const OUTLINE_PROXY_CONTROLLER_PATH =
-    path.join(unpackedAppPath(), 'tools', 'outline_proxy_controller', 'dist');
+const OUTLINE_PROXY_CONTROLLER_PATH = path.join(unpackedAppPath(), 'tools', 'outline_proxy_controller', 'dist');
 
 const LINUX_DAEMON_FILENAME = 'OutlineProxyController';
 const LINUX_DAEMON_SYSTEMD_SERVICE_FILENAME = 'outline_proxy_controller.service';
@@ -33,9 +32,7 @@ function unpackedAppPath() {
 }
 
 export function pathToEmbeddedBinary(toolname: string, filename: string) {
-  return path.join(
-      unpackedAppPath(), 'third_party', toolname, os.platform(),
-      filename + (isWindows ? '.exe' : ''));
+  return path.join(unpackedAppPath(), 'third_party', toolname, os.platform(), filename + (isWindows ? '.exe' : ''));
 }
 
 export function getServiceStartCommand(): string {
@@ -46,11 +43,10 @@ export function getServiceStartCommand(): string {
     //   build/windows
     //
     // Surrounding quotes important, consider "c:\program files"!
-    return `"${
-        path.join(
-            app.getAppPath().includes('app.asar') ? path.dirname(app.getPath('exe')) :
-                                                    app.getAppPath(),
-            'install_windows_service.bat')}"`;
+    return `"${path.join(
+      app.getAppPath().includes('app.asar') ? path.dirname(app.getPath('exe')) : app.getAppPath(),
+      'install_windows_service.bat'
+    )}"`;
   } else if (isLinux) {
     return path.join(copyServiceFilesToTempFolder(), LINUX_INSTALLER_FILENAME);
   } else {
@@ -62,12 +58,11 @@ export function getServiceStartCommand(): string {
 function copyServiceFilesToTempFolder() {
   const tmp = fs.mkdtempSync('/tmp/');
   console.log(`copying service files to ${tmp}`);
-  [LINUX_DAEMON_FILENAME, LINUX_DAEMON_SYSTEMD_SERVICE_FILENAME, LINUX_INSTALLER_FILENAME].forEach(
-      (filename) => {
-        const src = path.join(OUTLINE_PROXY_CONTROLLER_PATH, filename);
-        // https://github.com/jprichardson/node-fs-extra/issues/323
-        const dest = path.join(tmp, filename);
-        fsextra.copySync(src, dest, {overwrite: true});
-      });
+  [LINUX_DAEMON_FILENAME, LINUX_DAEMON_SYSTEMD_SERVICE_FILENAME, LINUX_INSTALLER_FILENAME].forEach(filename => {
+    const src = path.join(OUTLINE_PROXY_CONTROLLER_PATH, filename);
+    // https://github.com/jprichardson/node-fs-extra/issues/323
+    const dest = path.join(tmp, filename);
+    fsextra.copySync(src, dest, {overwrite: true});
+  });
   return tmp;
 }

--- a/src/electron/vpn_tunnel.ts
+++ b/src/electron/vpn_tunnel.ts
@@ -33,10 +33,10 @@ export interface VpnTunnel {
   readonly onceDisconnected: Promise<void>;
 
   // Sets an optional callback for when the tunnel is attempting to re-connect.
-  onReconnecting(listener?: (() => void)): void;
+  onReconnecting(listener?: () => void): void;
 
   // Sets an optional callback for when the tunnel successfully reconnects.
-  onReconnected(listener?: (() => void)): void;
+  onReconnected(listener?: () => void): void;
 
   // Turns on verbose logging. Must be called before connecting the tunnel.
   enableDebugMode(): void;

--- a/src/electron/webpack_electron_main.js
+++ b/src/electron/webpack_electron_main.js
@@ -12,30 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const path = require("path");
-const webpack = require("webpack");
+const path = require('path');
+const webpack = require('webpack');
 
 module.exports = env => {
   return {
-    entry: "./src/electron/index.ts",
-    target: "electron-main",
+    entry: './src/electron/index.ts',
+    target: 'electron-main',
     node: {
       __dirname: false,
       __filename: false,
     },
-    mode: "production",
-    devtool: "inline-source-map",
+    mode: 'production',
+    devtool: 'inline-source-map',
     module: {
       rules: [
         {
           test: /\.tsx?$/,
-          use: "ts-loader",
+          use: 'ts-loader',
           exclude: /node_modules/,
         },
       ],
     },
     resolve: {
-      extensions: [".tsx", ".ts", ".js"],
+      extensions: ['.tsx', '.ts', '.js'],
     },
     plugins: [
       new webpack.DefinePlugin({
@@ -43,8 +43,8 @@ module.exports = env => {
       }),
     ],
     output: {
-      filename: "index.js",
-      path: path.resolve(__dirname, "../../build/electron/electron"),
+      filename: 'index.js',
+      path: path.resolve(__dirname, '../../build/electron/electron'),
     },
   };
 };

--- a/src/electron/windows/electron_builder_signing_plugin.cjs
+++ b/src/electron/windows/electron_builder_signing_plugin.cjs
@@ -22,7 +22,7 @@
  */
 async function electronBuilderEntryPoint(configuration) {
   // CommonJS module is required, ES6 module is not supported by electron-builder
-  const { signWindowsExecutable } = await import('./sign_windows_executable.mjs');
+  const {signWindowsExecutable} = await import('./sign_windows_executable.mjs');
   await signWindowsExecutable(configuration.path, configuration.hash, null);
 }
 

--- a/src/electron/windows/sign_windows_executable.mjs
+++ b/src/electron/windows/sign_windows_executable.mjs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {spawn} from "child_process";
-import {constants} from "fs";
-import {access} from "fs/promises";
-import minimist from "minimist";
-import {dirname, resolve} from "path";
-import {fileURLToPath, pathToFileURL} from "url";
-import {format} from "util";
+import {spawn} from 'child_process';
+import {constants} from 'fs';
+import {access} from 'fs/promises';
+import minimist from 'minimist';
+import {dirname, resolve} from 'path';
+import {fileURLToPath, pathToFileURL} from 'url';
+import {format} from 'util';
 
 /**
  * Get the parent folder path of this script.
@@ -33,7 +33,7 @@ function currentDirname() {
  * @returns the folder path of outline-client root.
  */
 function outlineDirname() {
-  return resolve(currentDirname(), "..", "..", "..");
+  return resolve(currentDirname(), '..', '..', '..');
 }
 
 function assert(condition, msg) {
@@ -69,33 +69,33 @@ function getOptionValue(options, argName, envName, required) {
 
 function appendPfxJsignArgs(args, options) {
   // self-signed development certificate
-  args.push("--storetype", "PKCS12");
+  args.push('--storetype', 'PKCS12');
 
-  const pfxCert = getOptionValue(options, "pfx", "WINDOWS_SIGNING_PFX_CERT", true);
-  args.push("--keystore", pfxCert);
+  const pfxCert = getOptionValue(options, 'pfx', 'WINDOWS_SIGNING_PFX_CERT', true);
+  args.push('--keystore', pfxCert);
 }
 
 function appendDigicertUsbJsignArgs(args, options) {
   // extended validation certificate stored in USB drive
-  args.push("--storetype", "PKCS11");
+  args.push('--storetype', 'PKCS11');
 
-  const subject = getOptionValue(options, "subject", "WINDOWS_SIGNING_EV_CERT_SUBJECT", false);
+  const subject = getOptionValue(options, 'subject', 'WINDOWS_SIGNING_EV_CERT_SUBJECT', false);
   if (subject) {
-    args.push("--alias", subject);
+    args.push('--alias', subject);
   }
 
   var eTokenCfg;
   switch (process.platform) {
-    case "win32":
-      eTokenCfg = resolve(currentDirname(), "digicert-usb-config", "eToken-windows.cfg");
+    case 'win32':
+      eTokenCfg = resolve(currentDirname(), 'digicert-usb-config', 'eToken-windows.cfg');
       break;
-    case "darwin":
-      eTokenCfg = resolve(currentDirname(), "digicert-usb-config", "eToken-macos.cfg");
+    case 'darwin':
+      eTokenCfg = resolve(currentDirname(), 'digicert-usb-config', 'eToken-macos.cfg');
       break;
     default:
       throw new Error(`we do not support ev signing on ${process.platform}`);
   }
-  args.push("--keystore", eTokenCfg);
+  args.push('--keystore', eTokenCfg);
 }
 
 /**
@@ -106,19 +106,19 @@ function appendDigicertUsbJsignArgs(args, options) {
  */
 function jsign(fileToSign, options) {
   if (!options) {
-    throw new Error("options are required by jsign");
+    throw new Error('options are required by jsign');
   }
   if (!fileToSign) {
-    throw new Error("fileToSign is required by jsign");
+    throw new Error('fileToSign is required by jsign');
   }
 
-  const jSignJarPath = resolve(outlineDirname(), "third_party", "jsign", "jsign-4.0.jar");
-  const jsignProc = spawn("java", ["-jar", jSignJarPath, ...options, fileToSign], {
-    stdio: "inherit",
+  const jSignJarPath = resolve(outlineDirname(), 'third_party', 'jsign', 'jsign-4.0.jar');
+  const jsignProc = spawn('java', ['-jar', jSignJarPath, ...options, fileToSign], {
+    stdio: 'inherit',
   });
   return new Promise((resolve, reject) => {
-    jsignProc.on("error", reject);
-    jsignProc.on("exit", resolve);
+    jsignProc.on('error', reject);
+    jsignProc.on('exit', resolve);
   });
 }
 
@@ -131,34 +131,34 @@ function jsign(fileToSign, options) {
  *                         variables.
  */
 export async function signWindowsExecutable(exeFile, algorithm, options) {
-  const type = getOptionValue(options, "certtype", "WINDOWS_SIGNING_CERT_TYPE", false);
-  if (!type || type === "none") {
+  const type = getOptionValue(options, 'certtype', 'WINDOWS_SIGNING_CERT_TYPE', false);
+  if (!type || type === 'none') {
     console.info(`skip signing "${exeFile}"`);
     return;
   }
 
-  assert(!!exeFile, "executable path is required");
-  assert(algorithm === "sha1" || algorithm === "sha256", 'hashing algorithm must be either "sha1" or "sha256"');
+  assert(!!exeFile, 'executable path is required');
+  assert(algorithm === 'sha1' || algorithm === 'sha256', 'hashing algorithm must be either "sha1" or "sha256"');
 
   exeFile = resolve(exeFile);
   await assertFileExists(exeFile, 'executable file "%s" does not exist');
 
-  const password = getOptionValue(options, "password", "WINDOWS_SIGNING_CERT_PASSWORD", true);
+  const password = getOptionValue(options, 'password', 'WINDOWS_SIGNING_CERT_PASSWORD', true);
 
   const jsignArgs = [
-    "--alg",
-    algorithm === "sha256" ? "SHA-256" : "SHA-1",
-    "--tsaurl",
-    "http://timestamp.digicert.com",
-    "--storepass",
+    '--alg',
+    algorithm === 'sha256' ? 'SHA-256' : 'SHA-1',
+    '--tsaurl',
+    'http://timestamp.digicert.com',
+    '--storepass',
     password,
   ];
 
   switch (type) {
-    case "pfx":
+    case 'pfx':
       appendPfxJsignArgs(jsignArgs, options);
       break;
-    case "digicert-usb":
+    case 'digicert-usb':
       appendDigicertUsbJsignArgs(jsignArgs, options);
       break;
     default:
@@ -169,7 +169,7 @@ export async function signWindowsExecutable(exeFile, algorithm, options) {
   try {
     exitCode = await jsign(exeFile, jsignArgs);
   } catch (err) {
-    console.error("failed to start java, please make sure you have installed java");
+    console.error('failed to start java, please make sure you have installed java');
     throw new Error(err);
   }
 


### PR DESCRIPTION
In this purely reformat PR, I ran `npx prettier "src/electron/**/*.{cjs,mjs,html,js,json,md,ts}" --write` to format all code under `src/electron/**`, so in the future the feature code won't be distracted by the format change.

In addition, I also removed the `prettier` configuration in `package.json` because we already have the `.prettierrc.json` file. And I copied the [Google style guide](https://github.com/google/gts/blob/main/.prettierrc.json) to `.prettierrc.json` as well.

By default, `prettier` won't recognize `.cjs` files, so I assigned the `babel` parser to all `.cjs` files to prevent errors like `"No parser could be inferred for file: src/electron/windows/electron_builder_signing_plugin.cjs"`.