### PR TITLE
feat(client): add 16KB alignment flag to go build

### DIFF
--- a/client/go/Taskfile.yml
+++ b/client/go/Taskfile.yml
@@ -21,7 +21,7 @@ vars:
   OUT_DIR: '{{joinPath .REPO_ROOT "output/client"}}'
   BIN_DIR: '{{joinPath .OUT_DIR "/bin"}}'
   MOBILE_PKG: "{{.TASKFILE_DIR}}/outline/tun2socks"
-  GOMOBILE_BIND_CMD: "env PATH=\"{{.BIN_DIR}}:${PATH}\" CGO_CFLAGS='-fstack-protector-strong -falign-functions=16 -falign-loops=16' CGO_LDFLAGS='-Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=4096' '{{.BIN_DIR}}/gomobile' bind -ldflags='-s -w'"
+  GOMOBILE_BIND_CMD: "env PATH=\"{{.BIN_DIR}}:${PATH}\" CGO_CFLAGS='-fstack-protector-strong -falign-functions=16 -falign-loops=16' CGO_LDFLAGS='-Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384' '{{.BIN_DIR}}/gomobile' bind -ldflags='-s -w'"
 
 tasks:
   electron:


### PR DESCRIPTION
Additional fixes to https://github.com/Jigsaw-Code/outline-apps/issues/2678

This does not fix the overall build issue. However it does fix the UNALIGNED `libgojni.so` issue described [here](https://github.com/Jigsaw-Code/outline-apps/issues/2678#issuecomment-3661051279). So I'm not sure if this is the correct solution, or something we want to add. (Maybe the UNALIGNED `libgojni.so` files are fine.)

TESTING

ran a release build, then

```
./check_elf_alignment.sh Outline-Client.apk

Recursively analyzing Outline-Client.apk

NOTICE: Zip alignment check requires build-tools version 35.0.0-rc3 or higher.
  You can install the latest build-tools by running the below command
  and updating your $PATH:

    sdkmanager "build-tools;35.0.0-rc3"

=== ELF alignment ===
/var/folders/_s/1987wtss17b34gz5sv0f3mfm007mzb/T/Outline-Client_out_XXXXX.jTsVyC9Xqa/lib/armeabi-v7a/libsentry.so: \e[32mALIGNED\e[0m (2**14)
/var/folders/_s/1987wtss17b34gz5sv0f3mfm007mzb/T/Outline-Client_out_XXXXX.jTsVyC9Xqa/lib/armeabi-v7a/libgojni.so: \e[32mALIGNED\e[0m (2**14)
/var/folders/_s/1987wtss17b34gz5sv0f3mfm007mzb/T/Outline-Client_out_XXXXX.jTsVyC9Xqa/lib/armeabi-v7a/libsentry-android.so: \e[32mALIGNED\e[0m (2**14)
/var/folders/_s/1987wtss17b34gz5sv0f3mfm007mzb/T/Outline-Client_out_XXXXX.jTsVyC9Xqa/lib/x86/libsentry.so: \e[32mALIGNED\e[0m (2**14)
/var/folders/_s/1987wtss17b34gz5sv0f3mfm007mzb/T/Outline-Client_out_XXXXX.jTsVyC9Xqa/lib/x86/libgojni.so: \e[32mALIGNED\e[0m (2**14)
/var/folders/_s/1987wtss17b34gz5sv0f3mfm007mzb/T/Outline-Client_out_XXXXX.jTsVyC9Xqa/lib/x86/libsentry-android.so: \e[32mALIGNED\e[0m (2**14)
/var/folders/_s/1987wtss17b34gz5sv0f3mfm007mzb/T/Outline-Client_out_XXXXX.jTsVyC9Xqa/lib/arm64-v8a/libsentry.so: \e[32mALIGNED\e[0m (2**14)
/var/folders/_s/1987wtss17b34gz5sv0f3mfm007mzb/T/Outline-Client_out_XXXXX.jTsVyC9Xqa/lib/arm64-v8a/libgojni.so: \e[32mALIGNED\e[0m (2**14)
/var/folders/_s/1987wtss17b34gz5sv0f3mfm007mzb/T/Outline-Client_out_XXXXX.jTsVyC9Xqa/lib/arm64-v8a/libsentry-android.so: \e[32mALIGNED\e[0m (2**14)
/var/folders/_s/1987wtss17b34gz5sv0f3mfm007mzb/T/Outline-Client_out_XXXXX.jTsVyC9Xqa/lib/x86_64/libsentry.so: \e[32mALIGNED\e[0m (2**14)
/var/folders/_s/1987wtss17b34gz5sv0f3mfm007mzb/T/Outline-Client_out_XXXXX.jTsVyC9Xqa/lib/x86_64/libgojni.so: \e[32mALIGNED\e[0m (2**14)
/var/folders/_s/1987wtss17b34gz5sv0f3mfm007mzb/T/Outline-Client_out_XXXXX.jTsVyC9Xqa/lib/x86_64/libsentry-android.so: \e[32mALIGNED\e[0m (2**14)
ELF Verification Successful

./check_elf_alignment.sh Outline-Client.apk | grep UNALIGNED
[no output]
=====================
```

However I'm still getting the error
<img width="551" height="195" alt="image" src="https://github.com/user-attachments/assets/3f0c1545-dfcb-4935-b99d-6ea2a29c3d3c" />
when uploading the APK to the play store.