### PR TITLE
fix(client/cordova/apple/ios): remove the gap in the header

### DIFF
--- a/client/src/www/index_cordova.html
+++ b/client/src/www/index_cordova.html
@@ -19,7 +19,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>Outline</title>
-    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <!-- See https://github.com/webcomponents/custom-elements#es5-vs-es2015 -->
     <script src="webcomponentsjs/custom-elements-es5-adapter.js"></script>
     <script src="cordova.js"></script>


### PR DESCRIPTION
due to the various types of notches and islands across devices, [W3C came up with a "viewport-fit" meta config](https://www.w3.org/TR/css-round-display-1/#viewport-fit-descriptor). Setting this to `cover` fixes the gap on dynamic island phones:

![Screenshot 2024-07-24 at 2 08 20 PM](https://github.com/user-attachments/assets/47e67ca2-95c2-4911-a714-5e414a2317a4)

It also still works on notch phones:

![Screenshot 2024-07-24 at 2 16 01 PM](https://github.com/user-attachments/assets/2dae498a-fd55-40d8-8a21-26f2f3d17879)
