### PR TITLE
feat(service/linux): 🔒️ add outlinevpn group to further restrict permissions

### DIFF
--- a/resources/original_messages.json
+++ b/resources/original_messages.json
@@ -424,7 +424,7 @@
     "desciption": "An error message shown when the user tries to install Outline backend services but failed for some reason."
   },
   "outline_services_installed": {
-    "message": "Outline has been successfully initialized, please restart your machine for changes to take effect.",
+    "message": "Outline has been successfully initialized, please try again to connect to the server.",
     "desciption": "An information message shown when the Outline successfully installed all backend services, and we ask the user try to reconnect to the server."
   },
   "outline_services_installing": {

--- a/resources/original_messages.json
+++ b/resources/original_messages.json
@@ -424,7 +424,7 @@
     "desciption": "An error message shown when the user tries to install Outline backend services but failed for some reason."
   },
   "outline_services_installed": {
-    "message": "Outline has been successfully initialized, please try again to connect to the server.",
+    "message": "Outline has been successfully initialized, please restart your machine for changes to take effect.",
     "desciption": "An information message shown when the Outline successfully installed all backend services, and we ask the user try to reconnect to the server."
   },
   "outline_services_installing": {

--- a/src/electron/routing_service.ts
+++ b/src/electron/routing_service.ts
@@ -15,7 +15,7 @@
 import {createHash} from 'node:crypto';
 import * as fsextra from 'fs-extra';
 import {createConnection, Socket} from 'net';
-import {platform} from 'os';
+import {platform, userInfo} from 'os';
 import * as path from 'path';
 import * as sudo from 'sudo-prompt';
 
@@ -324,7 +324,7 @@ async function installLinuxRoutingServices(): Promise<void> {
     installationFileDescriptors
       .map(({filename, sha256}) => `/usr/bin/echo "${sha256}  ${path.join(tmp, filename)}" | /usr/bin/shasum -a 256 -c`)
       .join(' && ');
-  command += ` && "${path.join(tmp, LINUX_INSTALLER_FILENAME)}"`;
+  command += ` && "${path.join(tmp, LINUX_INSTALLER_FILENAME)}" "${userInfo().username}"`;
 
   console.log('trying to run command as root: ', command);
   await executeCommandAsRoot(command);

--- a/src/www/messages/en.json
+++ b/src/www/messages/en.json
@@ -53,7 +53,7 @@
   "outline-plugin-error-vpn-permission-not-granted": "Outline needs your permission to set up a VPN connection to the server. Please try again, or submit feedback if you need help.",
   "outline-services-installation-confirmation": "We will initialize Outline, which may require admin permissions. Would you like to proceed?",
   "outline-services-installation-failed": "Unfortunately we are not able to initialize Outline, please submit feedback through the app.",
-  "outline-services-installed": "Outline has been successfully initialized, please restart your machine for changes to take effect.",
+  "outline-services-installed": "Outline has been successfully initialized, please try again to connect to the server.",
   "outline-services-installing": "Initializing Outline...",
   "privacy": "Privacy",
   "privacy-text": "Some technical information is sent if you submit feedback, if there’s an app error or crash, or if your server administrator opts in to share anonymous server usage data.",

--- a/src/www/messages/en.json
+++ b/src/www/messages/en.json
@@ -53,7 +53,7 @@
   "outline-plugin-error-vpn-permission-not-granted": "Outline needs your permission to set up a VPN connection to the server. Please try again, or submit feedback if you need help.",
   "outline-services-installation-confirmation": "We will initialize Outline, which may require admin permissions. Would you like to proceed?",
   "outline-services-installation-failed": "Unfortunately we are not able to initialize Outline, please submit feedback through the app.",
-  "outline-services-installed": "Outline has been successfully initialized, please try again to connect to the server.",
+  "outline-services-installed": "Outline has been successfully initialized, please restart your machine for changes to take effect.",
   "outline-services-installing": "Initializing Outline...",
   "privacy": "Privacy",
   "privacy-text": "Some technical information is sent if you submit feedback, if there’s an app error or crash, or if your server administrator opts in to share anonymous server usage data.",

--- a/tools/outline_proxy_controller/dist/install_linux_service.sh
+++ b/tools/outline_proxy_controller/dist/install_linux_service.sh
@@ -17,6 +17,7 @@
 set -eux
 
 readonly PREFIX=/usr/local
+readonly SERVICE_DIR=/etc/systemd/system
 readonly SERVICE_NAME=outline_proxy_controller.service
 readonly GROUP_NAME=outlinevpn
 readonly SCRIPT_DIR="$(dirname ${0})"
@@ -32,7 +33,13 @@ fi
 
 # Copy/update the service's files.
 /usr/bin/cp -f "${SCRIPT_DIR}/OutlineProxyController" "${PREFIX}/sbin"
-/usr/bin/cp -f "${SCRIPT_DIR}/${SERVICE_NAME}" "/etc/systemd/system/"
+/usr/bin/cp -f "${SCRIPT_DIR}/${SERVICE_NAME}" "${SERVICE_DIR}/"
+
+# Replace "--owning-user-id" argument in ".service" file with the actual user
+if /usr/bin/id "${1}" &>/dev/null; then
+  owneruid="$(id -u "${1}")"
+  /usr/bin/sed -i "s/--owning-user-id=-1/--owning-user-id=${owneruid}/g" "${SERVICE_DIR}/${SERVICE_NAME}"
+fi
 
 # (Re-)start the service.
 /usr/bin/systemctl daemon-reload

--- a/tools/outline_proxy_controller/dist/install_linux_service.sh
+++ b/tools/outline_proxy_controller/dist/install_linux_service.sh
@@ -16,17 +16,27 @@
 
 readonly PREFIX=/usr/local
 readonly SERVICE_NAME=outline_proxy_controller.service
+readonly GROUP_NAME=outlinevpn
+readonly SCRIPT_DIR="$(dirname ${0})"
+
+# Create outlinevpn group
+/usr/sbin/groupadd "${GROUP_NAME}"
+if /usr/bin/id "${1}" &>/dev/null; then
+  /usr/sbin/usermod -aG "${GROUP_NAME}" "${1}"
+  /usr/bin/echo "user ${1} has been added to ${GROUP_NAME} group"
+else
+  /usr/bin/echo "warn: no user will be added to ${GROUP_NAME} group" >&2
+fi
 
 # Copy/update the service's files.
-readonly SCRIPT_DIR=$(dirname $0)
-cp -f "$SCRIPT_DIR/OutlineProxyController" $PREFIX/sbin
-cp -f "$SCRIPT_DIR/$SERVICE_NAME" /etc/systemd/system/
+/usr/bin/cp -f "${SCRIPT_DIR}/OutlineProxyController" "${PREFIX}/sbin"
+/usr/bin/cp -f "${SCRIPT_DIR}/${SERVICE_NAME}" "/etc/systemd/system/"
 
 # (Re-)start the service.
-systemctl daemon-reload
-systemctl enable $SERVICE_NAME
-systemctl restart $SERVICE_NAME
+/usr/bin/systemctl daemon-reload
+/usr/bin/systemctl enable "${SERVICE_NAME}"
+/usr/bin/systemctl restart "${SERVICE_NAME}"
 
 # Because the .service file specifies Type=simple, the installation script exits immediately.
 # Sleep for a couple of seconds before exiting.
-sleep 2
+/usr/bin/sleep 2

--- a/tools/outline_proxy_controller/dist/install_linux_service.sh
+++ b/tools/outline_proxy_controller/dist/install_linux_service.sh
@@ -14,13 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -eux
+
 readonly PREFIX=/usr/local
 readonly SERVICE_NAME=outline_proxy_controller.service
 readonly GROUP_NAME=outlinevpn
 readonly SCRIPT_DIR="$(dirname ${0})"
 
 # Create outlinevpn group
-/usr/sbin/groupadd "${GROUP_NAME}"
+/usr/sbin/groupadd -f "${GROUP_NAME}"
 if /usr/bin/id "${1}" &>/dev/null; then
   /usr/sbin/usermod -aG "${GROUP_NAME}" "${1}"
   /usr/bin/echo "user ${1} has been added to ${GROUP_NAME} group"

--- a/tools/outline_proxy_controller/dist/outline_proxy_controller.service
+++ b/tools/outline_proxy_controller/dist/outline_proxy_controller.service
@@ -19,7 +19,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/local/sbin/OutlineProxyController --socket-filename=/var/run/outline_controller
+ExecStart=/usr/local/sbin/OutlineProxyController --socket-filename=/var/run/outline_controller --owning-user-id=-1
 
 [Install]
 WantedBy=multi-user.target

--- a/tools/outline_proxy_controller/outline_controller_server.h
+++ b/tools/outline_proxy_controller/outline_controller_server.h
@@ -86,7 +86,9 @@ class OutlineControllerServer {
   /*
    * constructor: setup a listener on the file as a unix socket
    */
-  OutlineControllerServer(boost::asio::io_context& io_context, const std::string& file);
+  OutlineControllerServer(boost::asio::io_context& io_context,
+                          const std::string& file,
+                          uid_t owning_user);
 
  private:
   std::shared_ptr<OutlineProxyController> outlineProxyController_;


### PR DESCRIPTION
In this PR, I updated the permission model of the "outline_proxy_controller" daemon. We will have a group named as `outlinevpn`, only users in this group will be able to access "outline_proxy_controller" (through UNIX socket `/var/run/outline_controller`). During installation, we will only add the current user to `outlinevpn` group. System admins are free to add more users into this group. The new permission is listed below:

```
srw-rw---- 1 junyi outlinevpn 0 Oct  4 21:09 /var/run/outline_controller
```

Notice that I updated the owner to the current user `junyi` (instead of the default `root`), this is to prevent any potential restarts because Linux won't refresh group membership within the same login session.

Also I replaced all shell commands to absolute paths to prevent any potential `PATH` pollutions.