### PR TITLE
fix(electron/windows): 🩹 prevent command LPE in the installer

### DIFF
--- a/src/electron/README.md
+++ b/src/electron/README.md
@@ -16,10 +16,6 @@ npm run action electron/start [windows|linux]
 
 ### Windows
 
-Requirements for building on Windows:
-
-- [Cygwin](https://cygwin.com/install.html), if running action scripts outside of `src`. It provides the "missing Unix pieces" required by build system such as rsync (and many others). Besides the default selected Unix tools such as `bash` and `rsync`, please also make sure to install `git` during Cygwin installation as well. You will need to clone this repository using `git` in Cygwin instead of the native Windows version of git, in order to ensure Unix line endings.
-
 To build the _release_ version of Windows installer, you'll also need:
 
 - [Java 8+ Runtime](https://www.java.com/en/download/). This is required for the cross-platform Windows executable signing tool [Jsign](https://ebourg.github.io/jsign/). If you don't need to sign the executables, feel free to skip this.

--- a/src/electron/custom_install_steps.nsh
+++ b/src/electron/custom_install_steps.nsh
@@ -56,7 +56,7 @@ ${StrRep}
   File "${PROJECT_DIR}\src\electron\find_tap_device_name.bat"
 
   ; OutlineService files, stopping the service first in case it's still running.
-  nsExec::Exec "net stop OutlineService"
+  nsExec::Exec "$SYSDIR\net stop OutlineService"
   File "${PROJECT_DIR}\tools\OutlineService\OutlineService\bin\OutlineService.exe"
   File "${PROJECT_DIR}\tools\smartdnsblock\bin\smartdnsblock.exe"
   File "${PROJECT_DIR}\third_party\newtonsoft\Newtonsoft.Json.dll"
@@ -146,8 +146,8 @@ ${StrRep}
   installservice:
 
   nsExec::Exec install_windows_service.bat
-
-  nsExec::Exec "sc query OutlineService"
+  
+  nsExec::Exec "$SYSDIR\sc query OutlineService"
   Pop $0
   StrCmp $0 0 success
   ; TODO: Trigger a Sentry report for service installation failure, too, and revisit
@@ -165,6 +165,6 @@ ${StrRep}
 ;       with the bundled tapinstall.exe because it can only remove *all* devices
 ;       having hwid tap0901 and these may include non-Outline devices.
 !macro customUnInstall
-  nsExec::Exec "net stop OutlineService"
-  nsExec::Exec "sc delete OutlineService"
+  nsExec::Exec "$SYSDIR\net stop OutlineService"
+  nsExec::Exec "$SYSDIR\sc delete OutlineService"
 !macroend

--- a/src/electron/custom_install_steps.nsh
+++ b/src/electron/custom_install_steps.nsh
@@ -146,7 +146,7 @@ ${StrRep}
   installservice:
 
   nsExec::Exec install_windows_service.bat
-  
+
   nsExec::Exec "$SYSDIR\sc query OutlineService"
   Pop $0
   StrCmp $0 0 success

--- a/src/electron/install_windows_service.bat
+++ b/src/electron/install_windows_service.bat
@@ -24,13 +24,13 @@ setlocal EnableDelayedExpansion
 set PWD=%~dp0%
 
 :: Stop and delete the service.
-net stop OutlineService
-sc delete OutlineService
+%SystemRoot%\System32\net stop OutlineService
+%SystemRoot%\System32\sc delete OutlineService
 
 :: Install and start the service, configuring it to restart on boot.
 :: NOTE: spaces after the arguments are necessary for a correct installation, do not remove!
-sc create OutlineService binpath= "%PWD%OutlineService.exe" displayname= "OutlineService" start= "auto"
-net start OutlineService
+%SystemRoot%\System32\sc create OutlineService binpath= "%PWD%OutlineService.exe" displayname= "OutlineService" start= "auto"
+%SystemRoot%\System32\net start OutlineService
 
 :: This is for the client: sudo-prompt discards stdout/stderr if the script
 :: exits with a non-zero return code *which will happen if any of the previous


### PR DESCRIPTION
This PR tries to prevent the local privilege escalation issue in Outline Client Windows installer by specifying the full path of system commands. Note that in a `.bat` file we can use `%SystemRoot%` variable (typically expands to "C:\Windows"), but it is not available in the `.nsh` NSIS script, therefore we need to use the [NSIS defined constant `$SYSDIR`](https://documentation.help/CTRE-NSIS/Section4.2.html#4.2.3) (typically expands to "C:\Windows\System32").

I also removed the Cygwin related information from the document because it is not required any more.

Fixes: b/266050099