### PR TITLE
fix(electron): added salt prefix to check connectivity

### DIFF
--- a/src/electron/go_vpn_tunnel.ts
+++ b/src/electron/go_vpn_tunnel.ts
@@ -291,6 +291,8 @@ class GoTun2socks {
       this.config.password || '',
       '-proxyCipher',
       this.config.method || '',
+      '-proxyPrefix',
+      this.config.prefix || '',
       '-checkConnectivity',
     ]);
   }


### PR DESCRIPTION
The checkConnectivity method didn't check for salt prefixes, so the connection would never get established in countries where Outline doesn't work without a salt prefix.

