### PR TITLE
fix(client/macos): add missing translations to outline client

### DIFF
--- a/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ko.lproj/Localizable.strings
+++ b/client/src/cordova/apple/xcode/Outline/Classes/AppKitBridge/Resources/Strings/ko.lproj/Localizable.strings
@@ -2,3 +2,5 @@
 "disconnected_server_state" = "연결 해제됨";
 "tray_open_window" = "열기";
 "quit" = "종료";
+"disconnect" = "연결 해제";
+"connect" = "연결";


### PR DESCRIPTION
added translations for `connect` and `disconnect` in the macOS status bar.