### PR TITLE
chore: update question.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -9,4 +9,4 @@ assignees: ''
 
 The issue tracker is not for questions. 
 
-If you would like support with Outline Manager or Outline Client, please review the help articles on [support.getoutline.org](https://support.getoutline.org/), and [contact us](https://support.getoutline.org/s/contactsupport) if you need further assistance. Developers, please post your questions on the SDK [Discussion board](https://github.com/Jigsaw-Code/outline-sdk/discussions).
+If you would like support with Outline Manager or Outline Client, please review the help articles on [support.getoutline.org](https://support.getoutline.org/), and [contact us](https://support.getoutline.org/s/contactsupport) if you need further assistance. Developers using Outline SDK, please post your questions on the SDK [Discussion board](https://github.com/Jigsaw-Code/outline-sdk/discussions).


### PR DESCRIPTION
Clarify that only SDK developers should use the SDK board board.