### PR TITLE
fix: server card ip address text wrapping, platform in www/build

### DIFF
--- a/src/cordova/setup.action.mjs
+++ b/src/cordova/setup.action.mjs
@@ -49,7 +49,7 @@ export async function main(...parameters) {
     throw new SystemError('Building an Apple binary requires xcodebuild and can only be done on MacOS');
   }
 
-  await runAction('www/build', `--buildMode=${buildMode}`);
+  await runAction('www/build', platform, `--buildMode=${buildMode}`);
 
   await rmfr(`platforms/${platform}`);
 

--- a/src/www/views/servers_view/server_list_item/server_card/index.ts
+++ b/src/www/views/servers_view/server_list_item/server_card/index.ts
@@ -61,6 +61,7 @@ const sharedCSS = css`
   .card-metadata {
     font-family: var(--outline-font-family);
     color: var(--outline-text-color);
+    gap: var(--outline-slim-gutter);
     grid-area: metadata;
     height: 100%;
     display: flex;
@@ -74,26 +75,31 @@ const sharedCSS = css`
 
   .card-metadata-text {
     user-select: text;
-    padding: var(--outline-slim-gutter);
   }
 
-  .card-metadata-server-name {
+  .card-metadata-server-name,
+  .card-metadata-server-address {
     -webkit-box-orient: vertical;
-    /* https://caniuse.com/?search=line-clamp */
-    -webkit-line-clamp: 3;
-    color: var(--outline-text-color);
     display: -webkit-box;
     font-family: var(--outline-font-family);
-    font-size: var(--server-name-size);
-    margin-bottom: var(--outline-mini-gutter);
     overflow: hidden;
     text-overflow: ellipsis;
   }
 
+  .card-metadata-server-name {
+    /* https://caniuse.com/?search=line-clamp */
+    -webkit-line-clamp: 3;
+    color: var(--outline-text-color);
+    font-size: var(--server-name-size);
+    margin-bottom: var(--outline-mini-gutter);
+  }
+
   .card-metadata-server-address {
+    /* https://caniuse.com/?search=line-clamp */
+    -webkit-line-clamp: 2;
     color: var(--outline-label-color);
-    font-family: var(--outline-font-family);
     font-size: var(--server-address-size);
+    word-break: break-all;
   }
 
   .card-menu-button {


### PR DESCRIPTION
- adds text wrapping to card server address:
<img width="444" alt="Screen Shot 2022-06-22 at 10 55 54" src="https://user-images.githubusercontent.com/3759828/175081144-22299025-ef0a-4823-8500-1bd5f6fa7baa.png">
- passes the platform through to the `www/build` action call to select the right version #