### PR TITLE
docs: clarify VSCode setup in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,4 +24,4 @@ information on using pull requests.
 
 ## Setup: VSCode
 
-You'll have to clean up your extensions to get formatting to work properly. First, go to the `Extensions` tab and remove any extensions that might be formatting your code, like `esbenp.prettier-vscode`. Then, if VSCode doesn't automatically prompt you install the recommended extensions by searching for `@recommended`.
+You'll have to clean up your extensions to get formatting to work properly. First, go to the `Extensions` tab and remove any extensions that might be formatting your code, like `esbenp.prettier-vscode`. Then, if VSCode doesn't automatically prompt you, install the recommended extensions by searching for `@recommended`.


### PR DESCRIPTION
Note that I attempted to use [`editor.defaultFormatter`](https://code.visualstudio.com/docs/getstarted/settings#_default-settings) to specify which formatter to use and the prettier extension still trampled over it.