### PR TITLE
docs(client/android): fix the Cordova environment check script

### DIFF
--- a/client/src/cordova/android/README.md
+++ b/client/src/cordova/android/README.md
@@ -61,6 +61,7 @@ For development of the OutlineAndroidLib, we recommend installing Android Studio
 You can check your environment with:
 
 ```sh
+npm run action client/src/cordova/setup android
 cd client
 npx cordova requirements android
 ```


### PR DESCRIPTION
The original script will fail because `Current working directory is not a Cordova-based project`. We need to setup the Cordova folder structure first.

See: https://github.com/Jigsaw-Code/outline-sdk/discussions/451