### PR TITLE
fix(devtools): revert 'remove plugins folder on cordova setup'

### DIFF
--- a/src/cordova/setup.action.mjs
+++ b/src/cordova/setup.action.mjs
@@ -52,7 +52,6 @@ export async function main(...parameters) {
   await runAction('www/build', `--buildMode=${buildMode}`);
 
   await rmfr(`platforms/${platform}`);
-  await rmfr('plugins');
 
   if (!existsSync(path.resolve(process.env.ROOT_DIR, `platforms/${platform}`))) {
     await cordova.platform(


### PR DESCRIPTION
Reverts Jigsaw-Code/outline-client#1318

This breaks `www/start`. We need to find a better way of doing it.