### PR TITLE
refactor(service/linux): ♻️ upgrade boost and gcc to use co_await

### DIFF
--- a/tools/outline_proxy_controller/CMakeLists.txt
+++ b/tools/outline_proxy_controller/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 cmake_minimum_required (VERSION 3.1)
 project (OutlineProxyController)
-set(BOOST_VERSION 1.67)
+set(BOOST_VERSION 1.80)
 set(Boost_USE_STATIC_LIBS ON)
 find_package(Boost ${BOOST_VERSION} REQUIRED COMPONENTS
                                                         regex
@@ -31,7 +31,6 @@ configure_file (
   )
 
 set(CMAKE_BUILD_TYPE "Release")
-set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -Wall -ggdb ${SANITIZE}")
 
 include_directories(
@@ -46,6 +45,7 @@ add_executable(OutlineProxyController
     logger.cpp
     )
 
+target_compile_features(OutlineProxyController PRIVATE cxx_std_20)
 target_link_libraries(OutlineProxyController
     ${Boost_LIBRARIES}
 )

--- a/tools/outline_proxy_controller/CMakeLists.txt
+++ b/tools/outline_proxy_controller/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable(OutlineProxyController
     )
 
 target_compile_features(OutlineProxyController PRIVATE cxx_std_20)
+target_compile_options(OutlineProxyController PRIVATE "-fcoroutines")
 target_link_libraries(OutlineProxyController
-    ${Boost_LIBRARIES}
-)
+    -static-libstdc++
+    ${Boost_LIBRARIES})

--- a/tools/outline_proxy_controller/Dockerfile
+++ b/tools/outline_proxy_controller/Dockerfile
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:22.04
-RUN apt update && apt dist-upgrade -y
+FROM ubuntu:20.04
+RUN apt-get update && apt-get dist-upgrade -y
 # Preempt interactive tzdata prompt
 RUN DEBIAN_FRONTEND="noninteractive" TZ="America/New_York" apt-get -y install tzdata
-RUN apt install -y build-essential gcc-11 g++-11 cmake wget
+RUN apt-get install -y build-essential gcc-10 g++-10 make cmake wget
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10 --slave /usr/bin/gcov gcov /usr/bin/gcov-10
 
 # Install boost 1.80 manually (apt install libboost-all-dev is 1.74 at the time of writing)
 RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.80.0/source/boost_1_80_0.tar.bz2 \

--- a/tools/outline_proxy_controller/Dockerfile
+++ b/tools/outline_proxy_controller/Dockerfile
@@ -12,8 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 RUN apt update && apt dist-upgrade -y
 # Preempt interactive tzdata prompt
 RUN DEBIAN_FRONTEND="noninteractive" TZ="America/New_York" apt-get -y install tzdata
-RUN apt install -y build-essential cmake libboost-all-dev
+RUN apt install -y build-essential gcc-11 g++-11 cmake wget
+
+# Install boost 1.80 manually (apt install libboost-all-dev is 1.74 at the time of writing)
+RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.80.0/source/boost_1_80_0.tar.bz2 \
+    && tar --bzip2 -xf ./boost_1_80_0.tar.bz2
+RUN cd boost_1_80_0 \
+    && ./bootstrap.sh \
+    && ./b2 install

--- a/tools/outline_proxy_controller/logger.cpp
+++ b/tools/outline_proxy_controller/logger.cpp
@@ -20,7 +20,9 @@
 
 using namespace outline;
 
-Logger logger(DEBUG);
+namespace outline {
+  Logger logger(DEBUG);
+}
 
 // Standard constructor
 // Threshold adopts a default level of DEBUG if an invalid threshold is provided.

--- a/tools/outline_proxy_controller/logger.h
+++ b/tools/outline_proxy_controller/logger.h
@@ -92,6 +92,11 @@ class Logger {
                      std::string user_nick = "");
 };
 
+/**
+ * @brief A global logger instance which can be used to print logs.
+ */
+extern Logger logger;
+
 }  // namespace outline
 
 #endif  // SRC_LOGGER_H_

--- a/tools/outline_proxy_controller/outline_controller_server.h
+++ b/tools/outline_proxy_controller/outline_controller_server.h
@@ -12,28 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <array>
-#include <cstdio>
-#include <iostream>
 #include <memory>
-#include <stdexcept>
+#include <string>
 
-#include <sys/stat.h>
 #include <sys/types.h>
 
-#include <boost/algorithm/string.hpp>
-#include <boost/asio.hpp>
-#include <boost/asio/spawn.hpp>
-#include <boost/lexical_cast.hpp>
-#include <boost/property_tree/json_parser.hpp>
-#include <boost/property_tree/ptree.hpp>
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/local/stream_protocol.hpp>
 
 #include "outline_proxy_controller.h"
 
 #if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
-
-using namespace std;
-using boost::asio::local::stream_protocol;
 
 namespace outline {
 
@@ -42,52 +31,82 @@ const std::string CONFIGURE_ROUTING = "configureRouting";
 const std::string RESET_ROUTING = "resetRouting";
 const std::string GET_DEVICE_NAME = "getDeviceName";
 
-// Minimum length of JSON input from app
-const int JSON_INPUT_MIN_LENGTH = 10;
-
-class session : public std::enable_shared_from_this<session> {
- public:
-  session(stream_protocol::socket sock,
-          std::shared_ptr<OutlineProxyController> outlineProxyController)
-      : socket_(std::move(sock)),
-        executor_(socket_.get_executor()),
-        outlineProxyController_(outlineProxyController) {}
+/**
+ * @brief A session that serves requests from a specific Outline client, and
+ *        configures the system accordingly with root privileges.
+ */
+class OutlineClientSession : public std::enable_shared_from_this<OutlineClientSession> {
+public:
   /**
-   * callback from async_accept, starts a new session when
-   * a connection is comming in and reads the input from
-   * the client
+   * @brief Construct a new OutlineClientSession object with a specific channel as well
+   *        as the underlying worker `outline_proxy_controller`.
+   * 
+   * @param channel A socket that the session will be reading from and writing to.
+   * @param outline_proxy_controller A worker which can be used to configure the system.
    */
-  void start();
+  OutlineClientSession(boost::asio::local::stream_protocol::socket channel,
+                       std::shared_ptr<OutlineProxyController> outline_proxy_controller);
 
- private:
+public:
   /**
-   * Checks the input string and returns true if it's a valid json
+   * @brief Start serving requests from a specific Outline client asynchronously.
+   *
+   * @return boost::asio::awaitable<void> A co_awaitable C++20 coroutine.
    */
-  bool isValidJson(std::string str);
+  boost::asio::awaitable<void> Start();
+
+private:
+  /**
+   * @brief Execution result of a client request command.
+   */
+  struct CommandResult {
+    int status;
+    std::string result;
+    std::string action;
+  };
 
   /**
-   * interprets the commmands arriving as JSON input from the client app and
-   * act upon them
+   * @brief interprets the commmand (in JSON) from the client app and act upon them.
+   *
+   * @param command The Json string sent by Outline client.
+   * @return CommandResult The result of the command execution.
    */
-  std::tuple<int, std::string, std::string> runClientCommand(std::string clientCommand);
+  CommandResult RunClientCommand(const std::string &command);
 
-  stream_protocol::socket socket_;
-  boost::asio::executor executor_;
-  std::shared_ptr<OutlineProxyController> outlineProxyController_;
+private:
+  boost::asio::local::stream_protocol::socket channel_;
+  std::shared_ptr<OutlineProxyController> outline_controller_;
 };
 
+/**
+ * @brief A server that accepts requests from Outline client. Each request will
+ *        be served by a dedicated `OutlineClientSession` asynchronously.
+ */
 class OutlineControllerServer {
- public:
-  /*
-   * constructor: setup a listener on the file as a unix socket
+public:
+  /**
+   * @brief Construct a new OutlineControllerServer object with a specific
+   *        Unix socket name and the owner uid who is running Outline.
+   *        Need to call `start()` to start accepting requests.
+   *
+   * @param unix_socket The Unix socket name that we will be listening.
+   * @param owning_user The owner uid of the Unix socket (typically it is the
+   *                    user who installs Outline).
    */
-  OutlineControllerServer(boost::asio::io_context& io_context,
-                          const std::string& file,
-                          uid_t owning_user);
+  OutlineControllerServer(const std::string& unix_socket, uid_t owning_user);
 
- private:
-  std::shared_ptr<OutlineProxyController> outlineProxyController_;
-  std::string unix_socket_name;
+public:
+  /**
+   * @brief Start listening to the Outline Unix socket asynchronously.
+   *
+   * @return boost::asio::awaitable<void> A co_awaitable C++20 coroutine.
+   */
+  boost::asio::awaitable<void> Start();
+
+private:
+  std::shared_ptr<OutlineProxyController> outline_controller_;
+  std::string unix_socket_name_;
+  uid_t socket_owner_id_;
 };
 
 }  // namespace outline

--- a/tools/outline_proxy_controller/outline_controller_server.h
+++ b/tools/outline_proxy_controller/outline_controller_server.h
@@ -19,17 +19,13 @@
 
 #include <boost/asio/awaitable.hpp>
 #include <boost/asio/local/stream_protocol.hpp>
+#include <boost/property_tree/ptree.hpp>
 
 #include "outline_proxy_controller.h"
 
 #if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
 
 namespace outline {
-
-// Routing commands from App
-const std::string CONFIGURE_ROUTING = "configureRouting";
-const std::string RESET_ROUTING = "resetRouting";
-const std::string GET_DEVICE_NAME = "getDeviceName";
 
 /**
  * @brief A session that serves requests from a specific Outline client, and
@@ -68,12 +64,12 @@ private:
   };
 
   /**
-   * @brief interprets the commmand (in JSON) from the client app and act upon them.
+   * @brief interprets the request from the client app and act upon them.
    *
-   * @param command The Json string sent by Outline client.
+   * @param request The Json object sent by Outline client.
    * @return CommandResult The result of the command execution.
    */
-  CommandResult RunClientCommand(const std::string &command);
+  CommandResult RunClientCommand(const boost::property_tree::ptree &request);
 
 private:
   boost::asio::local::stream_protocol::socket channel_;

--- a/tools/outline_proxy_controller/outline_controller_server.h
+++ b/tools/outline_proxy_controller/outline_controller_server.h
@@ -44,8 +44,10 @@ public:
    * @param channel A socket that the session will be reading from and writing to.
    * @param outline_proxy_controller A worker which can be used to configure the system.
    */
-  OutlineClientSession(boost::asio::local::stream_protocol::socket channel,
+  OutlineClientSession(boost::asio::local::stream_protocol::socket &&channel,
                        std::shared_ptr<OutlineProxyController> outline_proxy_controller);
+
+  ~OutlineClientSession();
 
 public:
   /**

--- a/tools/outline_proxy_controller/outline_daemon.cpp
+++ b/tools/outline_proxy_controller/outline_daemon.cpp
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <syslog.h>
-#include <unistd.h>
-#include <array>
 #include <cstdlib>
 #include <ctime>
 #include <iostream>
 
-#include <boost/asio/io_context.hpp>
+#include <boost/asio.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
+
+#include <syslog.h>
+#include <unistd.h>
 
 #include "logger.h"
 #include "outline_controller_server.h"
@@ -93,16 +93,14 @@ int main(int argc, char* argv[]) {
     boost::asio::io_context io_context;
 
     try {
-      ControllerConfig controllerConfig(argc, argv);
-
-      if (controllerConfig.onlyShowHelp) return EXIT_SUCCESS;
+      ControllerConfig config(argc, argv);
+      if (config.onlyShowHelp) return EXIT_SUCCESS;
 
       // Initialise the server.
-      OutlineControllerServer server{
-        io_context, controllerConfig.socketFilename, controllerConfig.owningUid};
+      OutlineControllerServer server{config.socketFilename, config.owningUid};
+      boost::asio::co_spawn(io_context, server.Start(), boost::asio::detached);
 
       io_context.run();
-
     } catch (std::exception& e) {
       syslog(LOG_ERR | LOG_USER, "Exception: %s", e.what());
       std::cerr << "Exception: " << e.what() << std::endl;

--- a/tools/outline_proxy_controller/outline_daemon.cpp
+++ b/tools/outline_proxy_controller/outline_daemon.cpp
@@ -31,8 +31,6 @@ using namespace std;
 namespace po = boost::program_options;
 namespace fs = boost::filesystem;
 
-extern Logger logger;
-
 class ControllerConfig {
  public:
   string socketFilename;
@@ -96,7 +94,8 @@ int main(int argc, char* argv[]) {
       ControllerConfig config(argc, argv);
       if (config.onlyShowHelp) return EXIT_SUCCESS;
 
-      // Initialise the server.
+      // Initialise the server. No need to make_shared because io_context.run() will
+      // block until all asynchronous operations ended.
       OutlineControllerServer server{config.socketFilename, config.owningUid};
       boost::asio::co_spawn(io_context, server.Start(), boost::asio::detached);
 

--- a/tools/outline_proxy_controller/outline_proxy_controller.cpp
+++ b/tools/outline_proxy_controller/outline_proxy_controller.cpp
@@ -35,8 +35,6 @@
 using namespace std;
 using namespace outline;
 
-extern Logger logger;
-
 /**
  * @brief
  * Create a new child process of `cmd` with arguments `args`, and return its


### PR DESCRIPTION
I this PR, I upgraded several dependencies used by Linux service in order to use [C++20's coroutine](https://en.cppreference.com/w/cpp/language/coroutines), which is easier to understand than the legacy boost coroutine, also it will enable more features (like cancellation, multiple listeners) more easily.

* Upgrade `libboost` from `1.67` to `1.80`
* Upgrade `g++` from `9` to `10` (didn't upgrade to `11` or `12` for backward compatibility)
* Refactor the legacy boost coroutine with the new C++20 coroutine
* Some style refactoring according to [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html)
* Statically links standard C++ library to support more OS versions