### PR TITLE
fix(client): ensure empty state button background is transparent

### DIFF
--- a/client/src/www/views/servers_view/index.ts
+++ b/client/src/www/views/servers_view/index.ts
@@ -16,10 +16,10 @@
 
 import '@material/mwc-button';
 
-import { Localizer } from '@outline/infrastructure/i18n';
+import {Localizer} from '@outline/infrastructure/i18n';
 import {css, html, LitElement} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
-import { DirectiveResult } from 'lit/directive';
+import {DirectiveResult} from 'lit/directive';
 import {unsafeHTML, UnsafeHTMLDirective} from 'lit/directives/unsafe-html.js';
 
 import {ServerConnectionState as _ServerConnectionState} from './server_connection_indicator';
@@ -30,7 +30,7 @@ import {ServerListItem as _ServerListItem} from './server_list_item';
 export type ServerListItem = _ServerListItem;
 
 // (This value is used: it's exported.)
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+// eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
 export import ServerConnectionState = _ServerConnectionState;
 
 @customElement('servers-view')
@@ -40,7 +40,7 @@ export class ServerList extends LitElement {
       :host {
         display: flex;
         flex-direction: column;
-        font-size: .9rem;
+        font-size: 0.9rem;
         height: 100%;
         /* Use vh, as % does not work in iOS. |header-height|+|server-margin| = 64px.
          * Subtract |header-height| to fix iOS padding, and |server-margin| to fix scrolling in Android.
@@ -81,7 +81,7 @@ export class ServerList extends LitElement {
         font-weight: 400;
       }
       h2 {
-        font-size: .9rem;
+        font-size: 0.9rem;
         font-weight: initial;
         line-height: 1.5;
       }
@@ -92,6 +92,7 @@ export class ServerList extends LitElement {
       }
       button {
         align-items: center;
+        background-color: transparent;
         border: 0;
         display: flex;
         flex-direction: column;
@@ -119,7 +120,9 @@ export class ServerList extends LitElement {
   }
 
   private requestPromptAddServer() {
-    this.dispatchEvent(new CustomEvent('add-server', {bubbles: true, composed: true}));
+    this.dispatchEvent(
+      new CustomEvent('add-server', {bubbles: true, composed: true})
+    );
   }
 
   private get zeroStateContent(): DirectiveResult<typeof UnsafeHTMLDirective> {
@@ -127,16 +130,25 @@ export class ServerList extends LitElement {
     if (this.shouldShowAccessKeyWikiLink) {
       msg = this.localize(
         'server-create-your-own-zero-state-access',
-        'breakLine', '<br/>',
-        'openLink', '<a href=https://s3.amazonaws.com/outline-vpn/get-started/index.html#step-1>',
-        'openLink2', '<a href=https://www.reddit.com/r/outlinevpn/wiki/index/outline_vpn_access_keys/>',
-        'closeLink', '</a>');
+        'breakLine',
+        '<br/>',
+        'openLink',
+        '<a href=https://s3.amazonaws.com/outline-vpn/get-started/index.html#step-1>',
+        'openLink2',
+        '<a href=https://www.reddit.com/r/outlinevpn/wiki/index/outline_vpn_access_keys/>',
+        'closeLink',
+        '</a>'
+      );
     } else {
       msg = this.localize(
         'server-create-your-own-zero-state',
-        'breakLine', '<br/>',
-        'openLink', '<a href=https://s3.amazonaws.com/outline-vpn/get-started/index.html#step-1>',
-        'closeLink', '</a>');
+        'breakLine',
+        '<br/>',
+        'openLink',
+        '<a href=https://s3.amazonaws.com/outline-vpn/get-started/index.html#step-1>',
+        'closeLink',
+        '</a>'
+      );
     }
     return unsafeHTML(msg);
   }
@@ -147,7 +159,9 @@ export class ServerList extends LitElement {
         <section>
           <header>
             <button type="button" @click=${this.requestPromptAddServer}>
-              <server-connection-indicator connection-state="disconnected"></server-connection-indicator>
+              <server-connection-indicator
+                connection-state="disconnected"
+              ></server-connection-indicator>
               <h1>${this.localize('server-add')}</h1>
               <h2>${this.localize('server-add-zero-state-instructions')}</h2>
             </button>


### PR DESCRIPTION
![Screenshot 2024-08-28 at 5 09 32 PM](https://github.com/user-attachments/assets/d46b5089-7ea7-484c-8e0c-5a2619d41a4e)

Also had to lint the file - this is the relevant change: https://github.com/Jigsaw-Code/outline-apps/pull/2183/files#diff-63e12fab55fd10051e9131bddc2b5a09888a630be052c09143ef90f7078f55f1R95