### PR TITLE
fix(client/windows): fix `currentTunnel` race condition when stopping the VPN

### DIFF
--- a/client/electron/index.ts
+++ b/client/electron/index.ts
@@ -421,9 +421,10 @@ async function stopVpn() {
     return;
   }
 
+  const onceDisconnected = currentTunnel.onceDisconnected;
   void currentTunnel.disconnect();
   await tearDownAutoLaunch();
-  await currentTunnel.onceDisconnected;
+  await onceDisconnected;
 }
 
 function setUiTunnelStatus(status: TunnelStatus, tunnelId: string) {


### PR DESCRIPTION
Fixes the **"Cannot read properties of undefined (reading 'onceDisconnected')"** error (the largest error in Sentry) by capturing the `currentTunnel.onceDisconnected` into a local variable.

The error was caused by a race condition:
- Error thrown at (note that this is asynchronous): https://github.com/Jigsaw-Code/outline-apps/blob/44c501faa35545558110505fe13b65ec8871d0cf/client/electron/index.ts#L426
- Because `currentTunnel` could be set to `undefined` at: https://github.com/Jigsaw-Code/outline-apps/blob/44c501faa35545558110505fe13b65ec8871d0cf/client/electron/index.ts#L386-L391
