### PR TITLE
fix(cordova/apple/macos): correct app groups for catalyst

### DIFF
--- a/src/cordova/apple/xcode/ios/Outline/Outline.entitlements
+++ b/src/cordova/apple/xcode/ios/Outline/Outline.entitlements
@@ -11,6 +11,7 @@
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.org.outline.ios.client</string>
+		<string>$(TeamIdentifierPrefix)org.outline.macos.client</string>
 	</array>
 	<key>com.apple.security.network.client</key>
 	<true/>

--- a/src/cordova/apple/xcode/ios/Outline/VpnExtension.entitlements
+++ b/src/cordova/apple/xcode/ios/Outline/VpnExtension.entitlements
@@ -11,6 +11,7 @@
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.org.outline.ios.client</string>
+		<string>$(TeamIdentifierPrefix)org.outline.macos.client</string>
 	</array>
 	<key>com.apple.security.network.client</key>
 	<true/>


### PR DESCRIPTION
The location of the logs directory is specified by the provided App Group ID. This needs to match the app group so the `VpnExtension` can write log files for Sentry.