### PR TITLE
fix(www): 💊 hide server list scroll bar when there is enough space

### DIFF
--- a/src/www/ui_components/app-root.js
+++ b/src/www/ui_components/app-root.js
@@ -219,7 +219,7 @@ export class AppRoot extends mixinBehaviors([AppLocalizeBehavior], PolymerElemen
             min-height: 42px;
           }
         }
-        @media (min-height: 600px) {
+        @media (min-height: 650px) {
           #logo-nav {
             height: 180px;
           }

--- a/src/www/views/servers_view/index.ts
+++ b/src/www/views/servers_view/index.ts
@@ -41,8 +41,6 @@ Polymer({
         height: -webkit-calc(100vh - 64px);
         font-size: 14px;
         line-height: 20px;
-        /* Temporarily hard-coding additional padding at the bottom to give users more scroll room. */
-        padding-bottom: 50px;
       }
       :host a {
         color: var(--medium-green);


### PR DESCRIPTION
**Previous**

<img width="538" alt="image" src="https://user-images.githubusercontent.com/93548144/181633762-64c59e74-34b6-4dd6-ae98-9d4645531499.png">

<img width="277" alt="image" src="https://user-images.githubusercontent.com/93548144/181636283-0082287f-5aae-4d2d-ae20-85648f39a6d9.png">

**Now**

<img width="644" alt="image" src="https://user-images.githubusercontent.com/93548144/181633979-0d8e8984-6e4d-4bdc-9072-fff853407352.png">

<img width="324" alt="image" src="https://user-images.githubusercontent.com/93548144/181636474-23efbd3d-429c-4a61-83fe-46f5e6ff31b8.png">
