### PR TITLE
chore:allow github to search build folder

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 * text=auto eol=lf
 *.bat eol=crlf
+/src/build/** linguist-generated=false
+/tools/build/** linguist-generated=false


### PR DESCRIPTION
By default, GitHub excludes `build/` folders from [some searches](https://support.github.com/ticket/personal/0/1954062), such as GitHub's `t` search. This makes sense in many projects.

However, Outline's `build/` folder contains scripts, not build artefacts (which in Outline appear under `dist/`)

This change will allow github to search Outline's `build/` folder, as with most other folders.

To test:
- On the repo's GitHub page, press `t` and then try a search for `download_file`. You will get 0 results.
- Try the same on this PR's branch. You should get results!