### PR TITLE
chore: update support_request.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/support_request.md
+++ b/.github/ISSUE_TEMPLATE/support_request.md
@@ -8,4 +8,4 @@ assignees: ''
 ---
 The issue tracker is not for support requests. 
 
-If you would like support with Outline Manager or Outline Client, please review the help articles on [support.getoutline.org](https://support.getoutline.org/), and [contact us](https://support.getoutline.org/s/contactsupport) if you need further assistance. Developers, please post your questions on the SDK [Discussion board](https://github.com/Jigsaw-Code/outline-sdk/discussions).
+If you would like support with Outline Manager or Outline Client, please review the help articles on [support.getoutline.org](https://support.getoutline.org/), and [contact us](https://support.getoutline.org/s/contactsupport) if you need further assistance. Developers using Outline SDK, please post your questions on the SDK [Discussion board](https://github.com/Jigsaw-Code/outline-sdk/discussions).


### PR DESCRIPTION
Clarify that only SDK developers should use the SDK board board.