### PR TITLE
feat(client): remove application groups

### DIFF
--- a/client/src/cordova/apple/OutlineLib/VpnExtension/VpnExtension.entitlements
+++ b/client/src/cordova/apple/OutlineLib/VpnExtension/VpnExtension.entitlements
@@ -8,10 +8,6 @@
 	</array>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
-	<key>com.apple.security.application-groups</key>
-	<array>
-		<string>group.org.getoutline.client</string>
-	</array>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/client/src/cordova/apple/xcode/Outline/Outline.entitlements
+++ b/client/src/cordova/apple/xcode/Outline/Outline.entitlements
@@ -8,10 +8,6 @@
 	</array>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
-	<key>com.apple.security.application-groups</key>
-	<array>
-		<string>group.org.getoutline.client</string>
-	</array>
 	<key>com.apple.security.network.client</key>
 	<true/>
 </dict>


### PR DESCRIPTION
Required for mac app store transfer.

https://developer.apple.com/help/app-store-connect/transfer-an-app/app-transfer-criteria#:~:text=Mac%20apps%20that%20have%20used%20the%20sandbox%20environment%20and%20share%20the%20Application%20Group%20Container%20Directory%20with%20other%20Mac%20apps%20can%27t%20be%20transferred

Testflight release 1.19.4 contains these changes.