### PR TITLE
fix(electron/linux): 💊 outline icon is not shown in Ubuntu Dock

### DIFF
--- a/src/electron/electron-builder.json
+++ b/src/electron/electron-builder.json
@@ -8,6 +8,7 @@
   "linux": {
     "target": ["AppImage"],
     "files": [
+      "build/icons/png",
       "third_party/badvpn/linux",
       "third_party/outline-go-tun2socks/linux",
       "third_party/shadowsocks-libev/linux",


### PR DESCRIPTION
Our app's icon is not shown in Ubuntu Dock (on Windows it is fine):

<img width="438" alt="image" src="https://user-images.githubusercontent.com/93548144/169601560-13dc6d59-9f36-490a-ac9f-60bc5744a593.png">

Similar issues are reported to electron-builder (e.g., https://github.com/electron-userland/electron-builder/issues/2269). Though the issue is declared to be "fixed", it is actually not, people are still using the workaround of setting main windows's icon in electron code.

In this fix, I use the workaround mentioned above which is to forcibly set the window icon to the 64x64 icon image. The following images illustrate the icon displayed under 100%, 150% and 200% dpi settings:

<img width="438" alt="image" src="https://user-images.githubusercontent.com/93548144/169601854-30b74190-d3cb-4c98-9550-8eec932adb20.png">

<img width="657" alt="image" src="https://user-images.githubusercontent.com/93548144/169601965-f101b3fd-49bf-4568-a571-dead88bd1681.png">

<img width="866" alt="image" src="https://user-images.githubusercontent.com/93548144/169602052-d5f931b7-421d-4f8a-acde-3456d8569bea.png">

I did not set the icon to 128x128 because it actually looks too sharp under the regular DPI setting (100%), here a comparison between 64x64 and 128x128 under 100% dpi (though in higher dpi's, the 128x128 looks better):

<img width="438" alt="image" src="https://user-images.githubusercontent.com/93548144/169601854-30b74190-d3cb-4c98-9550-8eec932adb20.png">

<img width="423" alt="image" src="https://user-images.githubusercontent.com/93548144/169602791-15875358-40b8-4052-9ff8-8cc428ac4157.png">
