### PR TITLE
fix: filter node modules out of the actions list

### DIFF
--- a/list.action.mjs
+++ b/list.action.mjs
@@ -31,7 +31,13 @@ export async function main() {
   }
 
   for (const actionPath of await globby.default(['**/*.action.sh', '**/*.action.mjs'])) {
-    console.info(actionPath.match(/(.+)\.action/)[1]);
+    const action = actionPath.match(/(.+)\.action/)[1];
+
+    if (action.includes("node_modules")) {
+      continue;
+    }
+
+    console.info(action);
   }
 }
 


### PR DESCRIPTION
as a side effect of the monorepo, we're seeing actions in the `node_modules` folder pop up when you run `npm run action list` - this change filters out those results