### PR TITLE
fix: wrap long words in server name

### DIFF
--- a/src/www/views/servers_view/server_list_item/server_card/index.ts
+++ b/src/www/views/servers_view/server_list_item/server_card/index.ts
@@ -191,7 +191,7 @@ const getSharedComponents = (element: ServerListItemElement & LitElement) => {
       metadataText: html`
         <div class="card-metadata-text">
           <h2 class="card-metadata-server-name" id="server-name">
-            ${messages.serverName} Loremipsumdolorsitamet,consecteturadipisicingelit.Ea,suscipit.
+            ${messages.serverName}
           </h2>
           <label class="card-metadata-server-address">${server.address}</label>
         </div>

--- a/src/www/views/servers_view/server_list_item/server_card/index.ts
+++ b/src/www/views/servers_view/server_list_item/server_card/index.ts
@@ -95,6 +95,8 @@ const sharedCSS = css`
     color: var(--outline-text-color);
     font-size: var(--server-name-size);
     margin-bottom: var(--outline-mini-gutter);
+    /* To break the line in case a sequence of word characters is longer than the line.
+       See https://github.com/Jigsaw-Code/outline-client/issues/1372. */
     word-break: break-all;
   }
 

--- a/src/www/views/servers_view/server_list_item/server_card/index.ts
+++ b/src/www/views/servers_view/server_list_item/server_card/index.ts
@@ -73,10 +73,6 @@ const sharedCSS = css`
     align-items: center;
   }
 
-  .card-metadata-text {
-    max-width: 225px;
-  }
-
   server-connection-indicator {
     min-height: var(--min-indicator-size);
     max-height: var(--max-indicator-size);
@@ -99,6 +95,7 @@ const sharedCSS = css`
     color: var(--outline-text-color);
     font-size: var(--server-name-size);
     margin-bottom: var(--outline-mini-gutter);
+    word-break: break-all;
   }
 
   .card-metadata-server-address {
@@ -192,7 +189,7 @@ const getSharedComponents = (element: ServerListItemElement & LitElement) => {
       metadataText: html`
         <div class="card-metadata-text">
           <h2 class="card-metadata-server-name" id="server-name">
-            ${messages.serverName}
+            ${messages.serverName} Loremipsumdolorsitamet,consecteturadipisicingelit.Ea,suscipit.
           </h2>
           <label class="card-metadata-server-address">${server.address}</label>
         </div>

--- a/src/www/views/servers_view/server_list_item/server_card/index.ts
+++ b/src/www/views/servers_view/server_list_item/server_card/index.ts
@@ -73,10 +73,6 @@ const sharedCSS = css`
     align-items: center;
   }
 
-  .card-metadata-text {
-    max-width: 225px;
-  }
-
   server-connection-indicator {
     min-height: var(--min-indicator-size);
     max-height: var(--max-indicator-size);

--- a/src/www/views/servers_view/server_list_item/server_card/index.ts
+++ b/src/www/views/servers_view/server_list_item/server_card/index.ts
@@ -73,6 +73,10 @@ const sharedCSS = css`
     align-items: center;
   }
 
+  .card-metadata-text {
+    max-width: 225px;
+  }
+
   server-connection-indicator {
     min-height: var(--min-indicator-size);
     max-height: var(--max-indicator-size);


### PR DESCRIPTION
With long text without spaces, the container expanded and the button went beyond it.
Added max width for text block. 