### PR TITLE
fix(client): increase error text contrast to 4.5:1 in dark mode

### DIFF
--- a/client/src/www/style.css
+++ b/client/src/www/style.css
@@ -125,6 +125,8 @@ body {
 
 /* Class-based dark mode - applied when user selects dark theme */
 html.dark {
+  --outline-error: hsl(4, 90%, 62%);
+
   --outline-background: var(--outline-dark-bg);
   --outline-card-background: var(--outline-dark-card);
   --outline-card-footer: var(--outline-dark-footer);


### PR DESCRIPTION
<img width="723" height="724" alt="Screenshot 2025-07-22 at 12 57 52 PM" src="https://github.com/user-attachments/assets/09db3a62-9b62-4f7b-8670-01b56aa65bc9" />
