### PR TITLE
build(client): use per-platform team IDs for iOS and macOS signing

### DIFF
--- a/client/src/cordova/apple/OutlineLib/OutlineLib.xcodeproj/project.pbxproj
+++ b/client/src/cordova/apple/OutlineLib/OutlineLib.xcodeproj/project.pbxproj
@@ -329,7 +329,8 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = QT8Z3Q9V3A;
+				DEVELOPMENT_TEAM = WP4DKSWWZM;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = QT8Z3Q9V3A;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.getoutline.client.VpnExtensionTest;
@@ -348,7 +349,8 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = QT8Z3Q9V3A;
+				DEVELOPMENT_TEAM = WP4DKSWWZM;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = QT8Z3Q9V3A;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.getoutline.client.VpnExtensionTest;
@@ -495,7 +497,8 @@
 				CODE_SIGN_ENTITLEMENTS = VpnExtension/VpnExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = QT8Z3Q9V3A;
+				DEVELOPMENT_TEAM = WP4DKSWWZM;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = QT8Z3Q9V3A;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = VpnExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = VpnExtension;
@@ -532,7 +535,8 @@
 				CODE_SIGN_ENTITLEMENTS = VpnExtension/VpnExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = QT8Z3Q9V3A;
+				DEVELOPMENT_TEAM = WP4DKSWWZM;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = QT8Z3Q9V3A;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = VpnExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = VpnExtension;

--- a/client/src/cordova/apple/README.md
+++ b/client/src/cordova/apple/README.md
@@ -45,6 +45,15 @@ Apple is quite particular when it comes to making sure your app is properly sign
 
 ### External Contributors
 
+For **release builds via the command line**, set the `DEVELOPMENT_TEAM` environment variable to override the default team ID without editing any project files:
+
+```sh
+DEVELOPMENT_TEAM=<your_team_id> npm run action client/src/cordova/build ios -- --buildMode=release
+DEVELOPMENT_TEAM=<your_team_id> npm run action client/src/cordova/build macos -- --buildMode=release
+```
+
+For **development in Xcode**:
+
 1. Select the "Team" for your own account.
 1. Change the bundle identifier (e.g. `org.outline.ios.client`) to something unique.
 1. Remove the app group `group.org.getoutline.client`.

--- a/client/src/cordova/apple/xcode/Outline.xcodeproj/project.pbxproj
+++ b/client/src/cordova/apple/xcode/Outline.xcodeproj/project.pbxproj
@@ -805,7 +805,8 @@
 				CODE_SIGN_ENTITLEMENTS = Outline/Outline.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
-				DEVELOPMENT_TEAM = QT8Z3Q9V3A;
+				DEVELOPMENT_TEAM = WP4DKSWWZM;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = QT8Z3Q9V3A;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"Outline/Plugins/cordova-plugin-outline",
@@ -854,7 +855,8 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = YES;
-				DEVELOPMENT_TEAM = QT8Z3Q9V3A;
+				DEVELOPMENT_TEAM = WP4DKSWWZM;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = QT8Z3Q9V3A;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"Outline/Plugins/cordova-plugin-outline",

--- a/client/src/cordova/build.action.mjs
+++ b/client/src/cordova/build.action.mjs
@@ -147,13 +147,18 @@ async function appleDebug(platform) {
 }
 
 async function appleRelease(platform) {
+  const teamIdArgs = process.env.DEVELOPMENT_TEAM
+    ? [`DEVELOPMENT_TEAM=${process.env.DEVELOPMENT_TEAM}`]
+    : [];
+
   return spawnStream(
     'xcodebuild',
     'clean',
     ...getXcodeBuildArgs(platform),
     'archive',
     '-configuration',
-    'Release'
+    'Release',
+    ...teamIdArgs
   );
 }
 


### PR DESCRIPTION
iOS and macOS (Mac Catalyst) require different Apple Developer team IDs. Use Xcode's SDK-conditional build setting syntax to set the iOS team (WP4DKSWWZM) as the default and override with the macOS team (QT8Z3Q9V3A) when building against the macOS SDK.

Also supports a DEVELOPMENT_TEAM env var override in the build script, so external contributors can set their own team ID without editing project files.