### PR TITLE
feat(www): support name hash

### DIFF
--- a/src/www/app/outline_server_repository/index.ts
+++ b/src/www/app/outline_server_repository/index.ts
@@ -54,7 +54,13 @@ function isDynamicAccessKey(accessKey: string): boolean {
 // (Currenly done by setting the hash on the URI)
 function serverNameFromAccessKey(accessKey: string): string {
   if (isDynamicAccessKey(accessKey)) {
-    return new URL(accessKey.replace(/^ssconf:\/\//, 'https://')).hostname;
+    const {hostname, hash} = new URL(accessKey.replace(/^ssconf:\/\//, 'https://'));
+
+    if (hash && hash !== '#') {
+      return hash.slice(1);
+    }
+
+    return hostname;
   }
 
   return SHADOWSOCKS_URI.parse(accessKey).tag.data;


### PR DESCRIPTION
Adds the functionality for determining the server name that's on `ss://` to `ssconf://`

Question - do we want to add support for extra fields in the hash to both `ss://` and `ssconf://`? 