### PR TITLE
chore: 🚀 release v1.10.1 for Windows and Linux

### DIFF
--- a/src/build/get_version.mjs
+++ b/src/build/get_version.mjs
@@ -38,9 +38,9 @@ export async function getVersion(platform) {
       return plistValues[plistKeys.indexOf('CFBundleShortVersionString')];
     }
     case 'windows':
-      return '1.10.0';
+      return '1.10.1';
     case 'linux':
-      return '1.10.0';
+      return '1.10.1';
     default:
       throw new Error('get_version must be provided a platform argument');
   }


### PR DESCRIPTION
This hotfix fixes the connectivity test when prefix is applied: #1599