### PR TITLE
feat(client): add details to custom error

### DIFF
--- a/client/src/www/app/app.ts
+++ b/client/src/www/app/app.ts
@@ -223,6 +223,8 @@ export class App {
     } else if (error instanceof errors.SessionProviderError) {
       toastMessage = error.message;
       buttonMessage = this.localize('error-details');
+
+      console.log(error, error.message, error.details);
       buttonHandler = () => {
         this.showErrorDetailsDialog(error.details);
       };

--- a/client/src/www/app/outline_server_repository/access_key_serialization.ts
+++ b/client/src/www/app/outline_server_repository/access_key_serialization.ts
@@ -39,7 +39,7 @@ function parseShadowsocksSessionConfigJson(responseBody: string): ShadowsocksSes
   const responseJson = JSON.parse(responseBody);
 
   if ('error' in responseJson) {
-    throw new errors.SessionProviderError(responseJson.error.message, { details: responseJson.error.details });
+    throw new errors.SessionProviderError(responseJson.error.message, responseJson.error.details);
   }
 
   const {method, password, server, server_port, prefix} = responseJson;
@@ -85,7 +85,7 @@ export async function fetchShadowsocksSessionConfig(configLocation: URL): Promis
 
     return parseShadowsocksSessionConfigJson(responseBody);
   } catch (cause) {
-    if (cause instanceof errors.SessionConfigError) {
+    if (cause instanceof errors.SessionProviderError) {
       throw cause;
     }
 

--- a/client/src/www/model/errors.ts
+++ b/client/src/www/model/errors.ts
@@ -55,10 +55,10 @@ export class SessionConfigError extends CustomError {
 export class SessionProviderError extends CustomError {
   readonly details: string | undefined;
 
-  constructor(message: string, options?: {details?: string}) {
+  constructor(message: string, details?: string) {
     super(message);
 
-    this.details = options && options.details;
+    this.details = details;
   }
 }
 


### PR DESCRIPTION
This will allow providers to send:

```
{
  "error": {
    "message": "There was an error.",
    "details": "<Detailed information about the error, displayed in an alert box.>"
  }
}
```
<img width="338" alt="Screenshot 2024-05-03 at 4 10 36 PM" src="https://github.com/Jigsaw-Code/outline-apps/assets/3759828/cf1a90e4-57cb-4267-a9cc-475c06632e50">
