### PR TITLE
TEST: ask gemini to migrate the privacy_view to lit

### DIFF
--- a/client/src/www/views/privacy_view/index.ts
+++ b/client/src/www/views/privacy_view/index.ts
@@ -1,108 +1,105 @@
 import {LitElement, html, css} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+import '@material/mwc-button';
 
-class PrivacyView extends LitElement {
-  static get properties() {
-    return {
-      localize: {type: Function},
-      rootPath: {type: String},
-    };
+@customElement('privacy-view')
+export class PrivacyView extends LitElement {
+  @property({type: Function}) localize!: (key: string) => string; // Define the localize function type
+  @property({type: String}) rootPath!: string;
+
+  static styles = css`
+  :host {
+    background: #fff;
+    width: 100%;
+    height: 100vh;
+    font-family: var(--outline-font-family);
+    z-index: 1000; /* Give this a high z-index so it overlays the UI. */
   }
-
-  static get styles() {
-    return css`
-      :host {
-        background: #fff;
-        width: 100%;
-        height: 100vh;
-        font-family: var(--outline-font-family);
-        z-index: 1000; /* Give this a high z-index so it overlays the UI. */
-      }
-      #container {
-        display: flex;
-        flex-direction: column;
-        justify-content: space-around;
-        text-align: center;
-        background: var(--dark-green);
-        color: rgba(255, 255, 255, 0.87);
-        width: 100%;
-        height: 100%;
-      }
-      #header {
-        align-self: center;
-        margin: 96px auto 0 auto;
-      }
-      #privacy-lock {
-        width: 112px;
-        height: 158px;
-      }
-      #footer-container {
-        text-align: center;
-      }
-      #footer {
-        padding: 0 12px;
-        width: 276px;
-        margin: 24px auto;
-      }
-      #footer h3 {
-        font-size: 20px;
-        font-weight: 500;
-        line-height: 28px;
-        margin: 24px 0 0 0;
-      }
-      #footer p {
-        font-size: 14px;
-        line-height: 20px;
-        margin: 24px 0 0 0;
-        color: rgba(255, 255, 255, 0.54);
-      }
-      #button-container {
-        display: flex;
-        justify-content: space-between;
-        margin: 48px 0 0 0;
-      }
-      #button-container a {
-        text-decoration: none;
-      }
-      .faded {
-        color: rgba(255, 255, 255, 0.54);
-      }
-      @media (max-height: 600px) {
-        #header {
-          margin: 48px auto 0 auto;
-        }
-        #privacy-lock {
-          width: 90px;
-          height: 127px;
-        }
-        #button-container {
-          margin: 24px 0 0 0;
-        }
-      }
-      @media (min-width: 768px) {
-        #header {
-          margin: 144px auto 0 auto;
-        }
-        #privacy-lock {
-          width: 168px;
-          height: 237px;
-        }
-        #footer {
-          margin: 48px auto;
-          width: 552px;
-        }
-        #footer h3 {
-          font-size: 28px;
-          line-height: 40px;
-        }
-        #footer p,
-        #button-container {
-          font-size: 22px;
-          line-height: 30px;   
-
-        }
-      }
-    `;
+  #container {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+    text-align: center;
+    background: var(--dark-green);
+    color: rgba(255, 255, 255, 0.87);
+    width: 100%;
+    height: 100%;
   }
+  #header {
+    align-self: center;
+    margin: 96px auto 0 auto;
+  }
+  #privacy-lock {
+    width: 112px;
+    height: 158px;
+  }
+  #footer-container {
+    text-align: center;
+  }
+  #footer {
+    padding: 0 12px;
+    width: 276px;
+    margin: 24px auto;
+  }
+  #footer h3 {
+    font-size: 20px;
+    font-weight: 500;
+    line-height: 28px;
+    margin: 24px 0 0 0;
+  }
+  #footer p {
+    font-size: 14px;
+    line-height: 20px;
+    margin: 24px 0 0 0;
+    color: rgba(255, 255, 255, 0.54);
+  }
+  #button-container {
+    display: flex;
+    justify-content: space-between;
+    margin: 48px 0 0 0;
+  }
+  #button-container a {
+    text-decoration: none;
+  }
+  .faded {
+    color: rgba(255, 255, 255, 0.54);
+  }
+  @media (max-height: 600px) {
+    #header {
+      margin: 48px auto 0 auto;
+    }
+    #privacy-lock {
+      width: 90px;
+      height: 127px;
+    }
+    #button-container {
+      margin: 24px 0 0 0;
+    }
+  }
+  @media (min-width: 768px) {
+    #header {
+      margin: 144px auto 0 auto;
+    }
+    #privacy-lock {
+      width: 168px;
+      height: 237px;
+    }
+    #footer {
+      margin: 48px auto;
+      width: 552px;
+    }
+    #footer h3 {
+      font-size: 28px;
+      line-height: 40px;
+    }
+    #footer p,
+    #button-container {
+      font-size: 22px;
+      line-height: 30px;   
+
+    }
+  }
+`;
 
   _privacyTermsAcked() {
     this.dispatchEvent(new CustomEvent('PrivacyTermsAcked'));
@@ -125,13 +122,17 @@ class PrivacyView extends LitElement {
               <a
                 href="https://support.getoutline.org/s/article/Data-collection"
               >
-                <paper-button class="faded"
-                  >${this.localize('learn-more')}</paper-button
-                >
+                <mwc-button
+                  outlined
+                  label="${this.localize('learn-more')}"
+                  class="faded"
+                ></mwc-button>
               </a>
-              <paper-button @click="${this._privacyTermsAcked}"
-                >${this.localize('got-it')}</paper-button
-              >
+              <mwc-button
+                unelevated
+                label="${this.localize('got-it')}"
+                @click="${this._privacyTermsAcked}"
+              ></mwc-button>
             </div>
           </div>
         </div>
@@ -139,5 +140,3 @@ class PrivacyView extends LitElement {
     `;
   }
 }
-
-customElements.define('privacy-view', PrivacyView);


### PR DESCRIPTION
As a test, I asked gemini to migrate the client privacy view, currently written in polymer, to lit. This is what it came up with.

It's not 100% of the way, more like 60-70%

prompt used:

```
can you rewrite the following in lit and typescript? be sure to use decorators and replace paper-button with mwc-button.

<code>
```