### PR TITLE
build: allow xcode to automatically resolve provisioning profiles

### DIFF
--- a/client/src/cordova/build.action.mjs
+++ b/client/src/cordova/build.action.mjs
@@ -141,6 +141,7 @@ async function appleDebug(platform) {
     'build',
     '-configuration',
     'Debug',
+    '-allowProvisioningUpdates',
     'CODE_SIGN_IDENTITY=""',
     'CODE_SIGNING_ALLOWED="NO"'
   );
@@ -158,6 +159,7 @@ async function appleRelease(platform) {
     'archive',
     '-configuration',
     'Release',
+    '-allowProvisioningUpdates',
     ...teamIdArgs
   );
 }


### PR DESCRIPTION
This allows xcode to help us fix build issues when various pieces of configuration are missing.

I couldn't find good online docs about this arg, so here's the manpage:

```
man xcodebuild | col -b | grep -A 5 "allowProvisioningUpdates"

-allowProvisioningUpdates
	   Allow xcodebuild to communicate with the Apple Developer website.
	   For automatically signed targets, xcodebuild will create and update
	   profiles, app IDs, and certificates. For manually signed targets,
	   xcodebuild will download missing or updated provisioning profiles.
	   Requires a developer account to have been added in Xcode's Accounts
	   preference pane.
```

Tested: just used this to cut a 1.19.10 release