### PR TITLE
feat: use prefer-const eslint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -61,6 +61,7 @@
       }
     ],
     "no-prototype-builtins": "off",
+    "prefer-const": "error",
     "@typescript-eslint/ban-types": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/no-empty-function": "off",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "clean": "rimraf build node_modules www platforms plugins third_party/jsign/*.jar",
     "format:all": "prettier --write \"**/*.{cjs,mjs,html,js,json,md,ts}\"",
     "format": "pretty-quick --staged --pattern \"**/*.{cjs,mjs,html,js,json,md,ts}\"",
-    "lint:ts": "eslint --ext ts src",
+    "lint:ts": "eslint --ext ts,mjs src",
     "lint": "npm run lint:ts",
     "reset": "npm run clean && npm ci"
   },


### PR DESCRIPTION
All this does is enforce the use of `const` where it makes sense, for example:

<img width="708" alt="Screenshot 2023-03-01 at 14 57 29" src="https://user-images.githubusercontent.com/3759828/222252334-7c244058-6f56-4857-8109-76e82b690f15.png">

This way, now we know whenever we see a `let`, it's guaranteed to be modified later.