### PR TITLE
chore: update android build number to 41

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="org.outline.android.client" version="1.8.0" android-versionCode="40" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="org.outline.android.client" version="1.8.0" android-versionCode="41" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Outline</name>
     <description>
         Internet without borders (powered by Shadowsocks)


### PR DESCRIPTION
This is in the docs... I just forgot about it because Apple manages this for you automatically.