### PR TITLE
fix: stop lint task from being automatically cancelled

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@
 name: Lint
 
 concurrency:
-  group: ${{ github.head_ref || github.ref }}
+  group: ${{ github.head_ref || github.ref }}-lint
   cancel-in-progress: true
 
 on:


### PR DESCRIPTION
Annoyingly, the `lint` task belongs to the same concurrency group as some of our other tasks, so it kept being cancelled. This PR fixes that.