### PR TITLE
chore: update android api target to sdk 33

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -23,7 +23,7 @@
     <access origin="*" />
     <allow-intent href="http://*/*" />
     <allow-intent href="https://*/*" />
-    <preference name="android-minSdkVersion" value="23" />
+    <preference name="android-minSdkVersion" value="22" />
     <preference name="android-targetSdkVersion" value="33" />
     <preference name="AndroidLaunchMode" value="singleInstance" />
     <preference name="ShowSplashScreenSpinner" value="false" />


### PR DESCRIPTION
~I thought we did this already?~

I updated the min version incorrectly... not the target version... 