### PR TITLE
fix(service/linux): 🔒️ prevent command injection issue

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -17,6 +17,8 @@ module.exports = {
         'electron/linux',
         'electron/windows',
         'www',
+        'service/linux',
+        'service/windows',
       ],
     ],
   },

--- a/tools/outline_proxy_controller/outline_proxy_controller.h
+++ b/tools/outline_proxy_controller/outline_proxy_controller.h
@@ -14,18 +14,17 @@
 
 #pragma once
 
-#include <queue>
 #include <sstream>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include <cstdlib>
 
 namespace outline {
 
 typedef std::pair<std::string, uint8_t> OutputAndStatus;
-typedef std::pair<const std::string, const std::string> SubCommandPart;
-typedef std::queue<SubCommandPart> SubCommand;
+typedef std::vector<std::string> CommandArguments;
 
 class OutlineProxyController {
  public:
@@ -126,15 +125,17 @@ class OutlineProxyController {
   /**
    * exectues a shell command and returns the stdout
    */
-  OutputAndStatus executeCommand(const std::string commandName, const SubCommand args);
+  OutputAndStatus executeCommand(const std::string commandName,
+                                 const std::string subCommandName,
+                                 CommandArguments args);
 
-  OutputAndStatus executeIPCommand(const SubCommand args);
-  OutputAndStatus executeIPRoute(const SubCommand args);
-  OutputAndStatus executeIPLink(const SubCommand args);
-  OutputAndStatus executeIPTunTap(const SubCommand args);
-  OutputAndStatus executeIPAddress(const SubCommand args);
+  OutputAndStatus executeIPCommand(const CommandArguments &args);
+  OutputAndStatus executeIPRoute(const CommandArguments &args);
+  OutputAndStatus executeIPLink(const CommandArguments &args);
+  OutputAndStatus executeIPTunTap(const CommandArguments &args);
+  OutputAndStatus executeIPAddress(const CommandArguments &args);
 
-  OutputAndStatus executeSysctl(const SubCommand args);
+  OutputAndStatus executeSysctl(const CommandArguments &args);
 
   void detectBestInterfaceIndex();
   void processRoutingTable();
@@ -169,21 +170,14 @@ class OutlineProxyController {
    */
   std::string getParamValueInResult(std::string resultString, std::string param);
 
-  /**
-   *  store created route as an string so it can be deleted later
-   */
-  std::string createRoutingString(SubCommand args);
-
  private:
-  const std::string c_redirect_stderr_into_stdout = " 2>&1";
-
   const std::string resultDelimiter = " ";
 
   const std::string IPCommand = "ip";
-  const std::string IPRouteCommand = "ip route";
-  const std::string IPAddressCommand = "ip addr";
-  const std::string IPLinkCommand = "ip link";
-  const std::string IPTunTapCommand = "ip tuntap";
+  const std::string IPRouteSubCommand = "route";
+  const std::string IPAddressSubCommand = "addr";
+  const std::string IPLinkSubCommand = "link";
+  const std::string IPTunTapSubCommand = "tuntap";
   const std::string sysctlCommand = "sysctl";
 
   const std::string c_normal_traffic_priority_metric = "10";


### PR DESCRIPTION
> Please refer to the internal Issue ID: 239705916
> Test with Outline Client v1.7.0

In this PR, I implemented a `safe-popen` to replace the original `popen` system call.

I also refactored the `queue<pair<string, string>>` based `SubCommand` to a `vector<string>` based `CommandArguments` because:

1. We made assumptions about shell context, for example, we had code `SubCommand.push({"add dev", "xxx"})` which will be expanded to three arguments `add dev xxx`. This will not work in new code because `add dev` will be treated as a single argument. We can either split the string by spaces, or we just refactored it to a `vector`, I chose the later one.
2. It makes more sense to use a list of items than a FIFO queue as **argument list**

Finally I removed the un-implemented `createRoutingString` function.