### PR TITLE
chore: allow GitHub to search build folders

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 * text=auto eol=lf
 *.bat eol=crlf
+# Allow the build folders to be searched by GitHub's T file search
+build/** linguist-generated=false


### PR DESCRIPTION
By default, GitHub excludes `build/` folders from [some searches](https://support.github.com/ticket/personal/0/1954062), such as the `t` search on GItHub's website. This makes sense in many projects.

However, Outline's `/*/build/` folders contain scripts, not build artefacts (which in Outline appear under `/output/` - although formerly `/build/`)

This change will allow github to search Outline's `build/` folders, as with most other folders.

(Docs on `linguist` attributes [here](https://github.com/github-linguist/linguist/blob/master/docs/overrides.md).)

To test:
- On the [repo's GitHub page](https://github.com/JigSaw-Code/outline-client/), press `t` and then try a search for `download_file`. You will get 0 results.
- Try the same on [this PR's branch](https://github.com/joeytwiddle/outline-client/tree/patch-2). You should see a result!