### PR TITLE
fix: 🔨 fix Android release script and update Apple bundle versions

### DIFF
--- a/src/cordova/apple/OutlineAppleLib/Package.swift
+++ b/src/cordova/apple/OutlineAppleLib/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
         .binaryTarget(
             name: "Tun2socks",
             url: "https://github.com/Jigsaw-Code/outline-go-tun2socks/releases/download/v3.1.0/apple.zip",
-            checksum: "dcdd8ea539426858fccc8b3ee2f771297c0edde6d4f9f8f76f7148fee397d784"
+            checksum: "78f291482da13fd035de19d21a075048407658aab077fdeb23ce435f33cec3a2"
         ),
         .testTarget(
             name: "OutlineTunnelTest",

--- a/src/cordova/apple/xcode/ios/Outline/Outline-Info.plist
+++ b/src/cordova/apple/xcode/ios/Outline/Outline-Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.10.0</string>
 	<key>CFBundleVersion</key>
-	<string>36</string>
+	<string>39</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleDisplayName</key>

--- a/src/cordova/apple/xcode/ios/Outline/VpnExtension-Info.plist
+++ b/src/cordova/apple/xcode/ios/Outline/VpnExtension-Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleVersion</key>
-	<string>36</string>
+	<string>39</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/src/cordova/apple/xcode/macos/Outline/Outline-Info.plist
+++ b/src/cordova/apple/xcode/macos/Outline/Outline-Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.10.0</string>
 	<key>CFBundleVersion</key>
-	<string>37</string>
+	<string>40</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/src/cordova/apple/xcode/macos/Outline/VpnExtension-Info.plist
+++ b/src/cordova/apple/xcode/macos/Outline/VpnExtension-Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleVersion</key>
-	<string>37</string>
+	<string>40</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
 	<key>NSExtension</key>

--- a/src/cordova/build.action.mjs
+++ b/src/cordova/build.action.mjs
@@ -69,6 +69,7 @@ export async function main(...parameters) {
         );
       }
       argv = [
+        ...argv,
         '--keystore=keystore.p12',
         '--alias=privatekey',
         `--storePassword=${process.env.ANDROID_KEY_STORE_PASSWORD}`,


### PR DESCRIPTION
In this PR, I fixed the Android release script, and synced `BundleVersion` from Apple's App Store back to this repository. In addition, due to [a bug in golang's compiler for iOS](https://github.com/golang/go/issues/58323), I rebuilt the `outline-go-tun2socks` binary and updated the checksum here.