### PR TITLE
chore(client): remove App Groups capability for app transfer

### DIFF
--- a/client/src/cordova/apple/xcode/Outline.xcodeproj/project.pbxproj
+++ b/client/src/cordova/apple/xcode/Outline.xcodeproj/project.pbxproj
@@ -491,11 +491,6 @@
 				TargetAttributes = {
 					1D6058900D05DD3D006BFB54 = {
 						LastSwiftMigration = 1130;
-						SystemCapabilities = {
-							com.apple.ApplicationGroups.iOS = {
-								enabled = 1;
-							};
-						};
 					};
 					A246B7DC2B07AACF00ECACD5 = {
 						CreatedOnToolsVersion = 15.0.1;


### PR DESCRIPTION
This technically breaks the attaching of the logs into the Sentry reports, but doesn't break the core functionality and we can re-attach later once we define a new app group.
