### PR TITLE
fix(www): missing indicator width

### DIFF
--- a/scripts/run_action.mjs
+++ b/scripts/run_action.mjs
@@ -113,21 +113,25 @@ async function main() {
   process.env.BUILD_DIR ??= path.join(process.env.ROOT_DIR, 'build');
   process.env.FORCE_COLOR = true;
 
-  console.info(
-    chalk.bgGreen.bold(`
-     / __ \\| |  | |__   __| |    |_   _| \\ | |  ____|    
-    | |  | | |  | |  | |  | |      | | |  \\| | |__       
-    | |  | | |  | |  | |  | |      | | | . \` |  __|      
-    | |__| | |__| |  | |  | |____ _| |_| |\\  | |____     
-     \\____/ \\____/   |_|  |______|_____|_| \\_|______|    `)
-  );
-  console.info(
-    chalk.gray(`
-=========================================================
-             © The Outline Authors, 2022
-=========================================================
-`)
-  );
+  if (!process.env.IS_ACTION) {
+    console.info(
+      chalk.bgGreen.bold(`
+       / __ \\| |  | |__   __| |    |_   _| \\ | |  ____|    
+      | |  | | |  | |  | |  | |      | | |  \\| | |__       
+      | |  | | |  | |  | |  | |      | | | . \` |  __|      
+      | |__| | |__| |  | |  | |____ _| |_| |\\  | |____     
+       \\____/ \\____/   |_|  |______|_____|_| \\_|______|    `)
+    );
+    console.info(
+      chalk.gray(`
+  =========================================================
+               © The Outline Authors, 2022
+  =========================================================
+  `)
+    );
+
+    process.env.IS_ACTION = true;
+  }
 
   return runAction(...process.argv.slice(2));
 }

--- a/src/electron/build.action.sh
+++ b/src/electron/build.action.sh
@@ -49,7 +49,7 @@ if [[ -n ${SENTRY_DSN:-} ]]; then
     readonly SENTRY_URL="https://sentry.io/api/$PROJECT_ID/store/?sentry_version=7&sentry_key=$API_KEY"
 fi
 
-readonly WEBPACK_MODE="$(node ./scripts/get_webpack_mode.mjs --buildMode=${BUILD_MODE})"
+readonly WEBPACK_MODE="$(node ./scripts/get_webpack_build_mode.mjs --buildMode=${BUILD_MODE})"
 
 node ./scripts/run_action.mjs src/www/build "${PLATFORM}" --buildMode="${BUILD_MODE}"
 

--- a/src/www/views/servers_view/server_card/index.ts
+++ b/src/www/views/servers_view/server_card/index.ts
@@ -84,6 +84,9 @@ export class ServerCard extends LegacyElementMixin(PolymerElement) {
         width: 192px;
         height: 192px;
       }
+      #server-visualization-button server-connection-indicator {
+        width: 192px;
+      }
       .status-message {
         color: var(--disabled-text-color);
         font-size: small;


### PR DESCRIPTION
- adds missing width to single server indicator
- updates webpack flag script name
- don't show letter head on every bash script run