### PR TITLE
fix(service/linux): 💊 propagate VPN errors back to client

### DIFF
--- a/tools/outline_proxy_controller/CMakeLists.txt
+++ b/tools/outline_proxy_controller/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 3.1)
 project (OutlineProxyController)
 set(BOOST_VERSION 1.67)
 set(Boost_USE_STATIC_LIBS ON)
@@ -30,8 +30,9 @@ configure_file (
   "${PROJECT_BINARY_DIR}/OutlineProxyControllerConfig.h"
   )
 
-set(CMAKE_BUILD_TYPE "Debug")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -pthread -Wall -O0 -ggdb ${SANITIZE}")
+set(CMAKE_BUILD_TYPE "Release")
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -Wall -ggdb ${SANITIZE}")
 
 include_directories(
     "${Boost_INCLUDE_DIR}")
@@ -41,6 +42,7 @@ add_executable(OutlineProxyController
     outline_proxy_controller.cpp
     outline_controller_server.cpp
     outline_daemon.cpp
+    outline_error.cpp
     logger.cpp
     )
 

--- a/tools/outline_proxy_controller/outline_controller_server.cpp
+++ b/tools/outline_proxy_controller/outline_controller_server.cpp
@@ -23,9 +23,9 @@
 #include <unistd.h>
 #include <pwd.h>
 
+#include "outline_error.h"
 #include "outline_controller_server.h"
 
-using namespace std;
 using namespace outline;
 using boost::asio::local::stream_protocol;
 
@@ -50,10 +50,10 @@ void session::start() {
             break;
           }
         }
-        auto rc = runClientCommand(clientCommand);
-        response << "{\"statusCode\": " << std::get<0>(rc) << ",\"returnValue\": \""
-                 << std::get<1>(rc) << "\""
-                 << ",\"action\": \"" << std::get<2>(rc) << "\"}" << std::endl;
+        auto [err, result, action] = runClientCommand(clientCommand);
+        response << "{\"statusCode\": " << err
+                 << ",\"returnValue\": \"" << result << "\""
+                 << ",\"action\": \"" << action << "\"}" << std::endl;
         boost::asio::async_write(
             socket_, boost::asio::buffer(response.str(), response.str().length()), yield);
         std::cout << "Wrote back (" << response.str() << ") to unix socket" << std::endl;
@@ -94,51 +94,54 @@ std::tuple<int, std::string, std::string> session::runClientCommand(std::string 
     boost::property_tree::read_json(ss, pt);
   } catch (std::exception const& e) {
     std::cerr << e.what() << std::endl;
-    return std::make_tuple(GENERIC_FAILURE, "Invalid JSON", "");
+    return {static_cast<int>(outline_errc::unexpected), "Invalid JSON", {}};
   }
 
   boost::property_tree::ptree::assoc_iterator _action_iter = pt.find("action");
   if (_action_iter == pt.not_found()) {
     std::cerr << "Invalid input JSON - action doesn't exist" << std::endl;
-    return std::make_tuple(GENERIC_FAILURE, "Invalid JSON", "");
+    return {static_cast<int>(outline_errc::unexpected), "Invalid JSON", {}};
   }
   action = boost::lexical_cast<std::string>(pt.to_iterator(_action_iter)->second.data());
   // std::cout << action << std::endl;
 
-  if (action == CONFIGURE_ROUTING) {
-    boost::property_tree::ptree::assoc_iterator _parameters_iter = pt.find("parameters");
-    if (_parameters_iter == pt.not_found()) {
-      std::cerr << "Invalid input JSON - parameters doesn't exist" << std::endl;
-      return std::make_tuple(GENERIC_FAILURE, "Invalid JSON", action);
+  try {
+    if (action == CONFIGURE_ROUTING) {
+      boost::property_tree::ptree::assoc_iterator _parameters_iter = pt.find("parameters");
+      if (_parameters_iter == pt.not_found()) {
+        std::cerr << "Invalid input JSON - parameters doesn't exist" << std::endl;
+        return {static_cast<int>(outline_errc::unexpected), "Invalid JSON", action};
+      }
+      boost::property_tree::ptree parameters = pt.to_iterator(_parameters_iter)->second;
+      boost::property_tree::ptree::assoc_iterator _proxyIp_iter = parameters.find("proxyIp");
+      if (_proxyIp_iter == parameters.not_found()) {
+        std::cerr << "Invalid input JSON - parameters doesn't exist" << std::endl;
+        return {static_cast<int>(outline_errc::unexpected), "Invalid JSON", action};
+      }
+      outline_server_ip =
+          boost::lexical_cast<std::string>(pt.to_iterator(_proxyIp_iter)->second.data());
+
+      outlineProxyController_->routeThroughOutline(outline_server_ip);
+      std::cout << "Configure Routing to " << outline_server_ip << " is done." << std::endl;
+      return {static_cast<int>(outline_errc::ok), {}, action};
+    } else if (action == RESET_ROUTING) {
+      outlineProxyController_->routeDirectly();
+      std::cout << "Reset Routing done" << std::endl;
+      return {static_cast<int>(outline_errc::ok), {}, action};
+    } else if (action == GET_DEVICE_NAME) {
+      std::cout << "Get device name done" << std::endl;
+      return {static_cast<int>(outline_errc::ok), outlineProxyController_->getTunDeviceName(), action};
+    } else {
+      std::cerr << "Invalid action specified in JSON (" << action << ")" << std::endl;
+      return {static_cast<int>(outline_errc::unexpected), "Undefined Action", {}};
     }
-    boost::property_tree::ptree parameters = pt.to_iterator(_parameters_iter)->second;
-    boost::property_tree::ptree::assoc_iterator _proxyIp_iter = parameters.find("proxyIp");
-    if (_proxyIp_iter == parameters.not_found()) {
-      std::cerr << "Invalid input JSON - parameters doesn't exist" << std::endl;
-      return std::make_tuple(GENERIC_FAILURE, "Invalid JSON", action);
+  } catch (const std::system_error& err) {
+    std::cerr << "[" << err.code() << "] " << err.what() << std::endl;
+    if (err.code().category() == outline_category()) {
+      return {err.code().value(), {}, action};
     }
-    outline_server_ip =
-        boost::lexical_cast<std::string>(pt.to_iterator(_proxyIp_iter)->second.data());
-
-    // std::cout << "action: [" << action << "]" << std::endl;
-    // std::cout << "outline_server_ip: [" << outline_server_ip << "]" << std::endl;
-
-    outlineProxyController_->routeThroughOutline(outline_server_ip);
-    std::cout << "Configure Routing to " << outline_server_ip << " is done." << std::endl;
-    return std::make_tuple(SUCCESS, "", action);
-
-  } else if (action == RESET_ROUTING) {
-    outlineProxyController_->routeDirectly();
-    std::cout << "Reset Routing done" << std::endl;
-    return std::make_tuple(SUCCESS, "", action);
-  } else if (action == GET_DEVICE_NAME) {
-    std::cout << "Reset Routing done" << std::endl;
-    return std::make_tuple(SUCCESS, outlineProxyController_->getTunDeviceName(), action);
-  } else {
-    std::cerr << "Invalid action specified in JSON (" << action << ")" << std::endl;
+    return {static_cast<int>(outline_errc::unexpected), {}, action};
   }
-
-  return std::make_tuple(GENERIC_FAILURE, "Undefined Action", "");
 }
 
 OutlineControllerServer::OutlineControllerServer(boost::asio::io_context& io_context,
@@ -153,8 +156,11 @@ OutlineControllerServer::OutlineControllerServer(boost::asio::io_context& io_con
     auto outlineGrp = getgrnam(OUTLINE_GRP_NAME);
     if (outlineGrp != nullptr) {
       auto ownerUid = getpwuid(owning_user) != nullptr ? owning_user : -1;
-      chown(unix_socket_name.c_str(), ownerUid, outlineGrp->gr_gid);
-      std::cout << "updated unix socket owner to " << ownerUid << "," << outlineGrp->gr_gid << std::endl;
+      if (chown(unix_socket_name.c_str(), ownerUid, outlineGrp->gr_gid) == 0) {
+        std::cout << "updated unix socket owner to " << ownerUid << "," << outlineGrp->gr_gid << std::endl;
+      } else {
+        std::cerr << "failed to update unix socket owner" << std::endl;
+      }
     } else {
       std::cerr << "failed to get the id of " << OUTLINE_GRP_NAME << " group" << std::endl;
     }

--- a/tools/outline_proxy_controller/outline_controller_server.h
+++ b/tools/outline_proxy_controller/outline_controller_server.h
@@ -42,11 +42,6 @@ const std::string CONFIGURE_ROUTING = "configureRouting";
 const std::string RESET_ROUTING = "resetRouting";
 const std::string GET_DEVICE_NAME = "getDeviceName";
 
-// Error codes to communicate back to the app
-const int SUCCESS = 0;
-const int GENERIC_FAILURE = 1;
-const int UNSUPPORTED_ROUTING_TABLE = 2;
-
 // Minimum length of JSON input from app
 const int JSON_INPUT_MIN_LENGTH = 10;
 

--- a/tools/outline_proxy_controller/outline_error.cpp
+++ b/tools/outline_proxy_controller/outline_error.cpp
@@ -1,0 +1,75 @@
+// Copyright 2022 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include "outline_error.h"
+
+namespace outline {
+
+/**
+ * @brief The error category representing all error codes used by outline.
+ */
+class outline_error_category : public std::error_category {
+public:
+  virtual const char *name() const noexcept override;
+  virtual std::string message(int) const override;
+};
+
+const std::error_category& outline_category() {
+  static outline_error_category singleton;
+  return singleton;
+}
+
+std::error_code make_error_code(outline_errc err) {
+  return {static_cast<int>(err), outline_category()};
+}
+
+const char *outline_error_category::name() const noexcept {
+  return "outline";
+}
+
+std::string outline_error_category::message(int ev) const {
+  switch (ev) {
+    case static_cast<int>(outline_errc::ok):
+      return "ok";
+    case static_cast<int>(outline_errc::unexpected):
+      return "unexpected";
+    case static_cast<int>(outline_errc::vpn_permission_denied):
+      return "vpn permission denied";
+    case static_cast<int>(outline_errc::invalid_server_credentials):
+      return "invalid server credentials";
+    case static_cast<int>(outline_errc::udp_relay_not_enabled):
+      return "udp relay not enabled";
+    case static_cast<int>(outline_errc::server_unreachable):
+      return "server unreachable";
+    case static_cast<int>(outline_errc::vpn_start_failure):
+      return "vpn start failure";
+    case static_cast<int>(outline_errc::invalid_server_configuration):
+      return "invalid server configuration";
+    case static_cast<int>(outline_errc::shadowsocks_start_failure):
+      return "shadowsocks start failure";
+    case static_cast<int>(outline_errc::configure_system_proxy_failure):
+      return "configure system proxy failure";
+    case static_cast<int>(outline_errc::admin_permission_denied):
+      return "admin permission denied";
+    case static_cast<int>(outline_errc::unsupported_routing_table):
+      return "unsupported routing table";
+    case static_cast<int>(outline_errc::system_misconfigured):
+      return "system misconfigured";
+    default:
+      return "(unrecognized error)";
+  }
+}
+
+}

--- a/tools/outline_proxy_controller/outline_error.h
+++ b/tools/outline_proxy_controller/outline_error.h
@@ -1,0 +1,64 @@
+// Copyright 2022 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This file contains the C++11 standard conforming implementation of
+// all errors used by outline.
+
+#pragma once
+
+#include <system_error>
+
+namespace outline {
+
+/**
+ * @brief The standard error code constants used by outline.
+ * @remarks The codes are copied from "/src/www/model/errors.ts".
+ */
+enum class outline_errc {
+  ok = 0,
+  unexpected = 1,
+  vpn_permission_denied = 2,
+  invalid_server_credentials = 3,
+  udp_relay_not_enabled = 4,
+  server_unreachable = 5,
+  vpn_start_failure = 6,
+  invalid_server_configuration = 7,
+  shadowsocks_start_failure = 8,
+  configure_system_proxy_failure = 9,
+  admin_permission_denied = 10,
+  unsupported_routing_table = 11,
+  system_misconfigured = 12,
+};
+
+/**
+ * @brief Get a singleton instance representing outline error category.
+ * 
+ * @return const std::error_category& The outline error category.
+ */
+const std::error_category& outline_category();
+
+/**
+ * @brief Construct an error_code from outline_error.
+ * @remarks Can declare in the same namespace thanks to Koenig lookup.
+ */
+std::error_code make_error_code(outline::outline_errc);
+
+}
+
+namespace std {
+/**
+ * @brief Register to STL for implicit conversion to error_code.
+ */
+template<> struct is_error_code_enum<outline::outline_errc> : true_type {};
+}

--- a/tools/outline_proxy_controller/outline_proxy_controller.cpp
+++ b/tools/outline_proxy_controller/outline_proxy_controller.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <algorithm>
+#include <array>
 #include <cstdio>
 #include <fstream>
 #include <iostream>
@@ -21,12 +22,14 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <system_error>
 #include <tuple>
 
 #include <sys/wait.h>
 #include <unistd.h>
 
 #include "logger.h"
+#include "outline_error.h"
 #include "outline_proxy_controller.h"
 
 using namespace std;
@@ -156,9 +159,7 @@ OutputAndStatus OutlineProxyController::executeCommand(const std::string command
     received_args.insert(begin(received_args), subCommandName);
   }
 
-  pid_t pid;
-  FILE *pipe;
-  tie(pid, pipe) = safe_popen(commandName.c_str(), received_args);
+  auto [pid, pipe] = safe_popen(commandName.c_str(), received_args);
 
   array<char, 128> buffer;
   string result;
@@ -280,8 +281,9 @@ void OutlineProxyController::detectBestInterfaceIndex() {
 void OutlineProxyController::routeThroughOutline(std::string outlineServerIP) {
   // Sanity checks
   if (outlineServerIP.empty()) {
-    logger.error("Outline Server IP address cannot be empty");
-    throw runtime_error("outlineServerIP is empty");
+    throw std::system_error{
+      outline_errc::invalid_server_configuration,
+      "Outline Server IP address cannot be empty"};
   }
 
   logger.info("attempting to route through outline server " + outlineServerIP);
@@ -303,7 +305,7 @@ void OutlineProxyController::routeThroughOutline(std::string outlineServerIP) {
     // We failed to make a route through outline proxy. We just remove the flag
     // indicating DNS is backed up.
     resetFailRoutingAttempt(OUTLINE_PRIORITY_SET_UP);
-    return;
+    throw std::system_error{outline_errc::configure_system_proxy_failure};
   }
 
   try {
@@ -312,7 +314,7 @@ void OutlineProxyController::routeThroughOutline(std::string outlineServerIP) {
     logger.error("failed to remove the default route throw the current default router: " +
                  string(e.what()));
     resetFailRoutingAttempt(DEFAULT_GATEWAY_ROUTE_DELETED);
-    return;
+    throw std::system_error{outline_errc::configure_system_proxy_failure};
   }
 
   try {
@@ -320,7 +322,7 @@ void OutlineProxyController::routeThroughOutline(std::string outlineServerIP) {
   } catch (exception& e) {
     logger.error("failed to route network traffic through outline tun interfacet: ", e.what());
     resetFailRoutingAttempt(TRAFFIC_ROUTED_THROUGH_TUN);
-    return;
+    throw std::system_error{outline_errc::configure_system_proxy_failure};
   }
 
   try {
@@ -330,7 +332,7 @@ void OutlineProxyController::routeThroughOutline(std::string outlineServerIP) {
     logger.error("possible net traffic leakage. failed to disable IPv6 routes on all interfaces: " +
                  string(e.what()));
     resetFailRoutingAttempt(IPV6_ROUTING_FAILED);
-    return;
+    throw std::system_error{outline_errc::configure_system_proxy_failure};
   }
 
   try {
@@ -342,7 +344,7 @@ void OutlineProxyController::routeThroughOutline(std::string outlineServerIP) {
     // vulnerable to DNS poisening so we are going to reverse everthing
     logger.error("failed to enforce outline DNS server: ", e.what());
     resetFailRoutingAttempt(OUTLINE_DNS_SET);
-    return;
+    throw std::system_error{outline_errc::configure_system_proxy_failure};
   }
 
   routingStatus = ROUTING_THROUGH_OUTLINE;


### PR DESCRIPTION
Previously the `outline_proxy_controller` service on Linux [won't pass VPN configuration errors back to Outline client](https://github.com/Jigsaw-Code/outline-client/blob/a1bad8aa847b7c073acffbe76fe93821c08cee58/tools/outline_proxy_controller/outline_controller_server.cpp#L122). In this PR, I fixed it by introducing a new `outline_errc` (stands for outline error code) which conforms the [modern C++ native error system](http://blog.think-async.com/2010/04/system-error-support-in-c0x-part-1.html).

BTW, I also upgraded C++ from C++14 to C++20. This might be helpful if we need to use coroutines in the future. 