### PR TITLE
fix(client): app crash on add access key edit

### DIFF
--- a/client/src/www/views/root_view/add_access_key_dialog/index.ts
+++ b/client/src/www/views/root_view/add_access_key_dialog/index.ts
@@ -93,10 +93,6 @@ export class AddAccessKeyDialog extends LitElement {
         <section>
           <md-filled-text-field
             .error=${this.accessKey && !this.isValidAccessKey}
-            @change=${this.updateIsValidAccessKey(
-              this.accessKey,
-              this.validateAccessKey
-            )}
             @input=${this.handleEdit}
             error-text="${this.localize('add-access-key-dialog-error-text')}"
             label="${this.localize('add-access-key-dialog-label')}"
@@ -123,6 +119,7 @@ export class AddAccessKeyDialog extends LitElement {
     accessKey: string,
     validate: (accessKey: string) => Promise<boolean>
   ) {
+    this.isValidAccessKey = false;
     validate(accessKey).then(result => {
       this.isValidAccessKey = result;
     });
@@ -130,6 +127,8 @@ export class AddAccessKeyDialog extends LitElement {
 
   private handleEdit(event: InputEvent) {
     this.accessKey = (event.target as HTMLInputElement).value;
+
+    this.updateIsValidAccessKey(this.accessKey, this.validateAccessKey);
   }
 
   private handleConfirm() {


### PR DESCRIPTION
I encountered an issue where pasting in a dynamic key or editing the key in the key add modal would trigger an infinite render loop. Upon examination, we were repeatedly modifying a dynamic lit property in a function that was called on render, thus triggering the loop. I removed that property modification and now it works fine!


https://github.com/user-attachments/assets/8092ef45-9737-400c-bc11-55b8b23c28f4

