### PR TITLE
fix(service): 🔒️ reduce tun device subnet size to one (/32)

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -17,6 +17,7 @@ module.exports = {
         'electron/linux',
         'electron/windows',
         'www',
+        'service',
         'service/linux',
         'service/windows',
       ],

--- a/src/electron/add_tap_device.bat
+++ b/src/electron/add_tap_device.bat
@@ -102,7 +102,7 @@ powershell "Enable-NetAdapter -Name \"%DEVICE_NAME%\"" <nul
 :: TODO: Actually search the system for an unused subnet or make the subnet
 ::       configurable in the Outline client.
 echo Configuring TAP device subnet...
-netsh interface ip set address %DEVICE_NAME% static 10.0.85.2 255.255.255.0
+netsh interface ip set address %DEVICE_NAME% static 10.0.85.2 255.255.255.255
 if %errorlevel% neq 0 (
   echo Could not set TAP network device subnet. >&2
   exit /b %ERROR_TAP_CONFIGURE_SUBNET%


### PR DESCRIPTION
In this PR, I narrow down the subnet size of our tun/tap device to a single host (previously it was a `/24` subnet). Although I have tested with the current client and it is working, it would still be better to replace [the `255.255.255.0` network mask](https://github.com/Jigsaw-Code/outline-client/blob/1d2826339d8253f58f09281a2ae2a8385a5da715/src/electron/sslibev_badvpn_tunnel.ts#L38) used in `ss-local`. Let's use another PR to resolve this issue because:

1. For backward compatibility, because in Linux we do not have a way to upgrade the service for now
2. We will switch to the [go network stack](https://github.com/Jigsaw-Code/outline-client/blob/1d2826339d8253f58f09281a2ae2a8385a5da715/src/electron/go_vpn_tunnel.ts#L35) soon

Now the new tun/tap configuration looks like:

**Windows** (take effect after installation/upgrade)

<img width="359" alt="image" src="https://user-images.githubusercontent.com/93548144/188733664-9b500109-3848-4423-be72-553e53bfd652.png">


**Linux** (New installations works fine, existing service won't be replaced, but this is a different issue, can be resolved in another PR)

<img width="546" alt="image" src="https://user-images.githubusercontent.com/93548144/188734831-5142e39c-a90e-494a-8813-ec14331ccef0.png">
