### PR TITLE
chore(build): fix Carthage call

### DIFF
--- a/docs/apple_development.md
+++ b/docs/apple_development.md
@@ -5,7 +5,7 @@ This document describes how to develop and debug for macOS (formerly known as OS
 - An Apple Developer Account. You will need to be invited to your developer team as well.
 - XCode 13.2+ ([download](https://developer.apple.com/xcode/))
 - XCode command line tools: `xcode-select --install`
-- Carthage, which can be installed with `brew install carthage`
+- Carthage, which can be installed with `brew install carthage` (you need [Homebrew installed](https://docs.brew.sh/Installation) for that).
 
 > NOTE: Should you encounter issues with your build, there may be apple-specific dependencies that are out of date. Run `npm run clean` and try again!
 

--- a/docs/apple_development.md
+++ b/docs/apple_development.md
@@ -5,7 +5,8 @@ This document describes how to develop and debug for macOS (formerly known as OS
 - An Apple Developer Account. You will need to be invited to your developer team as well.
 - XCode 13.2+ ([download](https://developer.apple.com/xcode/))
 - XCode command line tools: `xcode-select --install`
-- Carthage, which can be installed with `brew install carthage` (you need [Homebrew installed](https://docs.brew.sh/Installation) for that).
+- Carthage ([install instructions](https://github.com/Carthage/Carthage/blob/master/README.md#installing-carthage))
+  - If you have [Homebrew installed](https://docs.brew.sh/Installation) you can do `brew install carthage`.
 
 > NOTE: Should you encounter issues with your build, there may be apple-specific dependencies that are out of date. Run `npm run clean` and try again!
 

--- a/third_party/CocoaLumberjack/Makefile
+++ b/third_party/CocoaLumberjack/Makefile
@@ -2,7 +2,7 @@
 .PHONY: clean
 
 Carthage/Build: Cartfile
-	carthage build --use-xcframeworks --platform macOS,iOS
+	carthage bootstrap --use-xcframeworks --platform macOS,iOS
 
 clean:
 	rm -rf Carthage

--- a/third_party/CocoaLumberjack/Makefile
+++ b/third_party/CocoaLumberjack/Makefile
@@ -2,7 +2,7 @@
 .PHONY: clean
 
 Carthage/Build: Cartfile
-	carthage update --use-xcframeworks --platform macOS,iOS
+	carthage build --use-xcframeworks --platform macOS,iOS
 
 clean:
 	rm -rf Carthage

--- a/third_party/sentry-cocoa/Makefile
+++ b/third_party/sentry-cocoa/Makefile
@@ -2,7 +2,7 @@
 .PHONY: clean
 
 Carthage/Build: Cartfile
-	carthage build --use-xcframeworks --no-use-binaries --platform macOS,iOS
+	carthage bootstrap --use-xcframeworks --no-use-binaries --platform macOS,iOS
 
 clean:
 	rm -rf Carthage

--- a/third_party/sentry-cocoa/Makefile
+++ b/third_party/sentry-cocoa/Makefile
@@ -2,7 +2,7 @@
 .PHONY: clean
 
 Carthage/Build: Cartfile
-	carthage update --use-xcframeworks --no-use-binaries --platform macOS,iOS
+	carthage build --use-xcframeworks --no-use-binaries --platform macOS,iOS
 
 clean:
 	rm -rf Carthage


### PR DESCRIPTION
Use `bootstrap` instead of `update`. The `update` command will prevent reproducible builds.