### PR TITLE
fix(electron): 💊 initialize Sentry in main, preload and renderer

### DIFF
--- a/src/electron/build_main.action.mjs
+++ b/src/electron/build_main.action.mjs
@@ -34,7 +34,7 @@ export async function main(...parameters) {
 
   // TODO(daniellacosse): separate building the preload script out into its own separate step
   await runWebpack(
-    electronMainWebpackConfigs({sentryDsn, APP_VERSION}).map(config => ({
+    electronMainWebpackConfigs({sentryDsn, appVersion: APP_VERSION}).map(config => ({
       ...config,
       mode: getWebpackBuildMode(buildMode),
     }))

--- a/src/electron/index.ts
+++ b/src/electron/index.ts
@@ -84,7 +84,12 @@ function setupSentry(): void {
   // Use 'typeof(v)' instead of '!!v' here to prevent ReferenceError
   if (typeof SENTRY_DSN !== 'undefined' && typeof APP_VERSION !== 'undefined') {
     // This config makes console (log/info/warn/error - no debug!) output go to breadcrumbs.
-    Sentry.init({dsn: SENTRY_DSN, release: APP_VERSION, maxBreadcrumbs: 100});
+    Sentry.init({
+      dsn: SENTRY_DSN,
+      release: APP_VERSION,
+      maxBreadcrumbs: 100,
+      debug: debugMode,
+    });
   }
 }
 

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -19,8 +19,10 @@
 
 // Please also update preload.d.ts whenever you changed this file.
 
+import * as os from 'node:os';
+
 import {clipboard, contextBridge, ipcRenderer, IpcRendererEvent} from 'electron';
-import * as os from 'os';
+import '@sentry/electron/preload';
 
 /**
  * The method channel for sending messages through electron's IPC.

--- a/src/electron/start.action.mjs
+++ b/src/electron/start.action.mjs
@@ -26,11 +26,9 @@ import {spawnStream} from '../build/spawn_stream.mjs';
  * @param {string[]} parameters
  */
 export async function main(...parameters) {
-  const {platform, buildMode} = getElectronBuildParameters(parameters);
+  const {buildMode} = getElectronBuildParameters(parameters);
 
-  await runAction('www/build', platform, `--buildMode=${buildMode}`);
-  await runAction('electron/build_main', ...parameters);
-  await runAction('electron/build', platform, `--buildMode=${buildMode}`);
+  await runAction('electron/build', ...parameters);
 
   process.env.OUTLINE_DEBUG = buildMode === 'debug';
 

--- a/src/electron/start.action.mjs
+++ b/src/electron/start.action.mjs
@@ -26,9 +26,11 @@ import {spawnStream} from '../build/spawn_stream.mjs';
  * @param {string[]} parameters
  */
 export async function main(...parameters) {
-  const {buildMode} = getElectronBuildParameters(parameters);
+  const {platform, buildMode} = getElectronBuildParameters(parameters);
 
-  await runAction('electron/build', ...parameters);
+  await runAction('www/build', platform, `--buildMode=${buildMode}`);
+  await runAction('electron/build_main', ...parameters);
+  await runAction('electron/build', platform, `--buildMode=${buildMode}`);
 
   process.env.OUTLINE_DEBUG = buildMode === 'debug';
 

--- a/src/www/app/electron_main.ts
+++ b/src/www/app/electron_main.ts
@@ -23,7 +23,6 @@ import {ErrorCode, OutlinePluginError} from '../model/errors';
 
 import {AbstractClipboard} from './clipboard';
 import {ElectronOutlineTunnel} from './electron_outline_tunnel';
-import {EnvironmentVariables} from './environment';
 import {getSentryBrowserIntegrations, OutlineErrorReporter} from './error_reporter';
 import {FakeNativeNetworking} from './fake_net';
 import {FakeOutlineTunnel} from './fake_tunnel';
@@ -90,14 +89,11 @@ class ElectronVpnInstaller implements VpnInstaller {
 }
 
 class ElectronErrorReporter implements OutlineErrorReporter {
-  constructor(appVersion: string, privateDsn: string) {
-    if (privateDsn) {
-      Sentry.init({
-        dsn: privateDsn,
-        release: appVersion,
-        integrations: getSentryBrowserIntegrations,
-      });
-    }
+  constructor() {
+    // parameters are initialized in main process
+    Sentry.init({
+      integrations: getSentryBrowserIntegrations,
+    });
   }
 
   report(userFeedback: string, feedbackCategory: string, userEmail?: string): Promise<void> {
@@ -124,7 +120,7 @@ main({
   },
   getUrlInterceptor: () => interceptor,
   getClipboard: () => new ElectronClipboard(),
-  getErrorReporter: (env: EnvironmentVariables) => new ElectronErrorReporter(env.APP_VERSION, env.SENTRY_DSN || ''),
+  getErrorReporter: _ => new ElectronErrorReporter(),
   getUpdater: () => new ElectronUpdater(),
   getVpnServiceInstaller: () => new ElectronVpnInstaller(),
   quitApplication: () => window.electron.methodChannel.send('quit-app'),

--- a/src/www/ui_components/app-root.js
+++ b/src/www/ui_components/app-root.js
@@ -362,7 +362,7 @@ export class AppRoot extends mixinBehaviors([AppLocalizeBehavior], PolymerElemen
               <img src$="[[rootPath]]assets/icons/outline.png" alt="outline"  />
               <span class="item-label">[[localize('servers-menu-item')]]</span>
             </paper-item>
-            <paper-item name="feedback" hidden$="[[shouldHideFeedback]]">
+            <paper-item name="feedback">
               <img src$="[[rootPath]]assets/icons/feedback.png" alt="feedback"  />
               [[localize('feedback-page-title')]]
             </paper-item>
@@ -522,11 +522,6 @@ export class AppRoot extends mixinBehaviors([AppLocalizeBehavior], PolymerElemen
       appVersion: {
         type: String,
         readonly: true,
-      },
-      shouldHideFeedback: {
-        type: Boolean,
-        readonly: true,
-        computed: '_computeShouldHideFeedback()',
       },
       page: {
         type: String,
@@ -719,11 +714,6 @@ export class AppRoot extends mixinBehaviors([AppLocalizeBehavior], PolymerElemen
     const overrideLanguage = window.localStorage.getItem('overrideLanguage');
     const bestMatchingLanguage = OutlineI18n.getBestMatchingLanguage(Object.keys(availableLanguages));
     return overrideLanguage || bestMatchingLanguage || defaultLanguage;
-  }
-
-  _computeShouldHideFeedback() {
-    // TODO(daniellacosse): restore feedback functionality in electron
-    return typeof window.electron !== 'undefined';
   }
 
   _computePage(pageFromRoute, DEFAULT_PAGE) {


### PR DESCRIPTION
Previously Sentry is working in electron apps because:

* [`webpack_electron_main.mjs`](https://github.com/Jigsaw-Code/outline-client/blob/644dc7761bf9c246720eb97ecf59ce1077ed2d92/src/electron/webpack_electron_main.mjs#L23) is accepting an object with field `appVersion`, but we are [passing `APP_VERSION` to it](https://github.com/Jigsaw-Code/outline-client/blob/644dc7761bf9c246720eb97ecf59ce1077ed2d92/src/electron/build_main.action.mjs#L37). Therefore we are skipping the [Sentry initialization in main process](https://github.com/Jigsaw-Code/outline-client/blob/644dc7761bf9c246720eb97ecf59ce1077ed2d92/src/electron/index.ts#L85) because the global variable `APP_VERSION` is `undefined`.
* We did not `import '@sentry/electron/preload'` (different than `Sentry.init`) to initialize Sentry environment in preload script.

In this PR, I fixed both issues and also re-enabled the user feedback form.