### PR TITLE
fix(www): reset the contact view if the user navigates back

### DIFF
--- a/src/www/ui_components/app-root.js
+++ b/src/www/ui_components/app-root.js
@@ -801,7 +801,7 @@ export class AppRoot extends mixinBehaviors([AppLocalizeBehavior], PolymerElemen
   }
 
   _goBack() {
-    if (this.page == 'contact') {
+    if (this.page === 'contact') {
       // TODO: Replace with `this.$.contactView` once the element is no longer inside a `dom-if`.
       this.shadowRoot.querySelector('#contactView').reset();
     }

--- a/src/www/ui_components/app-root.js
+++ b/src/www/ui_components/app-root.js
@@ -801,6 +801,11 @@ export class AppRoot extends mixinBehaviors([AppLocalizeBehavior], PolymerElemen
   }
 
   _goBack() {
+    if (this.page == 'contact') {
+      // TODO: Replace with `this.$.contactView` once the element is no longer inside a `dom-if`.
+      this.shadowRoot.querySelector('#contactView').reset();
+    }
+
     // If there is a navigation on the webview's history stack, pop it off to go back.
     if (history.length > 1) {
       history.back();

--- a/src/www/views/contact_view/index.spec.ts
+++ b/src/www/views/contact_view/index.spec.ts
@@ -56,6 +56,18 @@ describe('ContactView', () => {
     expect(exitCard.textContent).toContain('experiencing high support volume');
   });
 
+  it('resets the view on `reset()`', async () => {
+    const radioButton = el.shadowRoot!.querySelectorAll('mwc-formfield mwc-radio')[0] as HTMLElement;
+    radioButton.click();
+    await nextFrame();
+
+    el.reset();
+    await nextFrame();
+
+    const exitCard = el.shadowRoot!.querySelector('outline-card')!;
+    expect(exitCard).toBeNull();
+  });
+
   it('shows issue selector if the user selects that they have no open tickets', async () => {
     const radioButton = el.shadowRoot!.querySelectorAll('mwc-formfield mwc-radio')[1] as HTMLElement;
     radioButton.click();

--- a/src/www/views/contact_view/index.ts
+++ b/src/www/views/contact_view/index.ts
@@ -152,7 +152,7 @@ export class ContactView extends LitElement {
     this.step = Step.FORM;
   }
 
-  private reset() {
+  reset() {
     this.isFormSubmitting = false;
     this.showIssueSelector = false;
     this.step = Step.ISSUE_WIZARD;


### PR DESCRIPTION
Currently, the state remains even if the user clicks the back button, which is managed by the parent `AppRoot` element. This means that if they were sent to a help center article and then open the contact view in a subsequent navigation, they can't get to the original wizard to get help for a new issue.