### PR TITLE
💊 fix(electron): fix wrong connection status when error is thrown during connect

### DIFF
--- a/src/electron/index.ts
+++ b/src/electron/index.ts
@@ -438,6 +438,8 @@ function main() {
       });
     } catch (e) {
       console.error(`could not connect: ${e.name} (${e.message})`);
+      // stop the vpn and forget, no need to await because stopVpn itself might throw another error
+      stopVpn();
       throw errors.toErrorCode(e);
     }
   });

--- a/src/electron/routing_service.ts
+++ b/src/electron/routing_service.ts
@@ -111,7 +111,7 @@ export class RoutingDaemon {
           newSocket.on('data', this.dataHandler.bind(this));
 
           // Potential race condition: this routing daemon might already be stopped by the tunnel
-          // when one of the dependencies (ss-local/tunnel2socks) exited
+          // when one of the dependencies (ss-local/tun2socks) exited
           // TODO(junyi): better handling this case in the next installation logic fix
           if (this.stopping) {
             cleanup();


### PR DESCRIPTION
Previously when user clicks the "CONNECT" button, but encounters some errors (for example, routing daemon service is not running), our app still thinks we have *connected*, which is wrong. Even worse, when user tries to "DISCONNECT" then, our app just freezes forever.

In this PR, I fixed this issue by always making sure the `onceDisconnected` event is fired in `RoutingDaemon` when `stop()` method is called. It will then trigger the `onceDisconnected` event in `ShadowsocksLibevBadvpnTunnel`, and reset the state.
