### PR TITLE
chore(manager): remove unused jigsaw link

### DIFF
--- a/server_manager/www/ui_components/outline-about-dialog.ts
+++ b/server_manager/www/ui_components/outline-about-dialog.ts
@@ -73,7 +73,7 @@ Polymer({
         inner-h-t-m-l="[[localize('about-version', 'version', outlineVersion)]]"
       ></p>
       <p
-        inner-h-t-m-l="[[localize('about-outline', 'jigsawUrl', 'https://jigsaw.google.com', 'shadowsocksUrl', 'https://shadowsocks.org', 'gitHubUrl', 'https://github.com/jigsaw-Code/?q=outline', 'redditUrl', 'https://www.reddit.com/r/outlinevpn', 'mediumUrl', 'https://medium.com/jigsaw')]]"
+        inner-h-t-m-l="[[localize('about-outline', 'shadowsocksUrl', 'https://shadowsocks.org', 'gitHubUrl', 'https://github.com/jigsaw-Code/?q=outline', 'redditUrl', 'https://www.reddit.com/r/outlinevpn', 'mediumUrl', 'https://medium.com/jigsaw')]]"
       >
         &gt;
       </p>


### PR DESCRIPTION
This link is no longer used in https://github.com/OutlineFoundation/outline-apps/blob/d2d72a13c1d04e5907c72b2da054e6961da340ff/server_manager/messages/en.json#L2 / other language files

It was deleted in https://github.com/OutlineFoundation/outline-apps/pull/2675