### PR TITLE
chore: 🎉 release v1.8.1 for all platforms

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="org.outline.android.client" version="1.8.0" android-versionCode="41" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="org.outline.android.client" version="1.8.1" android-versionCode="42" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Outline</name>
     <description>
         Internet without borders (powered by Shadowsocks)

--- a/src/build/get_version.mjs
+++ b/src/build/get_version.mjs
@@ -41,9 +41,9 @@ export async function getVersion(platform) {
       return plistValues[plistKeys.indexOf('CFBundleShortVersionString')];
     }
     case 'windows':
-      return '1.8.0';
+      return '1.8.1';
     case 'linux':
-      return '1.8.0';
+      return '1.8.1';
     default:
       throw new Error('get_version must be provided a platform argument');
   }

--- a/src/cordova/apple/xcode/ios/Outline/Outline-Info.plist
+++ b/src/cordova/apple/xcode/ios/Outline/Outline-Info.plist
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleShortVersionString</key>
-	<string>1.8.0</string>
+	<string>1.8.1</string>
 	<key>CFBundleVersion</key>
-	<string>33</string>
+	<string>34</string>
   <key>CFBundleDevelopmentRegion</key>
   <string>English</string>
 	<key>CFBundleDisplayName</key>

--- a/src/cordova/apple/xcode/ios/Outline/VpnExtension-Info.plist
+++ b/src/cordova/apple/xcode/ios/Outline/VpnExtension-Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.3</string>
+	<string>1.8.1</string>
 	<key>CFBundleVersion</key>
-	<string>33</string>
+	<string>34</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/src/cordova/apple/xcode/macos/Outline/Outline-Info.plist
+++ b/src/cordova/apple/xcode/macos/Outline/Outline-Info.plist
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleShortVersionString</key>
-	<string>1.8.0</string>
+	<string>1.8.1</string>
 	<key>CFBundleVersion</key>
-	<string>28</string>
+	<string>29</string>
   <key>CFBundleDevelopmentRegion</key>
   <string>en</string>
   <key>CFBundleExecutable</key>

--- a/src/cordova/apple/xcode/macos/Outline/VpnExtension-Info.plist
+++ b/src/cordova/apple/xcode/macos/Outline/VpnExtension-Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.3</string>
+	<string>1.8.1</string>
 	<key>CFBundleVersion</key>
-	<string>28</string>
+	<string>29</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
 	<key>NSExtension</key>


### PR DESCRIPTION
This pull request bumps up the version number of all platforms to prepare for the version 1.7.0 release:

* Android v1.8.1
* iOS v1.8.1 (with VpnExtension v1.8.1)
* macOS v1.8.1 (with VpnExtension v1.8.1)
* Windows/Linux v1.8.1
