### PR TITLE
fix: restore text selection on iOS

### DIFF
--- a/src/www/views/servers_view/server_list_item/server_card/index.ts
+++ b/src/www/views/servers_view/server_list_item/server_card/index.ts
@@ -78,10 +78,6 @@ const sharedCSS = css`
     max-height: var(--max-indicator-size);
   }
 
-  .card-metadata-text {
-    user-select: text;
-  }
-
   .card-metadata-server-name,
   .card-metadata-server-address {
     -webkit-box-orient: vertical;
@@ -89,6 +85,8 @@ const sharedCSS = css`
     font-family: var(--outline-font-family);
     overflow: hidden;
     text-overflow: ellipsis;
+    -webkit-user-select: text;
+    user-select: text;
   }
 
   .card-metadata-server-name {


### PR DESCRIPTION
forgot to add prefixed text select on the relevant fields for ios...