### PR TITLE
feat(client/electron): add Connect/Disconnect to macOS tray menu

### DIFF
--- a/client/electron/index.ts
+++ b/client/electron/index.ts
@@ -264,6 +264,31 @@ function updateTray(status: TunnelStatus) {
       ...menuTemplate,
     ];
   }
+  // macOS: Add Connect/Disconnect menu item
+  if (process.platform === 'darwin') {
+    menuTemplate.splice(1, 0, {
+      label: isConnected ? 'Disconnect' : 'Connect',
+      click: async () => {
+        if (isConnected) {
+          await stopVpn();
+        } else {
+          // Try to reconnect to the last used tunnel
+          const request = await tunnelStore.load();
+          if (request) {
+            try {
+              await startVpn(request, false);
+              await setupAutoLaunch(request);
+            } catch (e) {
+              console.error('Could not connect from tray menu:', e);
+            }
+          } else {
+            // No previous tunnel, show window
+            mainWindow?.show();
+          }
+        }
+      },
+    });
+  }
   tray.setContextMenu(Menu.buildFromTemplate(menuTemplate));
 }
 


### PR DESCRIPTION
This PR adds a "Connect" or "Disconnect" menu item to the Outline Client tray menu on macOS.

Users can now connect or disconnect the VPN directly from the menu bar without opening the main window.

(If no previous connection exists, clicking "Connect" will open the main window)

#2509