### PR TITLE
fix: adds (most) untracked web view code files to a TODO file so they're in the metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 ![Build and Test](https://github.com/Jigsaw-Code/outline-client/actions/workflows/build_and_test_debug.yml/badge.svg?branch=master) [![Mattermost](https://badgen.net/badge/Mattermost/Outline%20Community/blue)](https://community.internetfreedomfestival.org/community/channels/outline-community) [![Reddit](https://badgen.net/badge/Reddit/r%2Foutlinevpn/orange)](https://www.reddit.com/r/outlinevpn/)
 
+> **Test coverage currently only tracks the core web view code:**
+>
+> [![codecov](https://codecov.io/gh/Jigsaw-Code/outline-client/branch/master/graph/badge.svg?token=gasD8v5tjn)](https://codecov.io/gh/Jigsaw-Code/outline-client)
+
 The Outline Client is a cross-platform VPN or proxy client for Windows, macOS, iOS, Android, and ChromeOS. The Outline Client is designed for use with the [Outline Server](https://github.com/Jigsaw-Code/outline-server) software, but it is fully compatible with any [Shadowsocks](https://shadowsocks.org/) server.
 
 The client's user interface is implemented in [Polymer](https://www.polymer-project.org/) 2.0. Platform support is provided by [Cordova](https://cordova.apache.org/) and [Electron](https://electronjs.org/), with additional native components in this repository.

--- a/src/www/TODO.spec.ts
+++ b/src/www/TODO.spec.ts
@@ -1,0 +1,67 @@
+/*
+  Copyright 2022 The Outline Authors
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+// TODO(daniellacosse): requires electron context (should be somewhere in src/electron)
+// import * as electronMain from './app/electron_main';
+// import * as electronOutlineTunnel from './app/electron_outline_tunnel';
+
+// TODO(daniellacosse): requires cordova context (should be somewhere in src/cordova)
+// import * as cordovaMain from './app/cordova_main';
+
+// TODO(daniellacosse): these modules have side effects, causing them to fail when we import into the test. They need to be encapsulated.
+// import * as main from './app/main';
+// import * as environment from './app/environment';
+// import * as outlineIcons from './ui_components/outline-icons';
+
+import * as clipboard from './app/clipboard';
+import * as errorReporter from './app/error_reporter';
+import * as platform from './app/platform';
+import * as tunnel from './app/tunnel';
+import * as updater from './app/updater';
+import * as urlInterceptor from './app/url_interceptor';
+import * as vpnInstaller from './app/vpn_installer';
+
+import * as aboutView from './ui_components/about-view';
+import * as addServerView from './ui_components/add-server-view';
+import * as appRoot from './ui_components/app-root.js';
+import * as feedbackView from './ui_components/feedback-view';
+import * as languageView from './ui_components/language-view';
+import * as privacyView from './ui_components/privacy-view';
+import * as serverRenameDialog from './ui_components/server-rename-dialog';
+import * as userCommsDialog from './ui_components/user-comms-dialog';
+
+describe('TODOs', () => {
+  it('loads all the files that have no tests against them', () => {
+    // expect(environment).toBeDefined();
+    // expect(main).toBeDefined();
+    // expect(outlineIcons).toBeDefined();
+    expect(aboutView).toBeDefined();
+    expect(addServerView).toBeDefined();
+    expect(appRoot).toBeDefined();
+    expect(clipboard).toBeDefined();
+    expect(errorReporter).toBeDefined();
+    expect(feedbackView).toBeDefined();
+    expect(languageView).toBeDefined();
+    expect(platform).toBeDefined();
+    expect(privacyView).toBeDefined();
+    expect(serverRenameDialog).toBeDefined();
+    expect(tunnel).toBeDefined();
+    expect(updater).toBeDefined();
+    expect(urlInterceptor).toBeDefined();
+    expect(userCommsDialog).toBeDefined();
+    expect(vpnInstaller).toBeDefined();
+  });
+});

--- a/src/www/webpack_test.mjs
+++ b/src/www/webpack_test.mjs
@@ -23,6 +23,11 @@ export default merge(baseConfig, {
         use: ['@jsdevtools/coverage-istanbul-loader', TS_LOADER],
       },
       {
+        test: /\.m?js$/,
+        exclude: /node_modules/,
+        use: ['@jsdevtools/coverage-istanbul-loader'],
+      },
+      {
         test: /\.png$/,
         use: ['file-loader'],
       },


### PR DESCRIPTION
It's still not perfect, a couple of our web files are not conducive to being tracked in this way - their side effects blow up the test runner. We're close enough to the actual number though that I'm comfortable showing it