### PR TITLE
feat(devtools): check PR for complete set of translation changes

### DIFF
--- a/resources/original_messages.json
+++ b/resources/original_messages.json
@@ -1,5 +1,4 @@
 {
-  "test": "hello",
   "close": {
     "message": "Close",
     "description": "The text for a button to close the current page or dialog."


### PR DESCRIPTION
if you change the `original_messages.json` and don't change every file in `src/www/messages`, you get the following:

<img width="723" alt="Screenshot 2023-05-14 at 16 40 20" src="https://github.com/Jigsaw-Code/outline-client/assets/3759828/f05bab7b-b8da-46a4-80b2-08e27aeced88">

---

if this works, in a future PR we can improve the workflow to add/remove `needs translations` label with https://github.com/actions-ecosystem/action-add-labels et. al. _(it gets a bit complicated, we have to create our own action maybe, so it's best to punt it)_

This label could maybe be what kokoro detects to trigger translation automation?
